### PR TITLE
Install Devbox Using Flakes

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,56 @@
+{
+  "nodes": {
+    "devbox-source": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1677791812,
+        "narHash": "sha256-9aGmX21TUINGDA3NB/OrGXi8W4i+b8fKS8ft8GtQxNM=",
+        "owner": "jetpack-io",
+        "repo": "devbox",
+        "rev": "c249fa1da3a24eb686220da378bc9dcdc6d49680",
+        "type": "github"
+      },
+      "original": {
+        "owner": "jetpack-io",
+        "ref": "0.4.2",
+        "repo": "devbox",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1676283394,
+        "narHash": "sha256-XX2f9c3iySLCw54rJ/CZs+ZK6IQy7GXNY4nSOyu2QG4=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "3db36a8b464d0c4532ba1c7dda728f4576d6d073",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "narHash": "sha256-Jgq50e4S4JVCYpWLqrabBzDp/1mfaxHCh8/OOorHTy0=",
+        "type": "tarball",
+        "url": "https://github.com/nixos/nixpkgs/archive/3954218cf613eba8e0dcefa9abe337d26bc48fd0.tar.gz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://github.com/nixos/nixpkgs/archive/3954218cf613eba8e0dcefa9abe337d26bc48fd0.tar.gz"
+      }
+    },
+    "root": {
+      "inputs": {
+        "devbox-source": "devbox-source",
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.lock
+++ b/flake.lock
@@ -1,22 +1,5 @@
 {
   "nodes": {
-    "devbox-source": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1677791812,
-        "narHash": "sha256-9aGmX21TUINGDA3NB/OrGXi8W4i+b8fKS8ft8GtQxNM=",
-        "owner": "jetpack-io",
-        "repo": "devbox",
-        "rev": "c249fa1da3a24eb686220da378bc9dcdc6d49680",
-        "type": "github"
-      },
-      "original": {
-        "owner": "jetpack-io",
-        "ref": "0.4.2",
-        "repo": "devbox",
-        "type": "github"
-      }
-    },
     "flake-utils": {
       "locked": {
         "lastModified": 1676283394,
@@ -45,7 +28,6 @@
     },
     "root": {
       "inputs": {
-        "devbox-source": "devbox-source",
         "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -15,6 +15,27 @@
         "type": "github"
       }
     },
+    "gomod2nix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "utils": "utils"
+      },
+      "locked": {
+        "lastModified": 1677459247,
+        "narHash": "sha256-JbakfAiPYmCCV224yAMq/XO0udN5coWv/oazblMKdoY=",
+        "owner": "nix-community",
+        "repo": "gomod2nix",
+        "rev": "3cbf3a51fe32e2f57af4c52744e7228bab22983d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "gomod2nix",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "narHash": "sha256-Jgq50e4S4JVCYpWLqrabBzDp/1mfaxHCh8/OOorHTy0=",
@@ -29,7 +50,23 @@
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
+        "gomod2nix": "gomod2nix",
         "nixpkgs": "nixpkgs"
+      }
+    },
+    "utils": {
+      "locked": {
+        "lastModified": 1653893745,
+        "narHash": "sha256-0jntwV3Z8//YwuOjzhV2sgJJPt+HY6KhU7VZUL0fKZQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "1ed9fb1935d260de5fe1c2f7ee0ebaae17ed2fa1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -16,9 +16,6 @@
   outputs = { self, nixpkgs, flake-utils, gomod2nix }:
     let
 
-      # to work with older version of flakes
-      lastModifiedDate =
-        self.lastModifiedDate or self.lastModified or "19700101";
       # System types to support.
       supportedSystems =
         [ "x86_64-linux" "x86_64-darwin" "aarch64-linux" "aarch64-darwin" ];

--- a/flake.nix
+++ b/flake.nix
@@ -25,13 +25,14 @@
       nixpkgsFor = forAllSystems (system: import nixpkgs { inherit system; });
 
       commit = builtins.substring 0 7 self.shortRev;
-      version = "0.4.2";
+      semver = "0.4.2";
     in {
 
       # Provide some binary packages for selected system types.
       packages = forAllSystems (system:
         let 
           pkgs = nixpkgsFor.${system};
+          version = "${semver}.${commit}";
           pname = "devbox";
           name = "devbox-${version}";
 
@@ -39,8 +40,8 @@
           devbox = pkgs.buildGoModule {
             inherit pname;
             inherit name;
+            inherit version;
 
-            version = "${version}.${commit}";
 
             src = ./.;
 

--- a/flake.nix
+++ b/flake.nix
@@ -16,6 +16,7 @@
   outputs = { self, nixpkgs, flake-utils, gomod2nix }:
     let
 
+      lastModifiedDate = self.lastModifiedDate or self.lastModified or "19700101";
       # System types to support.
       supportedSystems =
         [ "x86_64-linux" "x86_64-darwin" "aarch64-linux" "aarch64-darwin" ];
@@ -28,7 +29,12 @@
         inherit system; 
         overlays = [ gomod2nix.overlays.default ];});
 
-      commit = builtins.substring 0 7 self.shortRev;
+      commit = if builtins.hasAttr "shortRev" self 
+      then
+        builtins.substring 0 7 self.shortRev
+      else
+        "precommit-${lastModifiedDate}";
+        
       semver = "0.4.2";
     in {
 

--- a/flake.nix
+++ b/flake.nix
@@ -25,28 +25,32 @@
       forAllSystems = nixpkgs.lib.genAttrs supportedSystems;
 
       # Nixpkgs instantiated for supported system types.
-      nixpkgsFor = forAllSystems (system: import nixpkgs { 
-        inherit system; 
-        overlays = [ gomod2nix.overlays.default ];});
+      nixpkgsFor = forAllSystems (system: import nixpkgs {
+        inherit system;
+        overlays = [ gomod2nix.overlays.default ];
+      });
 
-      commit = if builtins.hasAttr "shortRev" self 
-      then
-        builtins.substring 0 7 self.shortRev
-      else
-        "precommit-${lastModifiedDate}";
-        
+      commit =
+        if builtins.hasAttr "shortRev" self
+        then
+          builtins.substring 0 7 self.shortRev
+        else
+          "precommit-${lastModifiedDate}";
+
       semver = "0.4.2";
-    in {
+    in
+    {
 
       # Provide some binary packages for selected system types.
       packages = forAllSystems (system:
-        let 
+        let
           pkgs = nixpkgsFor.${system};
           version = "${semver}.${commit}";
           pname = "devbox";
           name = "devbox-${version}";
 
-        in {
+        in
+        {
           devbox = pkgs.buildGoApplication {
             inherit pname;
             inherit name;
@@ -79,7 +83,8 @@
       # Add dependencies that are only needed for development
       devShells = forAllSystems (system:
         let pkgs = nixpkgsFor.${system};
-        in {
+        in
+        {
           default = pkgs.mkShell {
             buildInputs = with pkgs; [
               go_1_19
@@ -92,9 +97,6 @@
           };
         });
 
-      # The default package for 'nix build'. This makes sense if the
-      # flake provides only one package or there is a clear "main"
-      # package.
       defaultPackage = forAllSystems (system: self.packages.${system}.devbox);
     };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,96 @@
+{
+  description = "Devbox: Reproducible Dev Environments";
+  inputs = {
+    nixpkgs.url =
+      "https://github.com/nixos/nixpkgs/archive/3954218cf613eba8e0dcefa9abe337d26bc48fd0.tar.gz";
+
+    flake-utils.url = "github:numtide/flake-utils";
+
+    devbox-source = {
+      type= "github";
+      owner = "jetpack-io";
+      repo = "devbox";
+      ref = "0.4.2";
+      flake = false;
+    };
+
+  };
+
+  outputs = { self, nixpkgs, devbox-source, flake-utils }:
+    let
+
+      # to work with older version of flakes
+      lastModifiedDate =
+        self.lastModifiedDate or self.lastModified or "19700101";
+      # System types to support.
+      supportedSystems =
+        [ "x86_64-linux" "x86_64-darwin" "aarch64-linux" "aarch64-darwin" ];
+
+      # Helper function to generate an attrset '{ x86_64-linux = f "x86_64-linux"; ... }'.
+      forAllSystems = nixpkgs.lib.genAttrs supportedSystems;
+
+      # Nixpkgs instantiated for supported system types.
+      nixpkgsFor = forAllSystems (system: import nixpkgs { inherit system; });
+
+      version = "0.4.2";
+    in {
+
+      # Provide some binary packages for selected system types.
+      packages = forAllSystems (system:
+        let 
+          pkgs = nixpkgsFor.${system};
+          pname = "devbox";
+          name = "devbox-${version}";
+
+        in {
+          devbox = pkgs.buildGoModule {
+            inherit version;
+            inherit pname;
+            inherit name;
+
+            src = devbox-source;
+
+            # integration tests want filesystem access
+            doCheck = false;
+
+            ldflags = [
+              "-s"
+              "-w"
+              "-X go.jetpack.io/devbox/internal/build.Version=${version}"
+            ];
+
+            nativeBuildInputs = with pkgs; [ installShellFiles ];
+
+            vendorSha256 =
+              "sha256-62cJVlrGdrBSK+yzOA4WiHvplEMuKo09qp95+aX3WY0=";
+
+            postInstall = ''
+              installShellCompletion --cmd devbox \
+                --bash <($out/bin/devbox completion bash) \
+                --fish <($out/bin/devbox completion fish) \
+                --zsh <($out/bin/devbox completion zsh)
+            '';
+          };
+        });
+
+      # Add dependencies that are only needed for development
+      devShells = forAllSystems (system:
+        let pkgs = nixpkgsFor.${system};
+        in {
+          default = pkgs.mkShell {
+            buildInputs = with pkgs; [
+              go_1_19
+              gopls
+              gotools
+              go-tools
+              golangci-lint
+            ];
+          };
+        });
+
+      # The default package for 'nix build'. This makes sense if the
+      # flake provides only one package or there is a clear "main"
+      # package.
+      defaultPackage = forAllSystems (system: self.packages.${system}.devbox);
+    };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -6,17 +6,9 @@
 
     flake-utils.url = "github:numtide/flake-utils";
 
-    devbox-source = {
-      type= "github";
-      owner = "jetpack-io";
-      repo = "devbox";
-      ref = "0.4.2";
-      flake = false;
-    };
-
   };
 
-  outputs = { self, nixpkgs, devbox-source, flake-utils }:
+  outputs = { self, nixpkgs, flake-utils }:
     let
 
       # to work with older version of flakes
@@ -32,6 +24,7 @@
       # Nixpkgs instantiated for supported system types.
       nixpkgsFor = forAllSystems (system: import nixpkgs { inherit system; });
 
+      commit = builtins.substring 0 7 self.shortRev;
       version = "0.4.2";
     in {
 
@@ -44,11 +37,12 @@
 
         in {
           devbox = pkgs.buildGoModule {
-            inherit version;
             inherit pname;
             inherit name;
 
-            src = devbox-source;
+            version = "${version}.${commit}";
+
+            src = ./.;
 
             # integration tests want filesystem access
             doCheck = false;

--- a/gomod2nix.toml
+++ b/gomod2nix.toml
@@ -1,0 +1,177 @@
+schema = 3
+
+[mod]
+  [mod."cuelang.org/go"]
+    version = "v0.4.3"
+    hash = "sha256-i9wampQA4Fnjfzce91SNb76WD3iEQir8VP66WJdTNGY="
+  [mod."github.com/AlecAivazis/survey/v2"]
+    version = "v2.3.6"
+    hash = "sha256-1XZsn7ewI7X0GLbZfAkejg4CYXAB1Ol0L2XNM2U9w6o="
+  [mod."github.com/MakeNowJust/heredoc/v2"]
+    version = "v2.0.1"
+    hash = "sha256-vBdopg8n/cH0a0UFUDfLXeYGJNxK+HdqCmn82QB8j8w="
+  [mod."github.com/a8m/envsubst"]
+    version = "v1.4.2"
+    hash = "sha256-gfzqf/CXSwGXBK5VHJnepFZ1wB3WElpEp6ra9JI4WtY="
+  [mod."github.com/alessio/shellescape"]
+    version = "v1.4.1"
+    hash = "sha256-rTWqbtC+EVz4fT2HmDWpucUTMtQyraInPYf2hlG8/pM="
+  [mod."github.com/andybalholm/brotli"]
+    version = "v1.0.5"
+    hash = "sha256-/qS8wU8yZQJ+uTOg66rEl9s7spxq9VIXF5L1BcaEClc="
+  [mod."github.com/bmatcuk/doublestar/v4"]
+    version = "v4.6.0"
+    hash = "sha256-0Azugw9q+RgQd7FR8cnpS4GpfWU9oAeLFmLOffMH5Iw="
+  [mod."github.com/bmizerany/assert"]
+    version = "v0.0.0-20160611221934-b7ed37b82869"
+    hash = "sha256-WnAmAW0f97kZoGhBmIGNBjblTh02O9WfPrH9RD0PHqI="
+  [mod."github.com/briandowns/spinner"]
+    version = "v1.19.0"
+    hash = "sha256-WDdbgJcsBXQLjHWvNBNLuzkRQIlPGuLeJer7fWyY4wo="
+  [mod."github.com/cavaliergopher/grab/v3"]
+    version = "v3.0.1"
+    hash = "sha256-7yixBq4kPAp+NqHvEC4xCKFwI5bqSbZfzdVVLwvMvl4="
+  [mod."github.com/cockroachdb/apd/v2"]
+    version = "v2.0.2"
+    hash = "sha256-UrPHkvqVF8V78+kXKmjTHl79XsgDBnqFsje5BMYh0E4="
+  [mod."github.com/cpuguy83/go-md2man/v2"]
+    version = "v2.0.2"
+    hash = "sha256-OvWCtDsVrYzM84SMQwOXPLBxnWnMC1hDm+KiI6zm3uk="
+  [mod."github.com/creekorful/mvnparser"]
+    version = "v1.5.0"
+    hash = "sha256-PTodlzMKQBTUDsrz0cSnyc6/Z4X8S+0WS4c38SkOo7A="
+  [mod."github.com/davecgh/go-spew"]
+    version = "v1.1.1"
+    hash = "sha256-nhzSUrE1fCkN0+RL04N4h8jWmRFPPPWbCuDc7Ss0akI="
+  [mod."github.com/denisbrodbeck/machineid"]
+    version = "v1.0.1"
+    hash = "sha256-K7ID9G3Caq31ahbe8b8ym/Wx5pRDIMO4TIrC5MTCuRw="
+  [mod."github.com/dsnet/compress"]
+    version = "v0.0.1"
+    hash = "sha256-HCqu3cKayMvx1YIUPkJ+u4UM6WN8nrsNIhdvGJIJgwg="
+  [mod."github.com/fatih/color"]
+    version = "v1.14.1"
+    hash = "sha256-cCjkicVuBK19gkNKHU4BhKNKETfGKPx72Rus473HbcY="
+  [mod."github.com/fsnotify/fsnotify"]
+    version = "v1.6.0"
+    hash = "sha256-DQesOCweQPEwmAn6s7DCP/Dwy8IypC+osbpfsvpkdP0="
+  [mod."github.com/getsentry/sentry-go"]
+    version = "v0.18.0"
+    hash = "sha256-w5n0p7mFsOzBHJdvts2vxelo8qp6YJXAkTPB84nZaDs="
+  [mod."github.com/golang/snappy"]
+    version = "v0.0.4"
+    hash = "sha256-Umx+5xHAQCN/Gi4HbtMhnDCSPFAXSsjVbXd8n5LhjAA="
+  [mod."github.com/google/go-cmp"]
+    version = "v0.5.9"
+    hash = "sha256-lQc4O00R3QSMGs9LP8Sy7A9kj0cqV5rrUdpnGeipIyg="
+  [mod."github.com/google/uuid"]
+    version = "v1.3.0"
+    hash = "sha256-QoR55eBtA94T2tBszyxfDtO7/pjZZSGb5vm7U0Xhs0Y="
+  [mod."github.com/hashicorp/go-envparse"]
+    version = "v0.1.0"
+    hash = "sha256-MkHaxEZDHVz84IImaC8+s4lAgNLhsaAMSkVmt55JC3M="
+  [mod."github.com/imdario/mergo"]
+    version = "v0.3.13"
+    hash = "sha256-03LKAZXgR5YUMeK5IRh2ds2GyV6uSbdq5QCPbAzlTus="
+  [mod."github.com/inconshreveable/mousetrap"]
+    version = "v1.0.1"
+    hash = "sha256-ZTP9pLgwAAvHYK5A4PqwWCHGt00x5zMSOpCPoomQ3Sg="
+  [mod."github.com/kballard/go-shellquote"]
+    version = "v0.0.0-20180428030007-95032a82bc51"
+    hash = "sha256-AOEdKETBMUC39ln6jBJ9NYdJWp++jV5lSbjNqG3dV+c="
+  [mod."github.com/klauspost/compress"]
+    version = "v1.16.0"
+    hash = "sha256-bMMwJhgK/uR3xq16XdqE2ge8x0fn6WK1NGkU3cKSWV4="
+  [mod."github.com/klauspost/pgzip"]
+    version = "v1.2.5"
+    hash = "sha256-o2cjgEGdaw2ktMGtaeBvOjS/6H/q4xI3Ngcc8TWTxlQ="
+  [mod."github.com/mattn/go-colorable"]
+    version = "v0.1.13"
+    hash = "sha256-qb3Qbo0CELGRIzvw7NVM1g/aayaz4Tguppk9MD2/OI8="
+  [mod."github.com/mattn/go-isatty"]
+    version = "v0.0.17"
+    hash = "sha256-c1u9eiMF9wLXgGvPTB5DH6S8uuCPqWZJTa6tCGuB3Ek="
+  [mod."github.com/mgutz/ansi"]
+    version = "v0.0.0-20200706080929-d51e80ef957d"
+    hash = "sha256-RY6deYqJKpTTttr5tH2VW+PtuUIcieEq3Y6fGqRL0vk="
+  [mod."github.com/mholt/archiver/v4"]
+    version = "v4.0.0-alpha.7"
+    hash = "sha256-SptsF4nhQPjjVtJM0NRrVWmzVMMTiTY44XylVA1DBUs="
+  [mod."github.com/mpvl/unique"]
+    version = "v0.0.0-20150818121801-cbe035fff7de"
+    hash = "sha256-kWdg8qhWQem2xCzwQKbQ0dmwA8D5Zwe6owPIgSMSIB4="
+  [mod."github.com/nwaples/rardecode/v2"]
+    version = "v2.0.0-beta.2"
+    hash = "sha256-xwdH0iDu4voySQPXOUb82uWsRBlmdlyNvq7o11yvhIw="
+  [mod."github.com/pelletier/go-toml/v2"]
+    version = "v2.0.6"
+    hash = "sha256-BxAeApnn5H+OLlH3TXGvIbtC6LmbRnjwbcfT1qMZ4PE="
+  [mod."github.com/pierrec/lz4/v4"]
+    version = "v4.1.17"
+    hash = "sha256-36L+GNhRrHBCyhbHCqweCk5rfmggdRtHqH6g5m1ViQI="
+  [mod."github.com/pkg/diff"]
+    version = "v0.0.0-20210226163009-20ebb0f2a09e"
+    hash = "sha256-0aP4CtvBp9lmxoIvKq6mrOyQidLubH1bG92RD/n7bbw="
+  [mod."github.com/pkg/errors"]
+    version = "v0.9.1"
+    hash = "sha256-mNfQtcrQmu3sNg/7IwiieKWOgFQOVVe2yXgKBpe/wZw="
+  [mod."github.com/pmezard/go-difflib"]
+    version = "v1.0.0"
+    hash = "sha256-/FtmHnaGjdvEIKAJtrUfEhV7EVo5A/eYrtdnUkuxLDA="
+  [mod."github.com/rogpeppe/go-internal"]
+    version = "v1.9.0"
+    hash = "sha256-XKmbu8l55XGrvC20j8jocpauwZsdbP83YAwH79BEAC4="
+  [mod."github.com/russross/blackfriday/v2"]
+    version = "v2.1.0"
+    hash = "sha256-R+84l1si8az5yDqd5CYcFrTyNZ1eSYlpXKq6nFt4OTQ="
+  [mod."github.com/samber/lo"]
+    version = "v1.37.0"
+    hash = "sha256-5m0advnk/wy/bFygNyxaPVX2PgA5oF1lSHP71hAOhCc="
+  [mod."github.com/segmentio/analytics-go"]
+    version = "v3.1.0+incompatible"
+    hash = "sha256-6xR7q257Dv5L3W2iENbsvWb8L/kVi4TjCn1tnVMRtSM="
+  [mod."github.com/segmentio/backo-go"]
+    version = "v1.0.1"
+    hash = "sha256-k3m3sfGUZtfW7dc1ATmH3AztZJL82erJb8A7PagbCXc="
+  [mod."github.com/spf13/cobra"]
+    version = "v1.6.1"
+    hash = "sha256-80B5HcYdFisz6QLYkTyka7f9Dr6AfcVyPwp3QChoXwU="
+  [mod."github.com/spf13/pflag"]
+    version = "v1.0.5"
+    hash = "sha256-w9LLYzxxP74WHT4ouBspH/iQZXjuAh2WQCHsuvyEjAw="
+  [mod."github.com/stretchr/testify"]
+    version = "v1.8.1"
+    hash = "sha256-3e0vOJLgCMAan+GfaGN8RGZdarh5iCavM6flf6YMNPk="
+  [mod."github.com/therootcompany/xz"]
+    version = "v1.0.1"
+    hash = "sha256-SujtLzRINpXKEyldKuRYrTfhsLLop12PpdlY0F18/88="
+  [mod."github.com/ulikunitz/xz"]
+    version = "v0.5.11"
+    hash = "sha256-SUyrjc2wyN3cTGKe5JdBEXjtZC1rJySRxJHVUZ59row="
+  [mod."github.com/xtgo/uuid"]
+    version = "v0.0.0-20140804021211-a0b114877d4c"
+    hash = "sha256-PNMdRS+gY4QhJnSaHsm8WbyjB5eKTVY2Q73oCJJX9YI="
+  [mod."golang.org/x/exp"]
+    version = "v0.0.0-20230224173230-c95f2b4c22f2"
+    hash = "sha256-P4lqkRm6iNiw1PVW0kN/YByDjdo2Nhvgnc2Xun1R82Q="
+  [mod."golang.org/x/mod"]
+    version = "v0.8.0"
+    hash = "sha256-cgtmxQA937+MdXUiPrVeDvRoqhxD4hvIbtXAjK2SM8U="
+  [mod."golang.org/x/net"]
+    version = "v0.7.0"
+    hash = "sha256-LgZYZRwtMqm+soNh+esxDSeRuIDxRGb9OEfYaFJHCDI="
+  [mod."golang.org/x/sys"]
+    version = "v0.5.0"
+    hash = "sha256-0LTr3KeJ1OMQAwYUQo1513dXJtQAJn5Dq8sFkc8ps1U="
+  [mod."golang.org/x/term"]
+    version = "v0.5.0"
+    hash = "sha256-f3DiX7NkDsEZpPS+PbmnOH9F5WHFZ1sQrfFg/T2UPno="
+  [mod."golang.org/x/text"]
+    version = "v0.7.0"
+    hash = "sha256-ydgUqX+t5Qke16C6d3FP/06U/N1n+rUKpLRFj4KXjwk="
+  [mod."gopkg.in/natefinch/lumberjack.v2"]
+    version = "v2.0.0"
+    hash = "sha256-CLir3wRkgNy7tXQWODk7u3RP/W7qIsO2LADdM6/vWtQ="
+  [mod."gopkg.in/yaml.v3"]
+    version = "v3.0.1"
+    hash = "sha256-FqL9TKYJ0XkNwJFnq9j0VvJ5ZUU1RvH/52h/f5bkYAU="


### PR DESCRIPTION
## Context
We currently publish Devbox as a package in the `nixpkg` repository, but this version is often far behind our latest released version. For example: 22.11 currently has `devbox 0.1.0`, while unstable has `devbox 0.3.4` (we're on 0.4.2 as of this PR). 

By publishing a flake, we could make it easier for developers using NixOS, Nixpkg, or Home Manager to install Devbox on their system. Developers could add our repo + release tags as an input, and then have access to the latest versions as soon as we publish them.

With this installed, developers using Nix could install devbox with something like

```bash
nix build github:jetpack-io/devbox/latest
```

or adding 

```nix
{
  inputs = {
         devbox.url = "github:jetpack-io/devbox/latest";
   ...
  };
...
}
```

to their flake.

## Changes / Limitations with this PR:

1. **go.mod Hashes**  - We need to provide Nix with a sha256 of our vendored dependencies in order to build Devbox. We can do this by either adding a `vendorSHA256` to our Flake, or using `gomod2nix` to generate a module with the hashes of all the dependencies in our `go.mod` file. This PR goes with the `gomod2nix` approach. 

2. **Version Number** - The version number currently needs to be set and updated manually in the Flake. This is because Flake outputs don't have access to the repositories branches or tags. We could pull this version from a file in the repo, or by running a script that reads the tags. 

3. **Branch/Refs** - To make it easy to install the latest version, we'll need a ref in our git repo for `latest` or `stable`. This could be a branch or a tag, and should be updated whenever we make a new full release.

## How was it tested?

- [x]  aarch64-linux
- [x]  x86_64-linux
- [x]  aarch64-darwin
- [x]  x86_64-darwin
- [x]  WSL2

With `nix command` and `flakes` enabled: 

* `nix build`
* `nix flake`
