### PR TITLE
nix: don't pass --experimental-features to nix commands

### DIFF
--- a/.github/workflows/cli-tests.yaml
+++ b/.github/workflows/cli-tests.yaml
@@ -31,6 +31,12 @@ permissions:
   contents: read
   pull-requests: read
 
+defaults:
+  run:
+    # Explicitly setting the shell to bash runs commands with
+    # `bash --noprofile --norc -eo pipefail` instead of `bash -e`.
+    shell: bash
+
 env:
   HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}"
   HOMEBREW_NO_ANALYTICS: 1
@@ -102,10 +108,10 @@ jobs:
             brew install dash zsh
           fi
       - name: Install Nix
-        uses: DeterminateSystems/nix-installer-action@v1
+        uses: DeterminateSystems/nix-installer-action@v4
         with:
           logger: pretty
-          nix-build-user-count: 4
+          extra-conf: experimental-features = ca-derivations fetch-closure
       - name: Run tests
         env:
           # For devbox.json tests, we default to non-debug mode since the debug output is less useful than for unit testscripts.
@@ -115,6 +121,15 @@ jobs:
           # Used in `go test -timeout` flag. Needs a value that time.ParseDuration can parse.
           DEVBOX_GOLANG_TEST_TIMEOUT: "${{ (github.ref == 'refs/heads/main' || inputs.run-mac-tests) && '35m' || '20m' }}"
         run: |
+          echo "::group::Nix version"
+          nix --version
+          echo "::endgroup::"
+          echo "::group::Contents of /etc/nix/nix.conf"
+          cat /etc/nix/nix.conf || true
+          echo "::endgroup::"
+          echo "::group::Resolved Nix config"
+          nix show-config
+          echo "::endgroup::"
           go test -v -timeout $DEVBOX_GOLANG_TEST_TIMEOUT ./...
 
   auto-nix-install: # ensure Devbox installs nix and works properly after installation.
@@ -141,12 +156,14 @@ jobs:
           devbox run echo "Installing packages..."
       - name: Test removing package
         run: devbox rm go
-  
-  test-with-old-nix-version:
+
+  # Run a sanity test to make sure Devbox can install and remove packages with
+  # the last 3 Nix releases.
+  test-nix-versions:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        version: [2.15.1]
+        version: [2.15.1, 2.16.1, 2.17.0]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
@@ -155,15 +172,23 @@ jobs:
           go-version-file: ./go.mod
       - name: Build devbox
         run: go install ./cmd/devbox
-      - name: Install nix
-        run: sh <(curl -L https://releases.nixos.org/nix/nix-${{ matrix.version }}/install) --daemon
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@v4
+        with:
+          logger: pretty
+          extra-conf: experimental-features = ca-derivations fetch-closure
+          nix-package-url: https://releases.nixos.org/nix/nix-${{ matrix.version }}/nix-${{ matrix.version }}-${{ runner.arch == 'X64' && 'x86_64' || 'aarch64' }}-${{ runner.os == 'macOS' && 'darwin' || 'linux' }}.tar.xz
       - name: Install devbox packages
         run: |
-          # Setup github authentication to ensure Github's rate limits are not hit.
-          # If this works, we can consider refactoring this into a reusable github action helper.
-          mkdir -p ~/.config/nix
-          echo "access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}" > ~/.config/nix/nix.conf
-
-          devbox run echo "Installing packages..."
-      - name: Test removing package
-        run: devbox rm go
+          echo "::group::Nix version"
+          nix --version
+          echo "::endgroup::"
+          echo "::group::Contents of /etc/nix/nix.conf"
+          cat /etc/nix/nix.conf || true
+          echo "::endgroup::"
+          echo "::group::Resolved Nix config"
+          nix show-config
+          echo "::endgroup::"
+          devbox install
+          devbox run -- echo "Hello from devbox!"
+          devbox rm go

--- a/internal/impl/packages.go
+++ b/internal/impl/packages.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"io/fs"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"runtime/trace"
 	"strings"
@@ -239,7 +238,7 @@ func (d *Devbox) profilePath() (string, error) {
 		debug.Log("ERROR: resetProfileDirForFlakes error: %v\n", err)
 	}
 
-	return absPath, errors.WithStack(os.MkdirAll(filepath.Dir(absPath), 0755))
+	return absPath, errors.WithStack(os.MkdirAll(filepath.Dir(absPath), 0o755))
 }
 
 // syncPackagesToProfile ensures that all packages in devbox.json exist in the nix profile,
@@ -340,11 +339,10 @@ func (d *Devbox) removePackagesFromProfile(ctx context.Context, pkgs []string) e
 		}
 
 		// TODO: unify this with nix.ProfileRemove
-		cmd := exec.Command("nix", "profile", "remove",
+		cmd := nix.Command(ctx, "profile", "remove",
 			"--profile", profileDir,
 			fmt.Sprintf("%d", index),
 		)
-		cmd.Args = append(cmd.Args, nix.ExperimentalFlags()...)
 		cmd.Stdout = d.writer
 		cmd.Stderr = d.writer
 		err = cmd.Run()

--- a/internal/impl/shell.go
+++ b/internal/impl/shell.go
@@ -5,6 +5,7 @@ package impl
 
 import (
 	"bytes"
+	"context"
 	_ "embed"
 	"fmt"
 	"io/fs"
@@ -109,11 +110,9 @@ func shellPath(devbox *Devbox) (path string, err error) {
 
 	var bashNixStorePath string // of the form /nix/store/{hash}-bash-{version}/
 
-	cmd := exec.Command(
-		"nix", "eval", "--raw",
+	cmd := nix.Command(context.TODO(), "eval", "--raw",
 		fmt.Sprintf("%s#bashInteractive", nix.FlakeNixpkgs(devbox.cfg.NixPkgsCommitHash())),
 	)
-	cmd.Args = append(cmd.Args, nix.ExperimentalFlags()...)
 	out, err := cmd.Output()
 	if err != nil {
 		return "", errors.WithStack(err)
@@ -121,8 +120,7 @@ func shellPath(devbox *Devbox) (path string, err error) {
 	bashNixStorePath = string(out)
 
 	// install bashInteractive in nix/store without creating a symlink to local directory (--no-link)
-	cmd = exec.Command("nix", "build", bashNixStorePath, "--no-link")
-	cmd.Args = append(cmd.Args, nix.ExperimentalFlags()...)
+	cmd = nix.Command(context.TODO(), "build", bashNixStorePath, "--no-link")
 	err = cmd.Run()
 	if err != nil {
 		return "", errors.WithStack(err)

--- a/internal/nix/eval.go
+++ b/internal/nix/eval.go
@@ -1,13 +1,14 @@
 package nix
 
 import (
+	"context"
 	"encoding/json"
 	"os"
 	"strconv"
 )
 
 func EvalPackageName(path string) (string, error) {
-	cmd := command("eval", "--raw", path+".name")
+	cmd := Command(context.TODO(), "eval", "--raw", path+".name")
 	out, err := cmd.Output()
 	if err != nil {
 		return "", err
@@ -17,7 +18,7 @@ func EvalPackageName(path string) (string, error) {
 
 // PackageIsInsecure is a fun little nix eval that maybe works.
 func PackageIsInsecure(path string) bool {
-	cmd := command("eval", path+".meta.insecure")
+	cmd := Command(context.TODO(), "eval", path+".meta.insecure")
 	out, err := cmd.Output()
 	if err != nil {
 		// We can't know for sure, but probably not.
@@ -32,7 +33,7 @@ func PackageIsInsecure(path string) bool {
 }
 
 func PackageKnownVulnerabilities(path string) []string {
-	cmd := command("eval", path+".meta.knownVulnerabilities")
+	cmd := Command(context.TODO(), "eval", path+".meta.knownVulnerabilities")
 	out, err := cmd.Output()
 	if err != nil {
 		// We can't know for sure, but probably not.
@@ -50,7 +51,7 @@ func PackageKnownVulnerabilities(path string) []string {
 // nix eval --raw nixpkgs/9ef09e06806e79e32e30d17aee6879d69c011037#fuse3
 // to determine if a package if a package can be installed in system.
 func Eval(path string) ([]byte, error) {
-	cmd := command("eval", "--raw", path)
+	cmd := Command(context.TODO(), "eval", "--raw", path)
 	return cmd.CombinedOutput()
 }
 

--- a/internal/nix/profiles.go
+++ b/internal/nix/profiles.go
@@ -4,6 +4,7 @@
 package nix
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -17,7 +18,7 @@ import (
 )
 
 func ProfileList(writer io.Writer, profilePath string, useJSON bool) (string, error) {
-	cmd := command("profile", "list", "--profile", profilePath)
+	cmd := Command(context.TODO(), "profile", "list", "--profile", profilePath)
 	if useJSON {
 		cmd.Args = append(cmd.Args, "--json")
 	}
@@ -29,7 +30,6 @@ func ProfileList(writer io.Writer, profilePath string, useJSON bool) (string, er
 }
 
 func ProfileInstall(writer io.Writer, profilePath string, installable string) error {
-
 	if !IsInsecureAllowed() && PackageIsInsecure(installable) {
 		knownVulnerabilities := PackageKnownVulnerabilities(installable)
 		errString := fmt.Sprintf("Package %s is insecure. \n\n", installable)
@@ -40,7 +40,7 @@ func ProfileInstall(writer io.Writer, profilePath string, installable string) er
 		return usererr.New(errString)
 	}
 
-	cmd := command(
+	cmd := Command(context.TODO(),
 		"profile", "install",
 		"--profile", profilePath,
 		"--impure", // for NIXPKGS_ALLOW_UNFREE
@@ -63,8 +63,7 @@ func ProfileInstall(writer io.Writer, profilePath string, installable string) er
 }
 
 func ProfileRemove(profilePath string, indexes []string) error {
-
-	cmd := command(
+	cmd := Command(context.TODO(),
 		append([]string{
 			"profile", "remove",
 			"--profile", profilePath,

--- a/internal/nix/search.go
+++ b/internal/nix/search.go
@@ -1,18 +1,20 @@
 package nix
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
-	"os/exec"
 
 	"github.com/pkg/errors"
 	"go.jetpack.io/devbox/internal/boxcli/usererr"
 	"go.jetpack.io/devbox/internal/debug"
 )
 
-var ErrPackageNotFound = errors.New("package not found")
-var ErrPackageNotInstalled = errors.New("package not installed")
+var (
+	ErrPackageNotFound     = errors.New("package not found")
+	ErrPackageNotInstalled = errors.New("package not installed")
+)
 
 type Info struct {
 	// attribute key is different in flakes vs legacy so we should only use it
@@ -43,7 +45,6 @@ func parseSearchResults(data []byte) map[string]*Info {
 			PName:        result["pname"].(string),
 			Version:      result["version"].(string),
 		}
-
 	}
 	return infos
 }
@@ -87,8 +88,7 @@ func searchSystem(url string, system string) (map[string]*Info, error) {
 		_ = EnsureNixpkgsPrefetched(writer, hash)
 	}
 
-	cmd := exec.Command("nix", "search", "--json", url)
-	cmd.Args = append(cmd.Args, ExperimentalFlags()...)
+	cmd := Command(context.TODO(), "search", "--json", url)
 	if system != "" {
 		cmd.Args = append(cmd.Args, "--system", system)
 	}

--- a/internal/nix/store.go
+++ b/internal/nix/store.go
@@ -1,6 +1,7 @@
 package nix
 
 import (
+	"context"
 	"encoding/json"
 	"path/filepath"
 	"strings"
@@ -19,7 +20,7 @@ func StorePath(hash, name, version string) string {
 
 // ContentAddressedStorePath takes a store path and returns the content-addressed store path.
 func ContentAddressedStorePath(storePath string) (string, error) {
-	cmd := command("store", "make-content-addressed", storePath, "--json")
+	cmd := Command(context.TODO(), "store", "make-content-addressed", "--json", storePath)
 	out, err := cmd.Output()
 	if err != nil {
 		return "", errors.WithStack(err)

--- a/internal/nix/store_test.go
+++ b/internal/nix/store_test.go
@@ -2,18 +2,23 @@ package nix
 
 import (
 	"fmt"
+	"strings"
 	"testing"
+
+	"golang.org/x/exp/slices"
 )
 
 func TestContentAddressedPath(t *testing.T) {
-
 	testCases := []struct {
 		storePath string
-		expected  string
+		expected  []string
 	}{
 		{
 			"/nix/store/r2jd6ygnmirm2g803mksqqjm4y39yi6i-git-2.33.1",
-			"/nix/store/ldbhlwhh39wha58rm61bkiiwm6j7211j-git-2.33.1",
+			[]string{
+				"/nix/store/ldbhlwhh39wha58rm61bkiiwm6j7211j-git-2.33.1",
+				"/nix/store/d49wyvsz5nkqa23qp4p0ikr04mw9n4h9-git-2.33.1",
+			},
 		},
 	}
 
@@ -23,10 +28,9 @@ func TestContentAddressedPath(t *testing.T) {
 			if err != nil {
 				t.Errorf("got error: %v", err)
 			}
-			if out != testCase.expected {
-				t.Errorf("got %s, want %s", out, testCase.expected)
+			if !slices.Contains(testCase.expected, out) {
+				t.Errorf("got %q, want any of:\n%s", out, strings.Join(testCase.expected, "\n"))
 			}
 		})
-
 	}
 }

--- a/internal/nix/upgrade.go
+++ b/internal/nix/upgrade.go
@@ -4,16 +4,16 @@
 package nix
 
 import (
+	"context"
 	"fmt"
 	"os"
-	"os/exec"
 
 	"go.jetpack.io/devbox/internal/redact"
 	"go.jetpack.io/devbox/internal/ux"
 )
 
 func ProfileUpgrade(ProfileDir string, idx int) error {
-	cmd := command(
+	cmd := Command(context.TODO(),
 		"profile", "upgrade",
 		"--profile", ProfileDir,
 		fmt.Sprintf("%d", idx),
@@ -29,13 +29,11 @@ func ProfileUpgrade(ProfileDir string, idx int) error {
 
 func FlakeUpdate(ProfileDir string) error {
 	ux.Finfo(os.Stderr, "Running \"nix flake update\"\n")
-	cmd := exec.Command("nix", "flake", "update", ProfileDir)
-	cmd.Args = append(cmd.Args, ExperimentalFlags()...)
+	cmd := Command(context.TODO(), "flake", "update", ProfileDir)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return redact.Errorf(
 			"error running \"nix flake update\": %s: %w", out, err)
-
 	}
 	return nil
 }


### PR DESCRIPTION
When running nix commands, devbox passes two flags to enable experimental features:

1. `nix --extra-experimental-features ...`
2. `nix --option experimental-features ...`

The second flag causes issues because it overwrites the user's nix.conf. It doesn't seem to be doing anything, so remove it and just use `--extra-experimental-features`. There's also some cleanup to switch all callers of `nix.ExperimentalFlags` to use `nix.Command` instead. This function sets the correct flags and forwards SIGINTs to Nix instead of just killing the process when devbox gets interrupted.

Details
-------

A specific bug caused by this flag is https://github.com/jetpack-io/devbox/pull/1263. The DeterminateSystems installer configures Nix without a build users group and instead enables the `auto-allocate-uids` setting in `/etc/nix/nix.conf` on Linux. If this setting gets disabled by devbox, then the Nix daemon has no way of building flakes and fails.

The reason why `--option experimental-features ...` was added is because we were still seeing errors about ca-derivations not being enabled even though the `--extra-experimental-features ca-derivations` flag was set. Overwriting the config setting seemed to fix it, but that might've been a red herring.

The ca-derivations feature is unique in that it must be set in the Nix daemon, not just the client. This is because it changes the schema of the Nix database, requiring a restart of the daemon. The only reliable way to enable it is to add it to `/etc/nix/nix.conf` and restart the nix-daemon process.

Given that this flag is currently breaking some users and doesn't seem to be having the intended effect, I think we should remove it and figure out another way to ensure ca-derivations is enabled. Switching to using the DeterminateSystems installer and printing errors telling the user how to enable it are probably the best bet.