### PR TITLE
[generate] Added message output for generate dockerfile and devcontainer commands

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM jetpackio/devbox:latest
+
+# Installing your devbox project
+WORKDIR /code
+USER ${DEVBOX_USER}:${DEVBOX_USER}
+COPY --chown=${DEVBOX_USER}:${DEVBOX_USER} devbox.json devbox.json
+COPY --chown=${DEVBOX_USER}:${DEVBOX_USER} devbox.lock devbox.lock
+# Copy the rest of your project files and directories
+
+
+RUN devbox run -- echo "Installed Packages."
+
+CMD ["devbox", "shell"]

--- a/docs/app/docs/cli_reference/devbox_generate.md
+++ b/docs/app/docs/cli_reference/devbox_generate.md
@@ -3,7 +3,7 @@
 Top level command for generating Devcontainers,  Dockerfiles, and other useful files for your Devbox Project. 
 
 ```bash
-devbox generate <devcontainer|dockerfile|direnv> [flags]
+devbox generate <devcontainer|dockerfile|direnv|readme> [flags]
 ```
 
 ## Options

--- a/docs/app/docs/cli_reference/devbox_generate_devcontainer.md
+++ b/docs/app/docs/cli_reference/devbox_generate_devcontainer.md
@@ -10,6 +10,8 @@ Generate Dockerfile and devcontainer.json files necessary to run VSCode in remot
 devbox generate devcontainer [flags]
 ```
 
+The generated Dockerfile only copies `devbox.json` and `devbox.lock` files into the container. Users need to modify this file to include copying their project files as well.
+
 ### Options
 
 <!-- Markdown Table of Options -->

--- a/docs/app/docs/cli_reference/devbox_generate_dockerfile.md
+++ b/docs/app/docs/cli_reference/devbox_generate_dockerfile.md
@@ -10,6 +10,8 @@ Generate a Dockerfile that replicates devbox shell. Can be used to run devbox sh
 devbox generate dockerfile [flags]
 ```
 
+The generated Dockerfile only copies `devbox.json` and `devbox.lock` files into the container. Users need to modify this file to include copying their project files as well.
+
 ## Options
 
 <!-- Markdown Table of Options -->

--- a/internal/boxcli/generate.go
+++ b/internal/boxcli/generate.go
@@ -4,6 +4,8 @@
 package boxcli
 
 import (
+	"fmt"
+
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
@@ -175,13 +177,37 @@ func runGenerateCmd(cmd *cobra.Command, flags *generateCmdFlags) error {
 		Force:    flags.force,
 		RootUser: flags.rootUser,
 	}
+	quiet, err := cmd.Root().PersistentFlags().GetBool("quiet")
+	if err != nil {
+		return err
+	}
 	switch cmd.Use {
 	case "debug":
 		return box.Generate(cmd.Context())
 	case "devcontainer":
-		return box.GenerateDevcontainer(cmd.Context(), generateOpts)
+		err = box.GenerateDevcontainer(cmd.Context(), generateOpts)
+		if err != nil {
+			return err
+		}
+		if !quiet {
+			fmt.Fprintf(
+				cmd.OutOrStdout(),
+				"Finished generating devcontainer files. \n"+
+					"Make sure to modify the generated Dockerfile to include your project files.\n",
+			)
+		}
 	case "dockerfile":
-		return box.GenerateDockerfile(cmd.Context(), generateOpts)
+		err = box.GenerateDockerfile(cmd.Context(), generateOpts)
+		if err != nil {
+			return err
+		}
+		if !quiet {
+			fmt.Fprintf(
+				cmd.OutOrStdout(),
+				"Finished generating Dockerfile. \n"+
+					"Make sure to modify it to include your project files.\n",
+			)
+		}
 	}
 	return nil
 }

--- a/internal/devbox/generate/tmpl/devcontainerDockerfile.tmpl
+++ b/internal/devbox/generate/tmpl/devcontainerDockerfile.tmpl
@@ -12,7 +12,7 @@ COPY --chown=${DEVBOX_USER}:${DEVBOX_USER} devbox.lock devbox.lock
 COPY devbox.json devbox.json
 COPY devbox.lock devbox.lock
 {{- end}}
-
+# Copy the rest of your project files and directories here:
 {{if len .LocalFlakeDirs}}
 # Step 6: Copying local flakes directories
 {{- end}}


### PR DESCRIPTION
## Summary
Added explanation to the docs and a message output to `devbox gen dockerfile` and `devbox gen devcontainer` commands that the generated dockefile doesn't copy the whole project files. It only copies devbox.json and devbox.lock. The user needs to modify the dockerfile to include copying their project specific files and directories.

## How was it tested?

- devbox run build
- devbox gen 
- devbox gen --quiet dockerfile/devcontainer -f