### PR TITLE
Better Search Results

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,9 +24,11 @@ require (
 	github.com/google/go-cmp v0.6.0
 	github.com/google/uuid v1.6.0
 	github.com/hashicorp/go-envparse v0.1.0
+	github.com/jedib0t/go-pretty/v6 v6.5.4
 	github.com/joho/godotenv v1.5.1
 	github.com/mattn/go-isatty v0.0.20
 	github.com/mholt/archiver/v4 v4.0.0-alpha.8
+	github.com/mitchellh/go-wordwrap v1.0.1
 	github.com/pelletier/go-toml/v2 v2.1.1
 	github.com/pkg/errors v0.9.1
 	github.com/rogpeppe/go-internal v1.12.0

--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,6 @@ require (
 	github.com/joho/godotenv v1.5.1
 	github.com/mattn/go-isatty v0.0.20
 	github.com/mholt/archiver/v4 v4.0.0-alpha.8
-	github.com/mitchellh/go-wordwrap v1.0.1
 	github.com/pelletier/go-toml/v2 v2.1.1
 	github.com/pkg/errors v0.9.1
 	github.com/rogpeppe/go-internal v1.12.0

--- a/go.sum
+++ b/go.sum
@@ -278,8 +278,6 @@ github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d h1:5PJl274Y63IEHC+7izoQ
 github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d/go.mod h1:01TrycV0kFyexm33Z7vhZRXopbI8J3TDReVlkTgMUxE=
 github.com/mholt/archiver/v4 v4.0.0-alpha.8 h1:tRGQuDVPh66WCOelqe6LIGh0gwmfwxUrSSDunscGsRM=
 github.com/mholt/archiver/v4 v4.0.0-alpha.8/go.mod h1:5f7FUYGXdJWUjESffJaYR4R60VhnHxb2X3T1teMyv5A=
-github.com/mitchellh/go-wordwrap v1.0.1 h1:TLuKupo69TCn6TQSyGxwI1EblZZEsQ0vMlAFQflz0v0=
-github.com/mitchellh/go-wordwrap v1.0.1/go.mod h1:R62XHJLzvMFRBbcrT7m7WgmE1eOyTSsCt+hzestvNj0=
 github.com/muesli/reflow v0.3.0 h1:IFsN6K9NfGtjeggFP+68I4chLZV2yIKsXJFNZ+eWh6s=
 github.com/muesli/reflow v0.3.0/go.mod h1:pbwTDkVPibjO2kyvBQRBxTWEEGDGq0FlB1BIKtnHY/8=
 github.com/muesli/termenv v0.15.2 h1:GohcuySI0QmI3wN8Ok9PtKGkgkFIk7y6Vpb5PvrY+Wo=

--- a/go.sum
+++ b/go.sum
@@ -227,6 +227,8 @@ github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpO
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/jedib0t/go-pretty/v6 v6.5.4 h1:gOGo0613MoqUcf0xCj+h/V3sHDaZasfv152G6/5l91s=
+github.com/jedib0t/go-pretty/v6 v6.5.4/go.mod h1:5LQIxa52oJ/DlDSLv0HEkWOFMDGoWkJb9ss5KqPpJBg=
 github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGwWFoC7ycTf1rcQZHOlsJ6N8=
@@ -276,6 +278,8 @@ github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d h1:5PJl274Y63IEHC+7izoQ
 github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d/go.mod h1:01TrycV0kFyexm33Z7vhZRXopbI8J3TDReVlkTgMUxE=
 github.com/mholt/archiver/v4 v4.0.0-alpha.8 h1:tRGQuDVPh66WCOelqe6LIGh0gwmfwxUrSSDunscGsRM=
 github.com/mholt/archiver/v4 v4.0.0-alpha.8/go.mod h1:5f7FUYGXdJWUjESffJaYR4R60VhnHxb2X3T1teMyv5A=
+github.com/mitchellh/go-wordwrap v1.0.1 h1:TLuKupo69TCn6TQSyGxwI1EblZZEsQ0vMlAFQflz0v0=
+github.com/mitchellh/go-wordwrap v1.0.1/go.mod h1:R62XHJLzvMFRBbcrT7m7WgmE1eOyTSsCt+hzestvNj0=
 github.com/muesli/reflow v0.3.0 h1:IFsN6K9NfGtjeggFP+68I4chLZV2yIKsXJFNZ+eWh6s=
 github.com/muesli/reflow v0.3.0/go.mod h1:pbwTDkVPibjO2kyvBQRBxTWEEGDGq0FlB1BIKtnHY/8=
 github.com/muesli/termenv v0.15.2 h1:GohcuySI0QmI3wN8Ok9PtKGkgkFIk7y6Vpb5PvrY+Wo=

--- a/internal/boxcli/search.go
+++ b/internal/boxcli/search.go
@@ -100,25 +100,26 @@ func printSearchResults(
 		systemKey := ""
 		var versions []string
 		for i, pkgVersion := range pkg.Versions {
-			if pkgVersion.Version != "" {
-				if !showAll && i >= 10 {
-					resultsAreTrimmed = true
-					break
-				}
-
-				var systems []string
-				for _, sys := range pkgVersion.Systems {
-					systems = append(systems, sys.System)
-				}
-				slices.Sort(systems)
-				key := strings.Join(systems, " ")
-				if systemKey != key && systemKey != "" {
-					tableWriter.AppendRow(table.Row{pkg.Name, columnize(versions, 2), systemKey}, rowConfigAutoMerge)
-					versions = nil
-				}
-				systemKey = key
-				versions = append(versions, pkgVersion.Version)
+			if pkgVersion.Version == "" {
+				continue
 			}
+			if !showAll && i >= 10 {
+				resultsAreTrimmed = true
+				break
+			}
+
+			var systems []string
+			for _, sys := range pkgVersion.Systems {
+				systems = append(systems, sys.System)
+			}
+			slices.Sort(systems)
+			key := strings.Join(systems, " ")
+			if systemKey != key && systemKey != "" {
+				tableWriter.AppendRow(table.Row{pkg.Name, columnize(versions, 2), systemKey}, rowConfigAutoMerge)
+				versions = nil
+			}
+			systemKey = key
+			versions = append(versions, pkgVersion.Version)
 		}
 
 		if len(versions) > 0 {

--- a/internal/boxcli/search.go
+++ b/internal/boxcli/search.go
@@ -6,13 +6,14 @@ package boxcli
 import (
 	"bytes"
 	"fmt"
-	"github.com/spf13/cobra"
 	"io"
 	"math"
 	"net/url"
 	"slices"
 	"strings"
 	"text/tabwriter"
+
+	"github.com/spf13/cobra"
 
 	"github.com/jedib0t/go-pretty/v6/table"
 	"github.com/jedib0t/go-pretty/v6/text"
@@ -93,46 +94,46 @@ func printSearchResults(
 
 	rowConfigAutoMerge := table.RowConfig{AutoMerge: true}
 
-	t := table.NewWriter()
-	t.AppendHeader(table.Row{"Package", "Versions", "Platforms"}, rowConfigAutoMerge)
+	tableWriter := table.NewWriter()
+	tableWriter.AppendHeader(table.Row{"Package", "Versions", "Platforms"}, rowConfigAutoMerge)
 	for _, pkg := range pkgs {
 		systemKey := ""
 		var versions []string
-		for i, v := range pkg.Versions {
-			if v.Version != "" {
+		for i, pkgVersion := range pkg.Versions {
+			if pkgVersion.Version != "" {
 				if !showAll && i >= 10 {
 					resultsAreTrimmed = true
 					break
 				}
 
 				var systems []string
-				for _, sys := range v.Systems {
+				for _, sys := range pkgVersion.Systems {
 					systems = append(systems, sys.System)
 				}
 				slices.Sort(systems)
 				key := strings.Join(systems, " ")
 				if systemKey != key && systemKey != "" {
-					t.AppendRow(table.Row{pkg.Name, columnize(versions, 2), systemKey}, rowConfigAutoMerge)
+					tableWriter.AppendRow(table.Row{pkg.Name, columnize(versions, 2), systemKey}, rowConfigAutoMerge)
 					versions = nil
 				}
 				systemKey = key
-				versions = append(versions, v.Version)
+				versions = append(versions, pkgVersion.Version)
 			}
 		}
 
 		if len(versions) > 0 {
-			t.AppendRow(table.Row{pkg.Name, columnize(versions, 2), systemKey}, rowConfigAutoMerge)
+			tableWriter.AppendRow(table.Row{pkg.Name, columnize(versions, 2), systemKey}, rowConfigAutoMerge)
 		}
 	}
 
-	t.SetColumnConfigs([]table.ColumnConfig{
+	tableWriter.SetColumnConfigs([]table.ColumnConfig{
 		{Number: 1, AutoMerge: true, VAlign: text.VAlignMiddle},
 		{Number: 2, AutoMerge: true, Align: text.AlignJustify, AlignHeader: text.AlignCenter},
 		{Number: 3, AutoMerge: true, Align: text.AlignJustify, AlignHeader: text.AlignCenter, WidthMaxEnforcer: text.WrapSoft, WidthMin: 15, WidthMax: 15},
 	})
-	t.SetStyle(table.StyleLight)
-	t.Style().Options.SeparateRows = true
-	fmt.Println(t.Render())
+	tableWriter.SetStyle(table.StyleLight)
+	tableWriter.Style().Options.SeparateRows = true
+	fmt.Println(tableWriter.Render())
 
 	if resultsAreTrimmed {
 		fmt.Println()


### PR DESCRIPTION
## Summary

Output tabular search results which show the platforms available

```
❯ devbox search ruby
Found 6+ results for "ruby":

┌─────────────┬──────────────────────────────────┬─────────────────┐
│ PACKAGE     │             VERSIONS             │    PLATFORMS    │
├─────────────┼──────────────────────────────────┼─────────────────┤
│             │ 3.3.0                  3.3.0-rc1 │ aarch64-darwin  │
│             │ 3.3.0-preview3    3.3.0-preview2 │ aarch64-linux   │
│ ruby        │ 3.3.0-preview1             3.2.3 │ x86_64-darwin   │
│             │ 3.2.2                      3.2.1 │ x86_64-linux    │
│             │ 3.1.4                      3.1.3 │                 │
│             │                                  │                 │
├─────────────┼──────────────────────────────────┼─────────────────┤
│             │ 0.10.0                           │ aarch64-darwin  │
│ rubyfmt     │                                  │ aarch64-linux   │
│             │                                  │ x86_64-linux    │
│             ├──────────────────────────────────┼─────────────────┤
│             │ 0.8.1                            │ aarch64-darwin  │
│             │                                  │ aarch64-linux   │
│             │                                  │ x86_64-darwin   │
│             │                                  │ x86_64-linux    │
├─────────────┼──────────────────────────────────┤                 │
│             │ 0.14.0                    0.13.4 │                 │
│             │ 0.13.2                    0.13.0 │                 │
│ ruby-lsp    │ 0.11.1                     0.9.4 │                 │
│             │ 0.8.0                      0.7.4 │                 │
│             │                                  │                 │
├─────────────┼──────────────────────────────────┤                 │
│             │ 5.3.0                            │                 │
│ ruby-zoom   │                                  │                 │
│             │                                  │                 │
│             │                                  │                 │
├─────────────┼──────────────────────────────────┼─────────────────┤
│             │ 0.8.0rc3                         │ aarch64-linux   │
│ rubyripper  │ 0.6.2                            │ x86_64-linux    │
│             │                                  │                 │
├─────────────┼──────────────────────────────────┼─────────────────┤
│ rubyMinimal │ 2.6.6                            │ x86_64-linux    │
│             │                                  │                 │
└─────────────┴──────────────────────────────────┴─────────────────┘

Warning: Showing top 10 results and truncated versions. Use --show-all to show all.

Info: For more information go to: https://www.nixhub.io/search?q=ruby
```

```
❯ devbox search ruby --show-all
Found 6+ results for "ruby":

┌─────────────┬──────────────────────────────────┬─────────────────┐
│ PACKAGE     │             VERSIONS             │    PLATFORMS    │
├─────────────┼──────────────────────────────────┼─────────────────┤
│             │ 3.3.0                  3.3.0-rc1 │ aarch64-darwin  │
│             │ 3.3.0-preview3    3.3.0-preview2 │ aarch64-linux   │
│             │ 3.3.0-preview1             3.2.3 │ x86_64-darwin   │
│             │ 3.2.2                      3.2.1 │ x86_64-linux    │
│ ruby        │ 3.1.4                      3.1.3 │                 │
│             │ 3.1.2                      3.1.1 │                 │
│             │ 3.1.0                      3.0.6 │                 │
│             │ 3.0.5                      3.0.4 │                 │
│             │ 3.0.3                            │                 │
│             │                                  │                 │
│             ├──────────────────────────────────┼─────────────────┤
│             │ 3.0.2                            │ aarch64-darwin  │
│             │                                  │ x86_64-darwin   │
│             │                                  │ x86_64-linux    │
│             ├──────────────────────────────────┼─────────────────┤
│             │ 3.0.1                            │ x86_64-darwin   │
│             │                                  │ x86_64-linux    │
│             ├──────────────────────────────────┼─────────────────┤
│             │ 3.0.0                            │ x86_64-linux    │
│             │                                  │                 │
│             ├──────────────────────────────────┼─────────────────┤
│             │ 2.7.8                      2.7.7 │ aarch64-darwin  │
│             │ 2.7.6                      2.7.5 │ aarch64-linux   │
│             │                                  │ x86_64-darwin   │
│             │                                  │ x86_64-linux    │
│             ├──────────────────────────────────┼─────────────────┤
│             │ 2.7.4                            │ aarch64-darwin  │
│             │                                  │ x86_64-darwin   │
│             │                                  │ x86_64-linux    │
│             ├──────────────────────────────────┼─────────────────┤
│             │ 2.7.3                            │ x86_64-darwin   │
│             │                                  │ x86_64-linux    │
│             ├──────────────────────────────────┼─────────────────┤
│             │ 2.7.2                            │ x86_64-linux    │
│             │ 2.7.1                            │                 │
│             │                                  │                 │
│             ├──────────────────────────────────┼─────────────────┤
│             │ 2.6.8                            │ aarch64-darwin  │
│             │                                  │ x86_64-darwin   │
│             │                                  │ x86_64-linux    │
│             ├──────────────────────────────────┼─────────────────┤
│             │ 2.6.7                            │ x86_64-darwin   │
│             │                                  │ x86_64-linux    │
│             ├──────────────────────────────────┼─────────────────┤
│             │ 2.6.6                            │ x86_64-linux    │
│             │ 2.5.8                            │                 │
│             │                                  │                 │
├─────────────┼──────────────────────────────────┼─────────────────┤
│             │ 0.10.0                           │ aarch64-darwin  │
│ rubyfmt     │                                  │ aarch64-linux   │
│             │                                  │ x86_64-linux    │
│             ├──────────────────────────────────┼─────────────────┤
│             │ 0.8.1                            │ aarch64-darwin  │
│             │                                  │ aarch64-linux   │
│             │                                  │ x86_64-darwin   │
│             │                                  │ x86_64-linux    │
├─────────────┼──────────────────────────────────┤                 │
│             │ 0.14.0                    0.13.4 │                 │
│             │ 0.13.2                    0.13.0 │                 │
│ ruby-lsp    │ 0.11.1                     0.9.4 │                 │
│             │ 0.8.0                      0.7.4 │                 │
│             │                                  │                 │
├─────────────┼──────────────────────────────────┤                 │
│             │ 5.3.0                            │                 │
│ ruby-zoom   │                                  │                 │
│             │                                  │                 │
│             │                                  │                 │
├─────────────┼──────────────────────────────────┼─────────────────┤
│             │ 0.8.0rc3                         │ aarch64-linux   │
│ rubyripper  │ 0.6.2                            │ x86_64-linux    │
│             │                                  │                 │
├─────────────┼──────────────────────────────────┼─────────────────┤
│ rubyMinimal │ 2.6.6                            │ x86_64-linux    │
│             │                                  │                 │
└─────────────┴──────────────────────────────────┴─────────────────┘
Info: For more information go to: https://www.nixhub.io/search?q=ruby
```

## How was it tested?

Ran search locally and looked at the output.