### PR TITLE
Fixes plugins overwriting files outside of .devbox

### DIFF
--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -222,7 +222,8 @@ func (m *Manager) shouldCreateFile(
 	}
 
 	// Hidden .devbox files are always replaceable, so ok to recreate
-	if strings.Contains(filePath, devboxHiddenDirName) {
+	devboxHiddenDir := filepath.FromSlash("/.devbox/")
+	if strings.Contains(filePath, devboxHiddenDir) {
 		return true
 	}
 	_, err := os.Stat(filePath)


### PR DESCRIPTION
## Summary

This PR is to address #1909 

The issue was that the check for files in the `.devbox/` directory was including files inside `devbox.d/jetpack-io.devbox-plugins.{PLUGIN}/`. This resulted in plugin configuration being overwritten where it shouldn't have been.

This solution is rudimentary, I just wanted to highlight what I think is the cause.

## How was it tested?

On my machine, I replicated the issue and ensured that.
- Files inside .devbox/ are still being overwritten as expected
- Files outside of .devbox/ are no longer being overwritten
- `devbox run test` passes locally for this devbox build