### PR TITLE
feat: Add recompute flag to shellenv command

### DIFF
--- a/internal/boxcli/global.go
+++ b/internal/boxcli/global.go
@@ -14,12 +14,7 @@ import (
 	"go.jetpack.io/devbox/internal/ux"
 )
 
-type globalShellEnvCmdFlags struct {
-	recompute bool
-}
-
 func globalCmd() *cobra.Command {
-	globalShellEnvCmdFlags := globalShellEnvCmdFlags{}
 	globalCmd := &cobra.Command{}
 	persistentPreRunE := setGlobalConfigForDelegatedCommands(globalCmd)
 	*globalCmd = cobra.Command{
@@ -33,12 +28,6 @@ func globalCmd() *cobra.Command {
 		PersistentPostRunE: ensureGlobalEnvEnabled,
 	}
 
-	shellEnv := shellEnvCmd(&globalShellEnvCmdFlags.recompute)
-	shellEnv.Flags().BoolVarP(
-		&globalShellEnvCmdFlags.recompute, "recompute", "r", false,
-		"Recompute environment if needed",
-	)
-
 	addCommandAndHideConfigFlag(globalCmd, addCmd())
 	addCommandAndHideConfigFlag(globalCmd, installCmd())
 	addCommandAndHideConfigFlag(globalCmd, pathCmd())
@@ -47,7 +36,7 @@ func globalCmd() *cobra.Command {
 	addCommandAndHideConfigFlag(globalCmd, removeCmd())
 	addCommandAndHideConfigFlag(globalCmd, runCmd())
 	addCommandAndHideConfigFlag(globalCmd, servicesCmd(persistentPreRunE))
-	addCommandAndHideConfigFlag(globalCmd, shellEnv)
+	addCommandAndHideConfigFlag(globalCmd, shellEnvCmd())
 	addCommandAndHideConfigFlag(globalCmd, updateCmd())
 
 	// Create list for non-global? Mike: I want it :)

--- a/internal/boxcli/root.go
+++ b/internal/boxcli/root.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/samber/lo"
 	"github.com/spf13/cobra"
 
 	"go.jetpack.io/devbox/internal/boxcli/featureflag"
@@ -76,8 +75,7 @@ func RootCmd() *cobra.Command {
 	command.AddCommand(servicesCmd())
 	command.AddCommand(setupCmd())
 	command.AddCommand(shellCmd())
-	// True to always recompute environment if needed.
-	command.AddCommand(shellEnvCmd(lo.ToPtr(true)))
+	command.AddCommand(shellEnvCmd())
 	command.AddCommand(updateCmd())
 	command.AddCommand(versionCmd())
 	// Preview commands


### PR DESCRIPTION
## Summary

(related [issue](https://github.com/jetpack-io/devbox/issues/1882))
When used with direnv and when regularly switching between branches, Devbox slows down the workflow because it tries to keep the packages in sync with the devbox.lock state with a Ensuring packages are installed.
This PR add the `--recompute` flag to the `shellenv` command that allow to set it to `--recompute=false` and then disable the automatic installation of package in case `devbox.json` is out of sync.

## How was it tested?

Setting the `.envrc` (ie. the direnv config file) as:
```
devbox shellenv --init-hook --no-refresh-alias --recompute=false
```

`--install` has been removed and `--recompute=false` compared with what `devbox generate direnv --print-envrc` generate by default.

Then updating `devbox.json` does not trigger package installation or removal but the context (ie. the env vars) are correctly updated.
