### PR TITLE
[offline] Allow devbox to work offline if DNS fails

### DIFF
--- a/internal/devbox/devbox.go
+++ b/internal/devbox/devbox.go
@@ -1008,11 +1008,19 @@ func (d *Devbox) ensureStateIsUpToDateAndComputeEnv(
 	// When ensureStateIsUpToDate is called with ensure=true, it always
 	// returns early if the lockfile is up to date. So we don't need to check here
 	if err := d.ensureStateIsUpToDate(ctx, ensure); isConnectionError(err) {
+		if !fileutil.Exists(d.nixPrintDevEnvCachePath()) {
+			ux.Ferror(
+				d.stderr,
+				"Error connecting to the internet and no cached environment found. Aborting.\n",
+			)
+			return nil, err
+		}
 		ux.Fwarning(
 			d.stderr,
 			"Error connecting to the internet. Will attempt to use cached environment.\n",
 		)
 	} else if err != nil {
+		// Some other non connection error, just return it.
 		return nil, err
 	}
 

--- a/internal/devbox/devbox.go
+++ b/internal/devbox/devbox.go
@@ -1007,10 +1007,13 @@ func (d *Devbox) ensureStateIsUpToDateAndComputeEnv(
 
 	// When ensureStateIsUpToDate is called with ensure=true, it always
 	// returns early if the lockfile is up to date. So we don't need to check here
-	if err := d.ensureStateIsUpToDate(ctx, ensure); err != nil && !strings.Contains(err.Error(), "no such host") {
-		return nil, err
+	if err := d.ensureStateIsUpToDate(ctx, ensure); isConnectionError(err) {
+		ux.Fwarning(
+			d.stderr,
+			"Error connecting to the internet. Will attempt to use cached environment.\n",
+		)
 	} else if err != nil {
-		ux.Fwarning(d.stderr, "Error connecting to the internet. Will attempt to use cached environment.\n")
+		return nil, err
 	}
 
 	// Since ensureStateIsUpToDate calls computeEnv when not up do date,

--- a/internal/devbox/errors.go
+++ b/internal/devbox/errors.go
@@ -1,0 +1,12 @@
+package devbox
+
+import "strings"
+
+func isConnectionError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	return strings.Contains(err.Error(), "no such host") ||
+		strings.Contains(err.Error(), "connection refused")
+}


### PR DESCRIPTION
## Summary

Fixes https://github.com/jetify-com/devbox/issues/1977

(with another hack).

Unfortunately the way we structure our flake makes it really difficult to remove our network requests (when state is stale). Ideally, the flake can be built off of local only nix store references, but that's a much bigger project.

In the meantime, this is a quick hack that fixes issue above.

## How was it tested?

Added synthetic error that returns `connection refused` in the message. Ensures I was still able to run/shell with a stale state.
