### PR TITLE
[vscode-extension] Rebranding changes for extension

### DIFF
--- a/vscode-extension/CHANGELOG.md
+++ b/vscode-extension/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the "devbox" extension will be documented in this file.
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+## [0.1.5]
+
+- Rebranding changes from jetpack.io to jetify.com.
+
 ## [0.1.4]
 
 - Added debug mode in extension settings (only supports logs for "Reopen in Devbox Shell environment" feature).

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -1,15 +1,15 @@
 {
   "name": "devbox",
-  "displayName": "devbox by jetpack.io",
+  "displayName": "devbox by Jetify",
   "description": "devbox integration for VSCode",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "icon": "assets/icon.png",
   "repository": {
     "type": "git",
     "url": "https://github.com/jetify-com/devbox.git",
     "directory": "vscode-extension"
   },
-  "author": "jetpack-io",
+  "author": "Jetify",
   "publisher": "jetpack-io",
   "engines": {
     "vscode": "^1.72.0"

--- a/vscode-extension/src/devbox.ts
+++ b/vscode-extension/src/devbox.ts
@@ -15,7 +15,7 @@ export async function devboxReopen() {
       Please open VSCode from inside devbox shell in WSL using the CLI.', seeDocs
     );
     if (result === seeDocs) {
-      env.openExternal(Uri.parse('https://www.jetpack.io/devbox/docs/ide_configuration/vscode/#windows-setup'));
+      env.openExternal(Uri.parse('https://www.jetify.com/devbox/docs/ide_configuration/vscode/#windows-setup'));
       return;
     }
   }

--- a/vscode-extension/src/openinvscode.ts
+++ b/vscode-extension/src/openinvscode.ts
@@ -67,7 +67,7 @@ async function getVMInfo(token: string | null, vmId: string | null): Promise<any
 
 async function setupDevboxLauncher(): Promise<any> {
   // download devbox launcher script
-  const gatewayHost = 'https://releases.jetpack.io/devbox';
+  const gatewayHost = 'https://releases.jetify.com/devbox';
   const response = await fetch(gatewayHost, {
     method: 'get',
   });


### PR DESCRIPTION
## Summary
changes all mentions and links of jetpack to jetify.
Publisher field in package.json is not changed since we decided to keep the publisher Id.

## How was it tested?
N/A