### PR TITLE
[vscode extension] updated discord link and github action for publishing the extension

### DIFF
--- a/.github/workflows/vscode-ext-release.yaml
+++ b/.github/workflows/vscode-ext-release.yaml
@@ -12,10 +12,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Setup NodeJS 16
-        uses: actions/setup-node@v3
+      - name: Setup NodeJS 18
+        uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 18
       - name: Install dependencies
         run: |
           npm install -g yarn

--- a/docs/app/docs/ide_configuration/vscode.md
+++ b/docs/app/docs/ide_configuration/vscode.md
@@ -18,7 +18,7 @@ Follow the steps below to have VSCode's environment be in sync with Devbox shell
 
 Keep in mind that if you make changes to your devbox.json, you need to re-run Step 3 to make VSCode pick up the new changes.
 
-**NOTE:** This integration feature requires Devbox CLI v0.5.5 and above installed and in PATH. This feature is in beta. Please report any bugs/issues in [Github](https://github.com/jetify-com/devbox) or our [Discord](https://discord.gg/Rr5KPJq7).
+**NOTE:** This integration feature requires Devbox CLI v0.5.5 and above installed and in PATH. This feature is in beta. Please report any bugs/issues in [Github](https://github.com/jetify-com/devbox) or our [Discord](https://discord.gg/jetify).
 
 **NOTE2:** This feature is not yet available for Windows and WSL.
 

--- a/vscode-extension/CHANGELOG.md
+++ b/vscode-extension/CHANGELOG.md
@@ -31,7 +31,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 - Added reopen in devbox shell environment feature that allows projects with devbox.json
   reopen vscode in devbox environment. Note: It requires devbox CLI v0.5.5 and above
-  installed and in PATH. This feature is in beta. Please report any bugs/issues in [Github](https://github.com/jetify-com/devbox) or our [Discord](https://discord.gg/Rr5KPJq7).
+  installed and in PATH. This feature is in beta. Please report any bugs/issues in [Github](https://github.com/jetify-com/devbox) or our [Discord](https://discord.gg/jetify).
 
 ## [0.0.7]
 

--- a/vscode-extension/README.md
+++ b/vscode-extension/README.md
@@ -22,7 +22,7 @@ If the opened workspace in VSCode has a devbox.json file, from command palette, 
 4. Close current VSCode window and reopen it in a devbox shell environment as if VSCode was opened from a devbox shell terminal.
 
 NOTE: Requires devbox CLI v0.5.5 and above
-  installed and in PATH. This feature is in beta. Please report any bugs/issues in [Github](https://github.com/jetify-com/devbox) or our [Discord](https://discord.gg/Rr5KPJq7).
+  installed and in PATH. This feature is in beta. Please report any bugs/issues in [Github](https://github.com/jetify-com/devbox) or our [Discord](https://discord.gg/jetify).
 
 ### Run devbox commands from command palette
 


### PR DESCRIPTION
## Summary
github action node version 16 makes publishing the extension to ovsx fail. Discord link is also broken
## How was it tested?
