### PR TITLE
[docs] update the quickstart guide

### DIFF
--- a/docs/app/docs/quickstart.mdx
+++ b/docs/app/docs/quickstart.mdx
@@ -16,7 +16,7 @@ This Quickstart shows you how to install Devbox and use it to create a new Devel
 
 ## Install Devbox
 
-Follow the instruction from [the previous page](./installing_devbox.mdx).
+Follow the instruction from [the installation guide](./installing_devbox.mdx).
 
 :::note
 If you want to try Devbox before installing it, you can open a cloud shell on your browser using the link below

--- a/docs/app/docs/quickstart.mdx
+++ b/docs/app/docs/quickstart.mdx
@@ -16,12 +16,7 @@ This Quickstart shows you how to install Devbox and use it to create a new Devel
 
 ## Install Devbox
 
-Use the following install script to get the latest version of Devbox:
-
-```bash
-curl -fsSL https://get.jetify.com/devbox | bash
-```
-Devbox requires the [Nix Package Manager](https://nixos.org/download/). If Nix is not detected on your machine when running a command, Devbox will automatically install it for you with the default settings for your OS. Don't worry: You can use Devbox without needing to learn the Nix Language.
+Follow the instruction from [the previous page](./installing_devbox.mdx).
 
 :::note
 If you want to try Devbox before installing it, you can open a cloud shell on your browser using the link below


### PR DESCRIPTION
## Summary

Make sure that we do not duplicate the installation guide, because:
1) It's redundant; and
2) `curl -fsSL https://get.jetify.com/devbox | bash` does not work for [NixOS-WSL](https://github.com/nix-community/NixOS-WSL), but using NixOS guide is fine. If other NixOS users come across this page directly and directly install using the installation script, then I'm afraid they cannot install `devbox` as well.

## How was it tested?
N/A