### PR TITLE
[gen] Add gen alias command

### DIFF
--- a/internal/boxcli/generate.go
+++ b/internal/boxcli/generate.go
@@ -219,7 +219,7 @@ func genAliasCmd() *cobra.Command {
 			for _, script := range box.ListScripts() {
 				fmt.Fprintf(
 					cmd.OutOrStdout(),
-					"alias %s-%s='devbox -c %s run %s'\n",
+					"alias %s-%s='devbox -c \"%s\" run %s'\n",
 					prefix,
 					script,
 					box.ProjectDir(),

--- a/internal/boxcli/generate.go
+++ b/internal/boxcli/generate.go
@@ -11,6 +11,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
+	"go.jetpack.io/devbox/internal/boxcli/usererr"
 	"go.jetpack.io/devbox/internal/cloud"
 	"go.jetpack.io/devbox/internal/devbox"
 	"go.jetpack.io/devbox/internal/devbox/devopt"
@@ -210,7 +211,9 @@ func genAliasCmd() *cobra.Command {
 			re := regexp.MustCompile("[^a-zA-Z0-9_-]+")
 			prefix := cmp.Or(flags.prefix, box.Config().Root.Name)
 			if prefix == "" {
-				return errors.New("project name not set in devbox.json")
+				return usererr.New(
+					"To generate aliases, you must specify a prefix or set a name " +
+						"in devbox.json")
 			}
 			prefix = re.ReplaceAllString(prefix, "-")
 			for _, script := range box.ListScripts() {


### PR DESCRIPTION
## Summary

Add a command that allows creating aliases to devbox scripts. This lets users source aliases from any project they want. It's opt-in, works in POSIX and fish. Aliases make it easy to call the scripts for other projects or directories.

How it works:

```bash
eval "$(devbox gen alias)"
devbox-build
```

It builds the alias name using the project name in devbox.json.

Alternatively the user can specify a prefix

```bash
eval "$(devbox gen alias --prefix dx)"
dx-build
```

## How was it tested?

```bash
eval "$(devbox gen alias --prefix dx)"
dx-build
cd $HOME && dx-build
```
