### PR TITLE
[docker] Updated devbox install links for docker images

### DIFF
--- a/internal/devbox/generate/tmpl/DevboxImageDockerfile
+++ b/internal/devbox/generate/tmpl/DevboxImageDockerfile
@@ -18,7 +18,7 @@ RUN . ~/.nix-profile/etc/profile.d/nix.sh
 ENV PATH="/home/${DEVBOX_USER}/.nix-profile/bin:$PATH"
 
 # Step 3: Installing devbox
-RUN wget --quiet --output-document=/dev/stdout https://get.jetpack.io/devbox   | bash -s -- -f
+RUN wget --quiet --output-document=/dev/stdout https://get.jetify.com/devbox   | bash -s -- -f
 RUN chown -R "${DEVBOX_USER}:${DEVBOX_USER}" /usr/local/bin/devbox
 
 CMD ["devbox", "version"]

--- a/internal/devbox/generate/tmpl/DevboxImageDockerfileRootUser
+++ b/internal/devbox/generate/tmpl/DevboxImageDockerfileRootUser
@@ -12,6 +12,6 @@ RUN . ~/.nix-profile/etc/profile.d/nix.sh
 ENV PATH="/root/.nix-profile/bin:$PATH"
 
 # Step 3: Installing devbox
-RUN wget --quiet --output-document=/dev/stdout https://get.jetpack.io/devbox   | bash -s -- -f
+RUN wget --quiet --output-document=/dev/stdout https://get.jetify.com/devbox   | bash -s -- -f
 
 CMD ["devbox", "version"]


### PR DESCRIPTION
## Summary
Updated devbox install link for docker image.
After merging this we will release a new docker image, and that should upgrade the launcher version to 0.2.2. Currently, docker images have 0.2.1 or 0.2.0 for launchers due to devbox image being built and pushed to dockerhub before launcher changes.

## How was it tested?
N/A