### PR TITLE
[shellenv] add --recompute flag with default=true, while keep global shellenv's recompute flag with default=false

### DIFF
--- a/internal/boxcli/global.go
+++ b/internal/boxcli/global.go
@@ -31,8 +31,12 @@ func globalCmd() *cobra.Command {
 	shellEnv := shellEnvCmd()
 	// For `devbox shellenv` the default value of recompute is true.
 	// Change the default value to false for `devbox global shellenv` only.
-	shellEnv.Flag("recompute").DefValue = "false"
+	shellEnv.Flag("recompute").DefValue = "false" // Needed for help text
 	if err := shellEnv.Flag("recompute").Value.Set("false"); err != nil {
+		// This will never panic because internally it just does
+		// `strconv.ParseBool("false")` which is always valid.
+		// If this were to change, we'll immediately detect this during development
+		// since this code always runs on any devbox command (and will fix it).
 		panic(errors.WithStack(err))
 	}
 

--- a/internal/boxcli/global.go
+++ b/internal/boxcli/global.go
@@ -14,12 +14,7 @@ import (
 	"go.jetpack.io/devbox/internal/ux"
 )
 
-type globalShellEnvCmdFlags struct {
-	recompute bool
-}
-
 func globalCmd() *cobra.Command {
-	globalShellEnvCmdFlags := globalShellEnvCmdFlags{}
 	globalCmd := &cobra.Command{}
 	persistentPreRunE := setGlobalConfigForDelegatedCommands(globalCmd)
 	*globalCmd = cobra.Command{
@@ -33,11 +28,13 @@ func globalCmd() *cobra.Command {
 		PersistentPostRunE: ensureGlobalEnvEnabled,
 	}
 
-	shellEnv := shellEnvCmd(&globalShellEnvCmdFlags.recompute)
-	shellEnv.Flags().BoolVarP(
-		&globalShellEnvCmdFlags.recompute, "recompute", "r", false,
-		"Recompute environment if needed",
-	)
+	shellEnv := shellEnvCmd()
+	// For `devbox shellenv` the default value of recompute is true.
+	// Change the default value to false for `devbox global shellenv` only.
+	shellEnv.Flag("recompute").DefValue = "false"
+	if err := shellEnv.Flag("recompute").Value.Set("false"); err != nil {
+		panic(errors.WithStack(err))
+	}
 
 	addCommandAndHideConfigFlag(globalCmd, addCmd())
 	addCommandAndHideConfigFlag(globalCmd, installCmd())

--- a/internal/boxcli/root.go
+++ b/internal/boxcli/root.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/samber/lo"
 	"github.com/spf13/cobra"
 
 	"go.jetpack.io/devbox/internal/boxcli/featureflag"
@@ -77,8 +76,7 @@ func RootCmd() *cobra.Command {
 	command.AddCommand(servicesCmd())
 	command.AddCommand(setupCmd())
 	command.AddCommand(shellCmd())
-	// True to always recompute environment if needed.
-	command.AddCommand(shellEnvCmd(lo.ToPtr(true)))
+	command.AddCommand(shellEnvCmd())
 	command.AddCommand(updateCmd())
 	command.AddCommand(versionCmd())
 	// Preview commands

--- a/internal/boxcli/shellenv.go
+++ b/internal/boxcli/shellenv.go
@@ -20,10 +20,11 @@ type shellEnvCmdFlags struct {
 	noRefreshAlias    bool
 	preservePathStack bool
 	pure              bool
+	recomputeEnv      bool
 	runInitHook       bool
 }
 
-func shellEnvCmd(recomputeEnvIfNeeded *bool) *cobra.Command {
+func shellEnvCmd() *cobra.Command {
 	flags := shellEnvCmdFlags{}
 	command := &cobra.Command{
 		Use:     "shellenv",
@@ -31,7 +32,7 @@ func shellEnvCmd(recomputeEnvIfNeeded *bool) *cobra.Command {
 		Args:    cobra.ExactArgs(0),
 		PreRunE: ensureNixInstalled,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			s, err := shellEnvFunc(cmd, flags, *recomputeEnvIfNeeded)
+			s, err := shellEnvFunc(cmd, flags)
 			if err != nil {
 				return err
 			}
@@ -61,6 +62,12 @@ func shellEnvCmd(recomputeEnvIfNeeded *bool) *cobra.Command {
 			"Use this flag to disable this behavior.")
 	_ = command.Flags().MarkHidden("no-refresh-alias")
 
+	// Note, `devbox global shellenv` will override the default value to be false
+	command.Flags().BoolVarP(
+		&flags.recomputeEnv, "recompute", "r", true,
+		"Recompute environment if needed",
+	)
+
 	flags.config.register(command)
 	flags.envFlag.register(command)
 
@@ -70,7 +77,6 @@ func shellEnvCmd(recomputeEnvIfNeeded *bool) *cobra.Command {
 func shellEnvFunc(
 	cmd *cobra.Command,
 	flags shellEnvCmdFlags,
-	recomputeEnvIfNeeded bool,
 ) (string, error) {
 	env, err := flags.Env(flags.config.path)
 	if err != nil {
@@ -95,7 +101,7 @@ func shellEnvFunc(
 	}
 
 	envStr, err := box.EnvExports(cmd.Context(), devopt.EnvExportsOpts{
-		DontRecomputeEnvironment: !recomputeEnvIfNeeded,
+		DontRecomputeEnvironment: !flags.recomputeEnv,
 		NoRefreshAlias:           flags.noRefreshAlias,
 		RunHooks:                 flags.runInitHook,
 	})


### PR DESCRIPTION
## Summary

Credit to @dax and #1963 for pointing out the need for this, and pioneering this solution.
This PR merely nudges the code to be a bit neater.

## How was it tested?

```
% git diff
diff --git a/internal/boxcli/shellenv.go b/internal/boxcli/shellenv.go
index 991c2bec..8076e125 100644
--- a/internal/boxcli/shellenv.go
+++ b/internal/boxcli/shellenv.go
@@ -78,6 +78,9 @@ func shellEnvFunc(
        cmd *cobra.Command,
        flags shellEnvCmdFlags,
 ) (string, error) {
+       fmt.Printf("shellenv --recompute flag is %v\n", flags.recompute)
+       return "", nil
+
        env, err := flags.Env(flags.config.path)
        if err != nil {
                return "", err
```

compiled via `devbox run build`, and then:

```
 % devbox shellenv
shellenv --recompute flag is true

hash -r
 % devbox global shellenv
shellenv --recompute flag is false

hash -r
```