### PR TITLE
[easy] added env variable to distinguish pure shell

### DIFF
--- a/internal/devbox/devbox.go
+++ b/internal/devbox/devbox.go
@@ -1275,6 +1275,8 @@ func (d *Devbox) parseEnvAndExcludeSpecialCases(currentEnv []string) (map[string
 
 	// handling special case for PATH
 	if d.pure {
+		// Setting a custom env variable to differentiate pure and regular shell
+		env["DEVBOX_PURE_SHELL"] = "1"
 		// Finding nix executables in path and passing it through
 		// As well as adding devbox itself to PATH
 		// Both are needed for devbox commands inside pure shell to work


### PR DESCRIPTION
## Summary
`devbox shell` and `devbox shell --pure` have differences in inheriting the host shell's env variables. But there is no devbox-defined env variable for users and devbox itself to know if it is in a pure shell or regular shell. 
This PR sets a `DEVBOX_PURE_SHELL=1` env variable to help fix that issue. 

This will allow users to differentiate and customize their setup based on if they're in a pure shell or not. For example, not sourcing `.bashrc` if in a pure shell.

## How was it tested?
- `devbox run build`
- `devbox shell` then `env | grep "DEVBOX_PURE_SHELL"`
- exit
- `devbox shell --pure` then `env | grep "DEVBOX_PURE_SHELL"`
- confirm the env variable is set for pure shell and not for regular shell.