### PR TITLE
internal/nix: support older nix versions in DaemonVersion

### DIFF
--- a/internal/devbox/providers/nixcache/setup.go
+++ b/internal/devbox/providers/nixcache/setup.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"time"
 
+	"go.jetpack.io/devbox/internal/debug"
 	"go.jetpack.io/devbox/internal/envir"
 	"go.jetpack.io/devbox/internal/nix"
 	"go.jetpack.io/devbox/internal/redact"
@@ -32,12 +33,14 @@ func (n *nixSetupTask) NeedsRun(ctx context.Context, lastRun setup.RunInfo) bool
 	}
 	trusted, _ := cfg.IsUserTrusted(ctx, n.username)
 	if trusted {
+		debug.Log("nixcache: skipping setup task nixcache-setup-nix: user %s is already trusted", n.username)
 		return false
 	}
 
 	if _, err := nix.DaemonVersion(ctx); err != nil {
 		// This looks like a single-user install, so no need to
 		// configure the daemon.
+		debug.Log("nixcache: skipping setup task nixcache-setup-nix: error connecting to nix daemon, assuming single-user install: %v", err)
 		return false
 	}
 	return true
@@ -65,12 +68,14 @@ type awsSetupTask struct {
 func (a *awsSetupTask) NeedsRun(ctx context.Context, lastRun setup.RunInfo) bool {
 	// This task only needs to run once.
 	if !lastRun.Time.IsZero() {
+		debug.Log("nixcache: skipping setup task nixcache-setup-aws: setup was already run at %s", lastRun.Time)
 		return false
 	}
 
 	// No need to configure the daemon if this looks like a single-user
 	// install.
 	if _, err := nix.DaemonVersion(ctx); err != nil {
+		debug.Log("nixcache: skipping setup task nixcache-setup-aws: error connecting to nix daemon, assuming single-user install: %v", err)
 		return false
 	}
 	return true

--- a/internal/devpkg/narinfo_cache.go
+++ b/internal/devpkg/narinfo_cache.go
@@ -12,7 +12,6 @@ import (
 	"go.jetpack.io/devbox/internal/boxcli/featureflag"
 	"go.jetpack.io/devbox/internal/lock"
 	"go.jetpack.io/devbox/internal/nix"
-	"go.jetpack.io/devbox/internal/vercheck"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -206,8 +205,8 @@ func (p *Package) sysInfoIfExists() (*lock.SystemInfo, error) {
 		return nil, err
 	}
 
-	// enable for nix >= 2.17
-	if vercheck.SemverCompare(version, "2.17.0") < 0 {
+	// disable for nix < 2.17
+	if !version.AtLeast(nix.Version2_17) {
 		return nil, err
 	}
 

--- a/internal/nix/upgrade.go
+++ b/internal/nix/upgrade.go
@@ -9,7 +9,6 @@ import (
 
 	"go.jetpack.io/devbox/internal/redact"
 	"go.jetpack.io/devbox/internal/ux"
-	"go.jetpack.io/devbox/internal/vercheck"
 )
 
 func ProfileUpgrade(ProfileDir, indexOrName string) error {
@@ -34,7 +33,7 @@ func FlakeUpdate(ProfileDir string) error {
 	}
 	ux.Finfo(os.Stderr, "Running \"nix flake update\"\n")
 	cmd := exec.Command("nix", "flake", "update")
-	if vercheck.SemverCompare(version, "2.19.0") >= 0 {
+	if version.AtLeast(Version2_19) {
 		cmd.Args = append(cmd.Args, "--flake")
 	}
 	cmd.Args = append(cmd.Args, ProfileDir)

--- a/internal/telemetry/segment.go
+++ b/internal/telemetry/segment.go
@@ -34,9 +34,9 @@ func initSegmentClient() bool {
 }
 
 func newTrackMessage(name string, meta Metadata) *segment.Track {
-	nixVersion, err := nix.Version()
-	if err != nil {
-		nixVersion = "unknown"
+	nixVersion := "unknown"
+	if v, err := nix.Version(); err == nil {
+		nixVersion = v.Version
 	}
 
 	dur := time.Since(procStartTime)

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -141,9 +141,9 @@ func Error(err error, meta Metadata) {
 		return
 	}
 
-	nixVersion, err := nix.Version()
-	if err != nil {
-		nixVersion = "unknown"
+	nixVersion := "unknown"
+	if v, err := nix.Version(); err == nil {
+		nixVersion = v.Version
 	}
 
 	event := &sentry.Event{


### PR DESCRIPTION
To check if nix daemon is running, Devbox runs:

	nix store info --json --store daemon

This fails on older versions of Nix for a couple reasons:

- Before Nix 2.19.0, `nix store info` was `nix store ping`.
- Before Nix 2.14.0, the `--json` flag wasn't supported.

Check for both of these versions when constructing the `nix store` command so it works for Nix versions 2.12 - 2.21+.

Also add a `nix.VersionInfo.AtLeast` method and constants to make checking for supported major Nix versions easier.

Tested by running the `nix store` commands on all supported Nix versions.