### PR TITLE
[nix] Build all packages in same nix command

### DIFF
--- a/internal/devbox/packages.go
+++ b/internal/devbox/packages.go
@@ -430,79 +430,88 @@ func (d *Devbox) InstallRunXPackages(ctx context.Context) error {
 // and installing in the nix profile (even if offline).
 func (d *Devbox) installNixPackagesToStore(ctx context.Context, mode installMode) error {
 	packages, err := d.packagesToInstallInStore(ctx, mode)
-	if err != nil {
+	if err != nil || len(packages) == 0 {
 		return err
 	}
 
-	stepNum := 0
-	total := len(packages)
+	// --no-link to avoid generating the result objects
+	flags := []string{"--no-link"}
+	if mode == update {
+		flags = append(flags, "--refresh")
+	}
+
+	args := &nix.BuildArgs{
+		Flags:  flags,
+		Writer: d.stderr,
+	}
+	args.ExtraSubstituter, _ = d.providers.NixCache.URI(ctx)
+	// TODO (Landau): handle errors that are not auth.ErrNotLoggedIn
+	// Only lookup credentials if we have a cache to use
+	if args.ExtraSubstituter != "" {
+		creds, err := d.providers.NixCache.Credentials(ctx)
+		if err == nil {
+			args.Env = creds.Env()
+		}
+
+		u, err := user.Current()
+		if err != nil {
+			err = redact.Errorf("lookup current user: %v", err)
+			debug.Log("error configuring cache: %v", err)
+		}
+		err = d.providers.NixCache.Configure(ctx, u.Username)
+		if err != nil {
+			debug.Log("error configuring cache: %v", err)
+
+			var daemonErr *nix.DaemonError
+			if errors.As(err, &daemonErr) {
+				// Error here to give the user a chance to restart the daemon.
+				return usererr.New("Devbox configured Nix to use %q as a cache. Please restart the Nix daemon and re-run Devbox.", args.ExtraSubstituter)
+			}
+			// Other errors indicate we couldn't update nix.conf, so just warn and continue
+			// by building from source if necessary.
+			ux.Fwarning(d.stderr, "Devbox was unable to configure Nix to use your organization's private cache. Some packages might be built from source.")
+		}
+	}
+
+	packageNames := lo.Map(
+		packages,
+		func(p *devpkg.Package, _ int) string { return p.Raw },
+	)
+	ux.Finfo(
+		d.stderr,
+		"Installing the following packages to the nix store: %s\n",
+		strings.Join(packageNames, ", "),
+	)
+
+	installables := map[bool][]string{false: {}, true: {}}
 	for _, pkg := range packages {
-		stepNum += 1
-
-		stepMsg := fmt.Sprintf("[%d/%d] %s", stepNum, total, pkg)
-		fmt.Fprintf(d.stderr, stepMsg+"\n")
-
-		installables, err := pkg.Installables()
+		pkgInstallables, err := pkg.Installables()
 		if err != nil {
 			return err
 		}
-
-		// --no-link to avoid generating the result objects
-		flags := []string{"--no-link"}
-		if mode == update {
-			flags = append(flags, "--refresh")
-		}
-
-		args := &nix.BuildArgs{
-			AllowInsecure: pkg.HasAllowInsecure(),
-			Flags:         flags,
-			Writer:        d.stderr,
-		}
-		args.ExtraSubstituter, _ = d.providers.NixCache.URI(ctx)
-		// TODO (Landau): handle errors that are not auth.ErrNotLoggedIn
-		// Only lookup credentials if we have a cache to use
-		if args.ExtraSubstituter != "" {
-			creds, err := d.providers.NixCache.Credentials(ctx)
-			if err == nil {
-				args.Env = creds.Env()
-			}
-
-			u, err := user.Current()
-			if err != nil {
-				err = redact.Errorf("lookup current user: %v", err)
-				debug.Log("error configuring cache: %v", err)
-			}
-			err = d.providers.NixCache.Configure(ctx, u.Username)
-			if err != nil {
-				debug.Log("error configuring cache: %v", err)
-
-				var daemonErr *nix.DaemonError
-				if errors.As(err, &daemonErr) {
-					// Error here to give the user a chance to restart the daemon.
-					return usererr.New("Devbox configured Nix to use %q as a cache. Please restart the Nix daemon and re-run Devbox.", args.ExtraSubstituter)
-				}
-				// Other errors indicate we couldn't update nix.conf, so just warn and continue
-				// by building from source if necessary.
-				ux.Fwarning(d.stderr, "Devbox was unable to configure Nix to use your organization's private cache. Some packages might be built from source.")
-			}
-		}
-		for _, installable := range installables {
-			eventStart := time.Now()
-			err = nix.Build(ctx, args, installable)
-			if err != nil {
-				fmt.Fprintf(d.stderr, "%s: ", stepMsg)
-				color.New(color.FgRed).Fprintf(d.stderr, "Fail\n")
-				return packageInstallErrorHandler(err, pkg, installable)
-			}
-			telemetry.Event(telemetry.EventNixBuildSuccess, telemetry.Metadata{
-				EventStart: eventStart,
-				Packages:   []string{pkg.Raw},
-			})
-		}
-
-		fmt.Fprintf(d.stderr, "%s: ", stepMsg)
-		color.New(color.FgGreen).Fprintf(d.stderr, "Success\n")
+		installables[pkg.HasAllowInsecure()] = append(
+			installables[pkg.HasAllowInsecure()],
+			pkgInstallables...,
+		)
 	}
+
+	for allowInsecure, installables := range installables {
+		if len(installables) == 0 {
+			continue
+		}
+		eventStart := time.Now()
+		args.AllowInsecure = allowInsecure
+		err = nix.Build(ctx, args, installables...)
+		if err != nil {
+			color.New(color.FgRed).Fprintf(d.stderr, "Fail\n")
+			return err
+		}
+		telemetry.Event(telemetry.EventNixBuildSuccess, telemetry.Metadata{
+			EventStart: eventStart,
+			Packages:   packageNames,
+		})
+	}
+
 	return err
 }
 
@@ -540,7 +549,7 @@ func (d *Devbox) packagesToInstallInStore(ctx context.Context, mode installMode)
 		}
 	}
 
-	return packagesToInstall, nil
+	return lo.Uniq(packagesToInstall), nil
 }
 
 // packageInstallErrorHandler checks for two kinds of errors to print custom messages for so that Devbox users

--- a/internal/devbox/packages.go
+++ b/internal/devbox/packages.go
@@ -512,7 +512,7 @@ func (d *Devbox) installNixPackagesToStore(ctx context.Context, mode installMode
 		})
 	}
 
-	return err
+	return nil
 }
 
 func (d *Devbox) packagesToInstallInStore(ctx context.Context, mode installMode) ([]*devpkg.Package, error) {


### PR DESCRIPTION
## Summary

This changes how `installNixPackagesToStore` calls `nix.Build` so that it installs all installables in same nix command.

It does this by grouping all installables into two groups, one for allow-insecure and other for default and runs `build` on both groups (if not empty)

I was able to remove `packageInstallErrorHandler`  because it is already called in `packagesToInstallInStore` so we will never actually try to build something that can't build on the system, or if it requires `--allow-insecure` we will notice it then.

This does change our segment logging to group packages together for install times, so we will need to do some more work on the metrics side to determine slow packages. 

## How was it tested?

* Installed multiple packages not present in my nix store at once, including a combination of secure and insecure ones.
* Tried to install something that doesn't build on my system, saw correct error message

## Perf test

Anecdotal test:

Using the following
<img width="257" alt="image" src="https://github.com/jetify-com/devbox/assets/544948/8b1ab39c-7a1b-40d3-ab5a-516cde3b1525">


Before 
<img width="261" alt="image" src="https://github.com/jetify-com/devbox/assets/544948/ce397f59-1eaf-41dc-8256-6306f36e596b">

After 
<img width="293" alt="image" src="https://github.com/jetify-com/devbox/assets/544948/55ed3214-ff1d-4115-b767-7ad5d29dedd3">

