### PR TITLE
[process-compose] Bump version

### DIFF
--- a/internal/devbox/devbox.go
+++ b/internal/devbox/devbox.go
@@ -55,7 +55,7 @@ const (
 
 	// shellHistoryFile keeps the history of commands invoked inside devbox shell
 	shellHistoryFile            = ".devbox/shell_history"
-	processComposeTargetVersion = "v0.85.0"
+	processComposeTargetVersion = "v1.5.0"
 	arbitraryCmdFilename        = ".cmd"
 )
 


### PR DESCRIPTION
## Summary

Bumps to v1.5.0

Note: Because process-compose flake is not in any cache installing a new version can be pretty slow (it has to build which means it has to download dependencies in order to build). A few solutions:

* We could use nixpkgs (which lags the repo version by a few versions)
* We could use runx to install it (not nix, but it gets the latest version)
* We could store in our own cache.

## How was it tested?

Tested running services on a few examples.
