### PR TITLE
internal/setup: move sudo into SudoDevbox function + fix macOS CI

### DIFF
--- a/internal/devbox/packages.go
+++ b/internal/devbox/packages.go
@@ -469,7 +469,7 @@ func (d *Devbox) installNixPackagesToStore(ctx context.Context, mode installMode
 			}
 			// Other errors indicate we couldn't update nix.conf, so just warn and continue
 			// by building from source if necessary.
-			ux.Fwarning(d.stderr, "Devbox was unable to configure Nix to use your organization's private cache. Some packages might be built from source.")
+			ux.Fwarning(d.stderr, "Devbox was unable to configure Nix to use your organization's private cache. Some packages might be built from source.\n")
 		}
 	}
 


### PR DESCRIPTION
Move the code that calls `sudo devbox` into the `setup` package and clean it up a bit. Fix some issues that were preventing the cache from being configured in non-interactive environments (such as CI).

- Don't re-prompt the user for confirmation in the sudo process.
- Don't call NeedsRun a second time in the sudo process.
- Don't prompt the user when stdin isn't a tty. This fixes cache configuration on macOS in CI.
- Preserve Devbox environment variables such as DEVBOX_DEBUG, DEVBOX_API_TOKEN, DEVBOX_PROD, and DEVBOX_USE_VERSION. This addresses cases where the sudo devbox process would use the wrong auth or API endpoint.
- Combine the nixcache aws and nix setup tasks into one task. There was a lot of overlap and this simplifies the setup code.

Reran the `cache-upload` workflow against this branch and it looks like the macOS runner is able to use the cache now - https://github.com/jetify-com/devbox/actions/runs/9022662173/job/24792707507#step:5:828