### PR TITLE
Indicate of a package version list in `devbox search` is truncated

### DIFF
--- a/internal/boxcli/search.go
+++ b/internal/boxcli/search.go
@@ -9,12 +9,15 @@ import (
 	"math"
 	"strings"
 
+	"github.com/samber/lo"
 	"github.com/spf13/cobra"
 
 	"go.jetpack.io/devbox/internal/boxcli/usererr"
 	"go.jetpack.io/devbox/internal/searcher"
 	"go.jetpack.io/devbox/internal/ux"
 )
+
+const trimmedVersionsLength = 10
 
 type searchCmdFlags struct {
 	showAll bool
@@ -81,7 +84,7 @@ func printSearchResults(
 
 	resultsAreTrimmed := false
 	pkgs := results.Packages
-	if !showAll && len(pkgs) > 10 {
+	if !showAll && len(pkgs) > trimmedVersionsLength {
 		resultsAreTrimmed = true
 		pkgs = results.Packages[:int(math.Min(10, float64(len(results.Packages))))]
 	}
@@ -89,7 +92,7 @@ func printSearchResults(
 	for _, pkg := range pkgs {
 		nonEmptyVersions := []string{}
 		for i, v := range pkg.Versions {
-			if !showAll && i >= 10 {
+			if !showAll && i >= trimmedVersionsLength {
 				resultsAreTrimmed = true
 				break
 			}
@@ -100,7 +103,8 @@ func printSearchResults(
 
 		versionString := ""
 		if len(nonEmptyVersions) > 0 {
-			versionString = fmt.Sprintf(" (%s)", strings.Join(nonEmptyVersions, ", "))
+			ellipses := lo.Ternary(resultsAreTrimmed && pkg.NumVersions > trimmedVersionsLength, " ...", "")
+			versionString = fmt.Sprintf(" (%s%s)", strings.Join(nonEmptyVersions, ", "), ellipses)
 		}
 		fmt.Fprintf(w, "* %s %s\n", pkg.Name, versionString)
 	}


### PR DESCRIPTION
## Summary

Current `devbox search` UI only shows the 10 newest versions for a package, unless the developer runs the command with `--show-all`. With the current presentation, this may confuse developers by making it seem like only 10 versions are available at all.

This pr Adds a `...` at the end to indicate that more versions are available. For example: 

```
Found 8+ results for "python":

* python  (3.13.0a6, 3.13.0a5, 3.13.0a3, 3.13.0a2, 3.13.0a1, 3.12.3, 3.12.2, 3.12.1, 3.12.0, 3.12.0rc3 ...)
* python-cosmopolitan  (3.6.14)
* python-launcher  (1.0.0)
* python-qt  (3.5.2, 3.5.1, 3.4.2, 3.3.0, 3.2)
* python-swiftclient  (4.2.0, 4.1.0, 4.0.0, 3.13.1, 3.13.0, 3.12.0)
* python-language-server  (2022-02-18, 2021-09-08, 2021-05-20, 2020-10-08, 2020-06-19, 2020-04-24)
* python-matter-server  (5.10.0, 5.9.0, 5.8.1, 5.8.0, 5.7.0b2, 5.5.3, 5.1.1, 5.0.3, 4.0.2, 4.0.1 ...)
* python-full  (3.13.0a6, 3.13.0a5, 3.13.0a3, 3.13.0a2, 3.13.0a1, 3.12.3, 3.12.2, 3.12.1, 3.12.0, 3.11.9 ...)

Warning: Showing top 10 results and truncated versions. Use --show-all to show all.
```

## How was it tested?

Debugged locally, tested with `go` and `python`
Also verified that the ellipses don't appear when the `--show-all` flag is set
