### PR TITLE
Revert "[perf] Skip cache check if store path exists locally"

### DIFF
--- a/internal/devpkg/narinfo_cache.go
+++ b/internal/devpkg/narinfo_cache.go
@@ -5,13 +5,11 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"os"
 	"sync"
 	"time"
 
 	"github.com/pkg/errors"
 	"go.jetpack.io/devbox/internal/boxcli/featureflag"
-	"go.jetpack.io/devbox/internal/debug"
 	"go.jetpack.io/devbox/internal/lock"
 	"go.jetpack.io/devbox/internal/nix"
 	"golang.org/x/sync/errgroup"
@@ -53,7 +51,6 @@ func (p *Package) IsInBinaryCache() (bool, error) {
 // package in the list, and caches the result.
 // Callers of IsInBinaryCache may call this function first as a perf-optimization.
 func FillNarInfoCache(ctx context.Context, packages ...*Package) error {
-	defer debug.FunctionTimer().End()
 	if !featureflag.RemoveNixpkgs.Enabled() {
 		return nil
 	}
@@ -148,11 +145,6 @@ func (p *Package) fetchNarInfoStatus(outputName string) (bool, error) {
 
 	outputInCache := map[string]bool{} // key = output name, value = in cache
 	for _, output := range outputs {
-		// if store path exists locally, then it is equivalent to being in the cache.
-		if _, err := os.Stat(output.Path); err == nil {
-			outputInCache[output.Name] = true
-			continue
-		}
 		pathParts := nix.NewStorePathParts(output.Path)
 		reqURL := BinaryCache + "/" + pathParts.Hash + ".narinfo"
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)


### PR DESCRIPTION
Reverts jetify-com/devbox#2042

jetify-com/devbox#2042 introduced a bug where adding non-cached packages would fail to add them to the flake on the first attempt. (it would succeed on subsequent attempts after the package is already in the store).

The root cause is that `fetchNarInfoStatus` gets called twice per package (even though we cache it and we're not supposed to call it twice). The first call returns `false` because the package is not cached. The second call returns `true` because the package is already in store. This discrepancy essentially causes the package not to appear on the flake at all. When updating state again, the package is already in the nix store so both `fetchNarInfoStatus` calls return true.

I think reverting this is best immediate course of action. In follow up we should fix `fetchNarInfoStatus` so it only gets called once (it will improve performance and is more correct).

Later on we can think of better way to do jetify-com/devbox#2042. The current implementation is a bit fragile and not 100% consistent with the initial intention of the function, so I'm concerned it can lead to more bugs in the future.