### PR TITLE
[nix-cache] Prevent checking cache twice per package

### DIFF
--- a/internal/devpkg/narinfo_cache.go
+++ b/internal/devpkg/narinfo_cache.go
@@ -5,11 +5,12 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"slices"
+	"strings"
 	"sync"
 	"time"
 
 	"github.com/pkg/errors"
-	"github.com/samber/lo"
 	"go.jetpack.io/devbox/internal/boxcli/featureflag"
 	"go.jetpack.io/devbox/internal/lock"
 	"go.jetpack.io/devbox/internal/nix"
@@ -119,15 +120,15 @@ func (p *Package) keyForOutput(output string) string {
 		sysInfo, err := p.sysInfoIfExists()
 		// let's be super safe to always avoid empty key.
 		if err == nil && sysInfo != nil && len(sysInfo.DefaultOutputs()) > 0 {
-			output = lo.Reduce(
-				sysInfo.DefaultOutputs(),
-				func(acc string, o lock.Output, _ int) string {
-					return acc + o.Name
-				},
-				"",
-			)
+			names := make([]string, len(sysInfo.DefaultOutputs()))
+			for i, o := range sysInfo.DefaultOutputs() {
+				names[i] = o.Name
+			}
+			slices.Sort(names)
+			output = strings.Join(names, ",")
 		}
 	}
+	fmt.Println("output: ", output)
 
 	return fmt.Sprintf("%s^%s", p.Raw, output)
 }


### PR DESCRIPTION
## Summary

Fixes bug described here https://github.com/jetify-com/devbox/pull/2054

A better (but a bit more involved) solution is to parallelize by output. Currently we parallelize by meta-output (which includes `__default_output__`). This has two downsides:

* `__default_output__` can be multiple outputs, in which case we don't parallelize them at all.
* We still do redundant work when `__default_output__` is multiple outputs. (once as `__default_output__` and once for each individual outout that forms part of defaults). 

## How was it tested?
