### PR TITLE
[easy] rename jetpack-cloud to jetify-cloud

### DIFF
--- a/internal/boxcli/push.go
+++ b/internal/boxcli/push.go
@@ -22,7 +22,7 @@ func pushCmd() *cobra.Command {
 	flags := pushCmdFlags{}
 	cmd := &cobra.Command{
 		Use: "push <git-repo>",
-		Short: "Push a [global] config. Leave empty to use jetpack cloud. Can " +
+		Short: "Push a [global] config. Leave empty to use jetify cloud. Can " +
 			"be a git repo for self storage.",
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/boxcli/secrets.go
+++ b/internal/boxcli/secrets.go
@@ -52,7 +52,7 @@ func secretsCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:               "secrets",
 		Aliases:           []string{"envsec"},
-		Short:             "Interact with devbox secrets in jetpack cloud.",
+		Short:             "Interact with devbox secrets in jetify cloud.",
 		PersistentPreRunE: ensureNixInstalled,
 	}
 	cmd.AddCommand(secretsDownloadCmd(flags))
@@ -71,7 +71,7 @@ func secretsInitCmd(secretsFlags *secretsFlags) *cobra.Command {
 	flags := secretsInitCmdFlags{}
 	cmd := &cobra.Command{
 		Use:   "init",
-		Short: "Initialize secrets management with jetpack cloud",
+		Short: "Initialize secrets management with jetify cloud",
 		Args:  cobra.ExactArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return secretsInitFunc(cmd, flags, secretsFlags)

--- a/internal/devbox/devbox.go
+++ b/internal/devbox/devbox.go
@@ -1164,7 +1164,7 @@ func (d *Devbox) configEnvs(
 		} else if err != nil {
 			ux.Fwarning(
 				d.stderr,
-				"Ignoring env_from directive. jetpack cloud secrets is not "+
+				"Ignoring env_from directive. jetify cloud secrets is not "+
 					"initialized. Run `devbox secrets init` to initialize it.\n",
 			)
 		} else {
@@ -1172,7 +1172,7 @@ func (d *Devbox) configEnvs(
 			if err != nil {
 				ux.Fwarning(
 					os.Stderr,
-					"Error reading secrets from jetpack cloud: %s\n\n",
+					"Error reading secrets from jetify cloud: %s\n\n",
 					err,
 				)
 			} else {

--- a/internal/pullbox/s3/pull.go
+++ b/internal/pullbox/s3/pull.go
@@ -36,7 +36,7 @@ func PullToTmp(
 
 	ux.Finfo(
 		os.Stderr,
-		"Logged in as %s, pulling from jetpack cloud (profile: %s)\n",
+		"Logged in as %s, pulling from jetify cloud (profile: %s)\n",
 		creds.Email,
 		profile,
 	)


### PR DESCRIPTION
```
% git grep "jetpack cloud"
internal/boxcli/push.go:                Short: "Push a [global] config. Leave empty to use jetpack cloud. Can " +
internal/boxcli/secrets.go:             Short:             "Interact with devbox secrets in jetpack cloud.",
internal/boxcli/secrets.go:             Short: "Initialize secrets management with jetpack cloud",
internal/devbox/devbox.go:                              "Ignoring env_from directive. jetpack cloud secrets is not "+
internal/devbox/devbox.go:                                      "Error reading secrets from jetpack cloud: %s\n\n",
internal/pullbox/s3/pull.go:            "Logged in as %s, pulling from jetpack cloud (profile: %s)\n",
```

cleared these up
