### PR TITLE
chore(dev.Dockerfile.tmpl): Remove superfluous step number

### DIFF
--- a/internal/devbox/generate/tmpl/dev.Dockerfile.tmpl
+++ b/internal/devbox/generate/tmpl/dev.Dockerfile.tmpl
@@ -16,7 +16,7 @@ COPY devbox.lock devbox.lock
 {{- end}}
 
 {{if len .LocalFlakeDirs}}
-# Step 6: Copying local flakes directories
+# Copying local flakes directories
 {{- end}}
 {{range $i, $element := .LocalFlakeDirs -}}
 COPY {{$element}} {{$element}}


### PR DESCRIPTION
## Summary

### Issue

For some reason only the comment about copying the local flake dirs got a step number. Maybe a leftover?

### Fix

Just remove it, as no other step is numbered.

## How was it tested?

It wasn't as it is only a comment change. 😄 
