### PR TITLE
[perf] Improve install and ensure perf

### DIFF
--- a/internal/devpkg/narinfo_cache.go
+++ b/internal/devpkg/narinfo_cache.go
@@ -86,13 +86,13 @@ func FillNarInfoCache(ctx context.Context, packages ...*Package) error {
 	group, _ := errgroup.WithContext(ctx)
 	for _, p := range eligiblePackages {
 		pkg := p // copy the loop variable since its used in a closure below
-		outputs, err := pkg.GetOutputs()
+		outputNames, err := p.outputs.GetNames(p)
 		if err != nil {
 			return err
 		}
 
-		for _, output := range outputs {
-			name := output.Name
+		for _, outputName := range outputNames {
+			name := outputName
 			group.Go(func() error {
 				_, err := pkg.fetchNarInfoStatusOnce(name)
 				return err
@@ -132,7 +132,6 @@ func (p *Package) areExpectedOutputsInCacheOnce(outputName string) (bool, error)
 func (p *Package) fetchNarInfoStatusOnce(
 	outputName string,
 ) (map[string]string, error) {
-	defer debug.FunctionTimer().End()
 	ctx := context.TODO()
 
 	outputToCache := map[string]string{}

--- a/internal/devpkg/package.go
+++ b/internal/devpkg/package.go
@@ -16,7 +16,6 @@ import (
 	"github.com/samber/lo"
 	"go.jetpack.io/devbox/internal/boxcli/usererr"
 	"go.jetpack.io/devbox/internal/cachehash"
-	"go.jetpack.io/devbox/internal/debug"
 	"go.jetpack.io/devbox/internal/devbox/devopt"
 	"go.jetpack.io/devbox/internal/devconfig/configfile"
 	"go.jetpack.io/devbox/internal/devpkg/pkgtype"
@@ -679,7 +678,6 @@ func (p *Package) DocsURL() string {
 // specified in devbox.json package fields or as part of the flake reference.
 // If they exist in a cache, the cache URI is non-empty.
 func (p *Package) GetOutputs() ([]Output, error) {
-	defer debug.FunctionTimer().End()
 	if p.IsRunX() {
 		return nil, nil
 	}
@@ -707,4 +705,23 @@ func (p *Package) GetOutputs() ([]Output, error) {
 		outputs = append(outputs, output)
 	}
 	return outputs, nil
+}
+
+// GetResolvedStorePaths returns the store paths that are resolved (in lockfile)
+func (p *Package) GetResolvedStorePaths() ([]string, error) {
+	names, err := p.outputs.GetNames(p)
+	if err != nil {
+		return nil, err
+	}
+	storePaths := []string{}
+	for _, name := range names {
+		outputs, err := p.outputsForOutputName(name)
+		if err != nil {
+			return nil, err
+		}
+		for _, output := range outputs {
+			storePaths = append(storePaths, output.Path)
+		}
+	}
+	return storePaths, nil
 }

--- a/internal/nix/build.go
+++ b/internal/nix/build.go
@@ -2,6 +2,7 @@ package nix
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"os"
 	"os/exec"
@@ -22,6 +23,8 @@ type BuildArgs struct {
 
 func Build(ctx context.Context, args *BuildArgs, installables ...string) error {
 	defer debug.FunctionTimer().End()
+	fmt.Println("Building installables: ", installables)
+	fmt.Println("substituters: ", args.ExtraSubstituters)
 	// --impure is required for allowUnfreeEnv/allowInsecureEnv to work.
 	cmd := commandContext(ctx, "build", "--impure")
 	cmd.Args = append(cmd.Args, args.Flags...)

--- a/internal/nix/build.go
+++ b/internal/nix/build.go
@@ -2,7 +2,6 @@ package nix
 
 import (
 	"context"
-	"fmt"
 	"io"
 	"os"
 	"os/exec"
@@ -23,8 +22,6 @@ type BuildArgs struct {
 
 func Build(ctx context.Context, args *BuildArgs, installables ...string) error {
 	defer debug.FunctionTimer().End()
-	fmt.Println("Building installables: ", installables)
-	fmt.Println("substituters: ", args.ExtraSubstituters)
 	// --impure is required for allowUnfreeEnv/allowInsecureEnv to work.
 	cmd := commandContext(ctx, "build", "--impure")
 	cmd.Args = append(cmd.Args, args.Flags...)

--- a/internal/nix/store.go
+++ b/internal/nix/store.go
@@ -60,6 +60,9 @@ func StorePathsFromInstallable(ctx context.Context, installable string, allowIns
 // StorePathsAreInStore a map of store paths to whether they are in the store.
 func StorePathsAreInStore(ctx context.Context, storePaths []string) (map[string]bool, error) {
 	defer debug.FunctionTimer().End()
+	if len(storePaths) == 0 {
+		return map[string]bool{}, nil
+	}
 	args := append([]string{"path-info", "--offline", "--json"}, storePaths...)
 	cmd := commandContext(ctx, args...)
 	debug.Log("Running cmd %s", cmd)

--- a/internal/nix/store.go
+++ b/internal/nix/store.go
@@ -48,49 +48,74 @@ func StorePathsFromInstallable(ctx context.Context, installable string, allowIns
 
 		return nil, err
 	}
-	return parseStorePathFromInstallableOutput(installable, resultBytes)
+
+	validPaths, err := parseStorePathFromInstallableOutput(resultBytes)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse path-info for %s: %w", installable, err)
+	}
+
+	return maps.Keys(validPaths), nil
 }
 
-// StorePathsAreInStore returns true if the store path is in the store
-// It relies on `nix store ls` to check if the store path is in the store
-func StorePathsAreInStore(ctx context.Context, storePaths []string) (bool, error) {
+// StorePathsAreInStore a map of store paths to whether they are in the store.
+func StorePathsAreInStore(ctx context.Context, storePaths []string) (map[string]bool, error) {
 	defer debug.FunctionTimer().End()
-	for _, storePath := range storePaths {
-		cmd := commandContext(ctx, "store", "ls", storePath)
-		debug.Log("Running cmd %s", cmd)
-		if err := cmd.Run(); err != nil {
-			if exitErr := (&exec.ExitError{}); errors.As(err, &exitErr) {
-				return false, nil
-			}
-			return false, err
-		}
+	args := append([]string{"path-info", "--offline", "--json"}, storePaths...)
+	cmd := commandContext(ctx, args...)
+	debug.Log("Running cmd %s", cmd)
+	output, err := cmd.Output()
+	if err != nil {
+		return nil, err
 	}
-	return true, nil
+
+	validPaths, err := parseStorePathFromInstallableOutput(output)
+	if err != nil {
+		return nil, err
+	}
+
+	result := map[string]bool{}
+	for _, storePath := range storePaths {
+		_, ok := validPaths[storePath]
+		result[storePath] = ok
+	}
+
+	return result, nil
+}
+
+// Older nix versions (like 2.17) are an array of objects that contain path and valid fields
+type pathInfoLegacy struct {
+	Path  string `json:"path"`
+	Valid bool   `json:"valid"`
 }
 
 // parseStorePathFromInstallableOutput parses the output of `nix store path-from-installable --json`
 // This function is decomposed out of StorePathFromInstallable to make it testable.
-func parseStorePathFromInstallableOutput(installable string, output []byte) ([]string, error) {
-	// Newer nix versions (like 2.20)
+func parseStorePathFromInstallableOutput(output []byte) (map[string]any, error) {
+	// Newer nix versions (like 2.20) have output of the form
+	// {"<store-path>": {}}
+	// if a store path is used as an installable, the keys will be present even if invalid but
+	// the values will be null.
 	var out1 map[string]any
 	if err := json.Unmarshal(output, &out1); err == nil {
-		return maps.Keys(out1), nil
+		maps.DeleteFunc(out1, func(k string, v any) bool {
+			return v == nil
+		})
+		return out1, nil
 	}
 
-	// Older nix versions (like 2.17)
-	var out2 []struct {
-		Path  string `json:"path"`
-		Valid bool   `json:"valid"`
-	}
+	var out2 []pathInfoLegacy
+
 	if err := json.Unmarshal(output, &out2); err == nil {
-		res := []string{}
+		res := map[string]any{}
 		for _, outValue := range out2 {
-			res = append(res, outValue.Path)
+			if outValue.Valid {
+				res[outValue.Path] = true
+			}
 		}
 		return res, nil
 	}
 
-	return nil, fmt.Errorf("failed to parse store path from installable (%s) output: %s", installable, output)
+	return nil, fmt.Errorf("failed to parse path-info output: %s", output)
 }
 
 // DaemonError reports an unsuccessful attempt to connect to the Nix daemon.

--- a/internal/nix/store_test.go
+++ b/internal/nix/store_test.go
@@ -3,6 +3,8 @@ package nix
 import (
 	"slices"
 	"testing"
+
+	"golang.org/x/exp/maps"
 )
 
 func TestParseStorePathFromInstallableOutput(t *testing.T) {
@@ -19,18 +21,18 @@ func TestParseStorePathFromInstallableOutput(t *testing.T) {
 		},
 		{
 			name:     "go-basic-nix-2-17-0",
-			input:    `[{"path":"/nix/store/fgkl3qk8p5hnd07b0dhzfky3ys5gxjmq-go-1.22.0","valid":false}]`,
+			input:    `[{"path":"/nix/store/fgkl3qk8p5hnd07b0dhzfky3ys5gxjmq-go-1.22.0","valid":true}]`,
 			expected: []string{"/nix/store/fgkl3qk8p5hnd07b0dhzfky3ys5gxjmq-go-1.22.0"},
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			actual, err := parseStorePathFromInstallableOutput(tc.name, []byte(tc.input))
+			actual, err := parseStorePathFromInstallableOutput([]byte(tc.input))
 			if err != nil {
 				t.Errorf("Expected no error but got error: %s", err)
 			}
-			if !slices.Equal(tc.expected, actual) {
+			if !slices.Equal(tc.expected, maps.Keys(actual)) {
 				t.Errorf("Expected store path %s but got %s", tc.expected, actual)
 			}
 		})


### PR DESCRIPTION
## Summary

This improves install and ensure perf by making the following changes:

* Batch all store path existence checks. (previously we did one by one, each `nix ls` call is about 50ms)
* If lockfile has store paths we use them (instead of trying to get them from nix)
* Fix regression in `FillNarInfoCache`

## How was it tested?

Installed large devbox.json (30+ packages) and used `DEVBOX_PRINT_EXEC_TIME` and observed almost all "prep" time disappear. prep time is the work devbox does before actually building the packages.