### PR TITLE
[container] Added metadata to tag docker image with devbox version

### DIFF
--- a/.github/workflows/docker-image-release.yml
+++ b/.github/workflows/docker-image-release.yml
@@ -1,6 +1,10 @@
 name: docker-image-release
 
-on: workflow_dispatch
+on:
+  push:
+    tags:
+      - "!*-dev"
+      - "!*-dev*"
 
 jobs:
   docker-image-build-push:

--- a/.github/workflows/docker-image-release.yml
+++ b/.github/workflows/docker-image-release.yml
@@ -10,6 +10,26 @@ jobs:
         uses: actions/checkout@v4
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            jetpackio/devbox
+          tags: |
+            type=semver,pattern={{version}}
+          flavor: |
+            latest=true
+      - name: Docker meta root
+        id: metaroot
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            jetpackio/devbox-root-user
+          tags: |
+            type=semver,pattern={{version}}
+          flavor: |
+            latest=true
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
       - name: Login to Docker Hub
@@ -18,18 +38,18 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
       - name: Build and push default
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v5
         with:
           context: ./internal/devbox/generate/tmpl/
           file: ./internal/devbox/generate/tmpl/DevboxImageDockerfile
           push: true
           platforms: linux/amd64,linux/arm64
-          tags: jetpackio/devbox:latest
+          tags: ${{ steps.meta.outputs.tags }}
       - name: Build and push root user
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v5
         with:
           context: ./internal/devbox/generate/tmpl/
           file: ./internal/devbox/generate/tmpl/DevboxImageDockerfileRootUser
           push: true
           platforms: linux/amd64,linux/arm64
-          tags: jetpackio/devbox-root-user:latest
+          tags: ${{ steps.metaroot.outputs.tags }}


### PR DESCRIPTION
## Summary
Added metadata to tag each container image with the same version as devbox as well as `latest`

## How was it tested?
Will have to be tested with CICD