### PR TITLE
[easy][bug] Fix install if package has no storepaths in lockfile

### DIFF
--- a/internal/devbox/packages.go
+++ b/internal/devbox/packages.go
@@ -555,16 +555,17 @@ func (d *Devbox) packagesToInstallInStore(ctx context.Context, mode installMode)
 			if err != nil {
 				return nil, err
 			}
-			if resolvedStorePaths != nil {
+			if len(resolvedStorePaths) > 0 {
 				storePathsForPackage[pkg] = append(storePathsForPackage[pkg], resolvedStorePaths...)
 				continue
 			}
 
-			storePathsForPackage[pkg], err = nix.StorePathsFromInstallable(
+			storePathsForInstallable, err := nix.StorePathsFromInstallable(
 				ctx, installable, pkg.HasAllowInsecure())
 			if err != nil {
 				return nil, packageInstallErrorHandler(err, pkg, installable)
 			}
+			storePathsForPackage[pkg] = append(storePathsForPackage[pkg], storePathsForInstallable...)
 		}
 	}
 

--- a/internal/devpkg/package.go
+++ b/internal/devpkg/package.go
@@ -718,7 +718,7 @@ func (p *Package) GetOutputsWithCache() ([]Output, error) {
 
 // GetResolvedStorePaths returns the store paths that are resolved (in lockfile)
 func (p *Package) GetResolvedStorePaths() ([]string, error) {
-	names, err := p.outputs.GetNames(p)
+	names, err := p.GetOutputNames()
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary

Fixes issue introduced in https://github.com/jetify-com/devbox/blame/main/internal/devbox/packages.go#L558-L558

## How was it tested?

Removed store paths from lock file, ensured package was still installed. 