### PR TITLE
Add plugin support for postgres extensions

### DIFF
--- a/docs/app/docs/devbox_examples/databases/postgres.md
+++ b/docs/app/docs/devbox_examples/databases/postgres.md
@@ -25,6 +25,25 @@ Alternatively, you can add the following to your devbox.json:
 
 This will install the latest version of Postgres. You can find other installable versions of Postgres by running `devbox search postgresql`. You can also view the available versions on [Nixhub](https://www.nixhub.io/packages/postgresql)
 
+## Installing Extensions with PostgreSQL
+
+To install and use extensions in PostgreSQL, you should first install the `lib` output for Postgres by running `devbox add postgresql --outputs=out,lib`: 
+
+```json
+  "packages": {
+    "postgresql": {
+      "version": "latest",
+      "outputs": ["out", "lib"]
+    },
+  }
+```
+
+You can then install the extension using `devbox add postgresqlXXpackages.extension`, where `XX` is the major version of Postgres that you are using. For example, to install Postgis for PostgreSQL 15, you can run: 
+
+```bash
+devbox add postgresql15Packages.postgis
+```
+
 ## PostgreSQL Plugin Support
 
 Devbox will automatically create the following configuration when you run `devbox add postgresql`:
@@ -38,8 +57,7 @@ You can use `devbox services start|stop postgresql` to start or stop the Postgre
 
 `PGHOST=./.devbox/virtenv/postgresql`
 `PGDATA=./.devbox/virtenv/postgresql/data`
-
-This variable tells PostgreSQL which directory to use for creating and storing databases.
+`NIX_PGLIBDIR=./.devbox/nix/profile/default/lib`
 
 ### Notes
 

--- a/examples/databases/postgres/devbox.json
+++ b/examples/databases/postgres/devbox.json
@@ -1,10 +1,14 @@
 {
   "packages": {
-    "postgresql": "latest",
+    "postgresql": {
+      "version": "latest",
+      "outputs": ["out", "lib"]
+    },
     "glibcLocales": {
       "version":   "latest",
       "platforms": ["x86_64-linux", "aarch64-linux"]
-    }
+    },
+    "postgresql15Packages.postgis": "latest"
   },
   "shell": {
     "init_hook": null

--- a/plugins/postgresql.json
+++ b/plugins/postgresql.json
@@ -1,10 +1,11 @@
 {
     "name": "postgresql",
-    "version": "0.0.2",
-    "description": "To initialize the database run `initdb`.",
+    "version": "0.0.3",
+    "description": "To initialize the database run `initdb`.\nIf you want to install extensions with Postgres, make sure to add the lib output with `devbox add postgresql --outputs=out,lib`",
     "env": {
         "PGDATA": "{{ .Virtenv }}/data",
-        "PGHOST": "{{ .Virtenv }}"
+        "PGHOST": "{{ .Virtenv }}",
+        "NIX_PGLIBDIR": "{{ .DevboxProfileDefault }}/lib"
     },
     "create_files": {
         "{{ .Virtenv }}/data": "",


### PR DESCRIPTION
## Summary

This PR makes it possible to install Postgres Extensions with Devbox. This didn't work with previous versions of Devbox + the Postgres plugin because: 

1. Postgres was only looking for extensions within a subdirectory of the Postgres package in the Nix Store. Unless we install the extensions using the 
2. The default PostgreSQL output `out` doesn't include libraries used to install some extensions.

Fortunately, the Nix PostgreSQL package is [patched](https://github.com/NixOS/nixpkgs/blob/master/pkgs/servers/sql/postgresql/patches/specify_pkglibdir_at_runtime.patch) so that you can set the pkglibdir at runtime using the `NIX_PGLIBDIR` environment variable. If we set this variable to `$DEVBOX_PACKAGES_DIR/lib`, and if the user installs the `lib` output, extensions should work as expected. 

This PR sets the NIX_PGLIBDIR variable in the plugin, and adds documentation + modifies the example to highlight how to install postgres with the lib output.


## How was it tested?

Tested on our Postgres example with the PostGIS extension.