### PR TITLE
fix(nix): add support for Nix forks

### DIFF
--- a/internal/nix/nix.go
+++ b/internal/nix/nix.go
@@ -191,6 +191,10 @@ const (
 	MinVersion = Version2_12
 )
 
+// VersionRegexp matches the first line of "nix --version" output.
+// Semantic component sourced from https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
+var VersionRegexp = regexp.MustCompile(`^([a-z]+) \(.+\) ((?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)(?:-(?P<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)$`)
+
 // VersionInfo contains information about a Nix installation.
 type VersionInfo struct {
 	// Name is the executed program name (the first element of argv).
@@ -253,10 +257,14 @@ func parseVersionInfo(data []byte) (VersionInfo, error) {
 
 	lines := strings.Split(string(data), "\n")
 	found := false
-	info.Name, info.Version, found = strings.Cut(lines[0], " (Nix) ")
+
+	versionMatch := VersionRegexp.FindStringSubmatch(lines[0])
+	found = len(versionMatch) >= 3
 	if !found {
 		return info, redact.Errorf("parse nix version: %s", redact.Safe(lines[0]))
 	}
+	info.Name = versionMatch[1]
+	info.Version = versionMatch[2]
 	for _, line := range lines {
 		name, value, found := strings.Cut(line, ": ")
 		if !found {

--- a/internal/nix/nix.go
+++ b/internal/nix/nix.go
@@ -191,9 +191,9 @@ const (
 	MinVersion = Version2_12
 )
 
-// VersionRegexp matches the first line of "nix --version" output.
+// versionRegexp matches the first line of "nix --version" output.
 // Semantic component sourced from https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
-var VersionRegexp = regexp.MustCompile(`^([a-z]+) \(.+\) ((?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)(?:-(?P<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)$`)
+var versionRegexp = regexp.MustCompile(`^(.+) \(.+\) ((?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)(?:-(?P<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)$`)
 
 // VersionInfo contains information about a Nix installation.
 type VersionInfo struct {
@@ -256,15 +256,12 @@ func parseVersionInfo(data []byte) (VersionInfo, error) {
 	}
 
 	lines := strings.Split(string(data), "\n")
-	found := false
-
-	versionMatch := VersionRegexp.FindStringSubmatch(lines[0])
-	found = len(versionMatch) >= 3
-	if !found {
+	matches := versionRegexp.FindStringSubmatch(lines[0])
+	if len(matches) < 3 {
 		return info, redact.Errorf("parse nix version: %s", redact.Safe(lines[0]))
 	}
-	info.Name = versionMatch[1]
-	info.Version = versionMatch[2]
+	info.Name = matches[1]
+	info.Version = matches[2]
 	for _, line := range lines {
 		name, value, found := strings.Cut(line, ": ")
 		if !found {

--- a/internal/nix/nix_test.go
+++ b/internal/nix/nix_test.go
@@ -1,3 +1,4 @@
+//nolint:dupl
 package nix
 
 import (


### PR DESCRIPTION
## Summary

Increases leniency for `nix --version` output to support Nix forks, such as [Lix](https://lix.systems):

`nix (Lix, like Nix) 2.90.0-beta.1-lixpre20240506-b6799ab`

## How was it tested?

On Lix:

```bash
$ nix --version
nix (Lix, like Nix) 2.90.0-beta.1-lixpre20240506-b6799ab

$ go run ./cmd/devbox run nix --version
nix (Lix, like Nix) 2.90.0-beta.1-lixpre20240506-b6799ab

$ go run ./cmd/devbox shell
# (works as expected)
```

On Nix:

```bash
$ nix shell nixpkgs#nix

$ nix --version
nix (Nix) 2.18.2

$ go run ./cmd/devbox run nix --version
nix (Nix) 2.18.2

$ go run ./cmd/devbox shell
# (works as expected)
```

## What did it look like before?

```bash
$ go run ./cmd/devbox shell
Error: nix: ensure install: get version: parse nix version: nix (Lix, like Nix) 2.90.0-beta.1-lixpre20240506-b6799ab

exit status 1
```