### PR TITLE
Add a readiness_probe for postgresql

### DIFF
--- a/plugins/postgresql/process-compose.yaml
+++ b/plugins/postgresql/process-compose.yaml
@@ -8,3 +8,6 @@ processes:
       command: "pg_ctl stop -m fast"
     availability:
       restart: "always"
+    readiness_probe:
+      exec:
+        command: "pg_isready"


### PR DESCRIPTION
## Summary

This PR adds the following `readiness_probe` to the `postgresql` plugin:

```yaml
    readiness_probe:
      exec:
        command: "pg_isready"
```

With that change, Devbox users have the ability to create their own processes that depend on a healthy postgresql service. For example, to seed a database, one can add the following to a `process-compose.yml`:

```yaml
version: "0.5"
processes:
  seed_db:
    command: |
      npm run db:seed # for example
    depends_on:
      postgresql:
        condition: process_healthy
```

## How was it tested?

In a project with the above `process-compose.yml` file and the changes in this PR applied to `.devbox/virtenv/postgresql/process-compose.yml`