### PR TITLE
internal/devbox: fix warning when user refuses cache setup

### DIFF
--- a/internal/devbox/packages.go
+++ b/internal/devbox/packages.go
@@ -513,7 +513,7 @@ func (d *Devbox) appendExtraSubstituters(ctx context.Context, args *nix.BuildArg
 	}
 	if err != nil {
 		ux.Fwarning(d.stderr, "Devbox was unable to authenticate with the Jetify Nix cache. Some packages might be built from source.\n")
-		return nil
+		return nil //nolint:nilerr
 	}
 
 	caches, err := nixcache.CachedReadCaches(ctx)


### PR DESCRIPTION
Don't add extra substituters when the user answers "no" to the confirmation prompt for configuring Nix caches. This stops Nix from printing warnings such as:

	warning: ignoring untrusted substituter 's3://mycache', you are not a trusted user.
	Run man nix.conf for more information on the substituters configuration option.

Also print a message saying that `devbox cache configure` can be used to configure the cache after answering no.