### PR TITLE
nixcache: don't check Jetify caches if they're not configured

### DIFF
--- a/internal/devbox/packages.go
+++ b/internal/devbox/packages.go
@@ -513,7 +513,7 @@ func (d *Devbox) appendExtraSubstituters(ctx context.Context, args *nix.BuildArg
 	}
 	if err != nil {
 		ux.Fwarning(d.stderr, "Devbox was unable to authenticate with the Jetify Nix cache. Some packages might be built from source.\n")
-		return nil
+		return nil //nolint:nilerr
 	}
 
 	caches, err := nixcache.CachedReadCaches(ctx)

--- a/internal/devbox/providers/nixcache/setup.go
+++ b/internal/devbox/providers/nixcache/setup.go
@@ -21,6 +21,18 @@ import (
 	"go.jetpack.io/devbox/internal/ux"
 )
 
+const setupKey = "nixcache-setup"
+
+func IsConfigured(ctx context.Context) bool {
+	u, err := user.Current()
+	if err != nil {
+		return false
+	}
+	task := &setupTask{u.Username}
+	status := setup.Status(ctx, setupKey, task)
+	return status == setup.TaskDone
+}
+
 func Configure(ctx context.Context) error {
 	u, err := user.Current()
 	if err != nil {
@@ -34,15 +46,14 @@ func ConfigureReprompt(ctx context.Context, username string) error {
 }
 
 func configure(ctx context.Context, username string, reprompt bool) error {
-	const key = "nixcache-setup"
 	if reprompt {
-		setup.Reset(key)
+		setup.Reset(setupKey)
 	}
 
 	task := &setupTask{username}
 	const sudoPrompt = "You're logged into a Devbox account that now has access to a Nix cache. " +
 		"Allow Devbox to configure Nix to use the new cache (requires sudo)?"
-	err := setup.ConfirmRun(ctx, key, task, sudoPrompt)
+	err := setup.ConfirmRun(ctx, setupKey, task, sudoPrompt)
 	if err != nil {
 		return redact.Errorf("nixcache: run setup: %w", err)
 	}

--- a/internal/devpkg/narinfo_cache.go
+++ b/internal/devpkg/narinfo_cache.go
@@ -341,6 +341,10 @@ func fetchNarInfoStatusFromS3(
 
 func readCaches(ctx context.Context) ([]string, error) {
 	cacheURIs := []string{binaryCache}
+	if !nixcache.IsConfigured(ctx) {
+		return cacheURIs, nil
+	}
+
 	otherCaches, err := nixcache.CachedReadCaches(ctx)
 	if err != nil {
 		return nil, err

--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -66,6 +66,50 @@ type RunInfo struct {
 	Error string `json:"error,omitempty"`
 }
 
+// TaskStatus describes the status of a task.
+type TaskStatus int
+
+const (
+	// TaskDone indicates that a task doesn't need to run and that its most
+	// recent run (if any) didn't report an error. Note that a task can be
+	// done without ever running if its NeedsRun method returns false before
+	// the first run.
+	TaskDone TaskStatus = iota
+
+	// TaskNeedsRun is the status of a task that needs to be run.
+	TaskNeedsRun
+
+	// TaskUserRefused indicates that the user answered no to a confirmation
+	// prompt to run the task.
+	TaskUserRefused
+
+	// TaskError indicates that a task's most recent run failed and it
+	// cannot be re-run without a call to [Reset].
+	TaskError
+
+	// TaskSudoing occurs when the caller of [Status] is running in a sudoed
+	// process due to the task calling [SudoDevbox] from the parent process.
+	TaskSudoing
+)
+
+// Status returns the status of a setup task.
+func Status(ctx context.Context, key string, task Task) TaskStatus {
+	state := loadState(key)
+	switch {
+	case isSudo(key):
+		return TaskSudoing
+	case state.ConfirmPrompt.Asked && !state.ConfirmPrompt.Allowed:
+		return TaskUserRefused
+	case task.NeedsRun(ctx, state.LastRun):
+		return TaskNeedsRun
+	case state.LastRun.Error == "":
+		return TaskDone
+	case state.LastRun.Error != "":
+		return TaskError
+	}
+	panic("setup.Status switch isn't exhaustive")
+}
+
 // Run runs a setup task and stores its state under a given key. Keys are
 // namespaced by user. It only calls the task's Run method when NeedsRun returns
 // true.
@@ -187,14 +231,7 @@ var defaultPrompt = func(msg string) (response any, err error) {
 func run(ctx context.Context, key string, task Task, prompt string) error {
 	ctx = context.WithValue(ctx, ctxKeyTask, key)
 
-	// DEVBOX_SUDO_TASK is set when a task relaunched Devbox by calling
-	// SudoDevbox. If it matches the current task key, then the pre-sudo
-	// process is already running this task and we can skip checking
-	// task.NeedsRun and prompting the user.
-	isSudo := false
-	if envTask := os.Getenv("DEVBOX_SUDO_TASK"); envTask != "" {
-		isSudo = envTask == key
-	}
+	isSudo := isSudo(key)
 	state := loadState(key)
 	if !isSudo && !task.NeedsRun(ctx, state.LastRun) {
 		return nil
@@ -342,4 +379,13 @@ func devboxExecutable() (string, error) {
 		return "", redact.Errorf("get path to devbox executable: %v", err)
 	}
 	return exe, nil
+}
+
+func isSudo(key string) bool {
+	// DEVBOX_SUDO_TASK is set when a task relaunched Devbox by calling
+	// SudoDevbox. If it matches the current task key, then the pre-sudo
+	// process is already running this task and we can skip checking
+	// task.NeedsRun and prompting the user.
+	envTask := os.Getenv("DEVBOX_SUDO_TASK")
+	return envTask != "" && envTask == key
 }


### PR DESCRIPTION
Don't check the Jetify Nix caches for store paths if Nix isn't configured to use them. This can happen if the user says "no" to the confirmation prompt for cache setup. Otherwise, `nix build` prints an error about the path missing:

	$ devbox add mongodb@6.0.15
	Info: Adding package "mongodb@6.0.15" to devbox.json
	? You're logged into a Devbox account that now has access to a Nix cache. Allow Devbox to configure Nix to use the new cache (requires sudo)? No
	Info: Skipping cache setup. Run `devbox cache configure` to enable the cache at a later time.
	Info: Installing the following packages to the nix store: mongodb@6.0.15
	error: path '/nix/store/n7fkj8vif9yc1g063r0z88j5dh3i7p8a-mongodb-6.0.15' is required, but there is no substituter that can build it