### PR TITLE
[bug] Fix parseStorePathFromInstallableOutput

### DIFF
--- a/internal/nix/store_test.go
+++ b/internal/nix/store_test.go
@@ -21,7 +21,7 @@ func TestParseStorePathFromInstallableOutput(t *testing.T) {
 		},
 		{
 			name:     "go-basic-nix-2-17-0",
-			input:    `[{"path":"/nix/store/fgkl3qk8p5hnd07b0dhzfky3ys5gxjmq-go-1.22.0","valid":true}]`,
+			input:    `[{"path":"/nix/store/fgkl3qk8p5hnd07b0dhzfky3ys5gxjmq-go-1.22.0"}]`,
 			expected: []string{"/nix/store/fgkl3qk8p5hnd07b0dhzfky3ys5gxjmq-go-1.22.0"},
 		},
 	}

--- a/testscripts/lockfile/nopaths.txt
+++ b/testscripts/lockfile/nopaths.txt
@@ -1,0 +1,23 @@
+# Test installing a package without outputs in the store path. 
+# NOTE: Purposefully using a weird version to ensure it is not already in store.
+
+exec devbox run curl --version | grep -o 'curl\s7\.87\.0'
+stdout 'curl 7.87.0'
+
+-- devbox.json --
+{
+  "packages": ["curl@7.87.0"],
+}
+
+-- devbox.lock --
+{
+  "lockfile_version": "1",
+  "packages": {
+    "curl@7.87.0": {
+      "last_modified": "2023-02-26T03:47:33Z",
+      "resolved": "github:NixOS/nixpkgs/9952d6bc395f5841262b006fbace8dd7e143b634#curl",
+      "source": "devbox-search",
+      "version": "7.87.0"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Fix regression introduced in https://github.com/jetify-com/devbox/pull/2076

I misunderstood the API. A null value (in modern API) or a valid: false (in legacy API) occur when store path doesn't exist. Whether the store path itself is a valid store path doesn't matter, obviously if it is not a valid path, it won't be present in the store, but if it's valid and not installed, it will return null value or valid: false. The users of this function do not want to ignore these paths.

Edit: This bug is a bit less bad than initially thought. Because we install non-cached packages in flake, so anything missing would be installed then.

## How was it tested?

Unit test. 

This is tricky to test. I added a test script that can hopefully catch this.

Edit: This test doesn't actually catch this because the package ends up getting installed later on (in the flake). I still think this test is good to have.
