### PR TITLE
Refactor the list command

### DIFF
--- a/internal/boxcli/global.go
+++ b/internal/boxcli/global.go
@@ -60,35 +60,6 @@ func addCommandAndHideConfigFlag(parent, child *cobra.Command) {
 	_ = child.Flags().MarkHidden("config")
 }
 
-type listCmdFlags struct {
-	config configFlags
-}
-
-func listCmd() *cobra.Command {
-	flags := listCmdFlags{}
-	cmd := &cobra.Command{
-		Use:     "list",
-		Aliases: []string{"ls"},
-		Short:   "List global packages",
-		PreRunE: ensureNixInstalled,
-		RunE: func(cmd *cobra.Command, args []string) error {
-			box, err := devbox.Open(&devopt.Opts{
-				Dir:    flags.config.path,
-				Stderr: cmd.ErrOrStderr(),
-			})
-			if err != nil {
-				return errors.WithStack(err)
-			}
-			for _, p := range box.AllPackageNamesIncludingRemovedTriggerPackages() {
-				fmt.Fprintf(cmd.OutOrStdout(), "* %s\n", p)
-			}
-			return nil
-		},
-	}
-	flags.config.register(cmd)
-	return cmd
-}
-
 var globalConfigPath string
 
 func ensureGlobalConfig() (string, error) {

--- a/internal/boxcli/list.go
+++ b/internal/boxcli/list.go
@@ -22,7 +22,7 @@ func listCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "list",
 		Aliases: []string{"ls"},
-		Short:   "List the packages in your current devbox project",
+		Short:   "List installed packages",
 		PreRunE: ensureNixInstalled,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			box, err := devbox.Open(&devopt.Opts{

--- a/internal/boxcli/list.go
+++ b/internal/boxcli/list.go
@@ -1,0 +1,43 @@
+// Copyright 2024 Jetify Inc. and contributors. All rights reserved.
+// Use of this source code is governed by the license in the LICENSE file.
+
+package boxcli
+
+import (
+	"fmt"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+
+	"go.jetpack.io/devbox/internal/devbox"
+	"go.jetpack.io/devbox/internal/devbox/devopt"
+)
+
+type listCmdFlags struct {
+	config configFlags
+}
+
+func listCmd() *cobra.Command {
+	flags := listCmdFlags{}
+	cmd := &cobra.Command{
+		Use:     "list",
+		Aliases: []string{"ls"},
+		Short:   "List the packages in your current devbox project",
+		PreRunE: ensureNixInstalled,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			box, err := devbox.Open(&devopt.Opts{
+				Dir:    flags.config.path,
+				Stderr: cmd.ErrOrStderr(),
+			})
+			if err != nil {
+				return errors.WithStack(err)
+			}
+			for _, p := range box.AllPackageNamesIncludingRemovedTriggerPackages() {
+				fmt.Fprintf(cmd.OutOrStdout(), "* %s\n", p)
+			}
+			return nil
+		},
+	}
+	flags.config.register(cmd)
+	return cmd
+}


### PR DESCRIPTION
## Summary
Refactor the list command into its own file. Also update the description to be more accurate.

## How was it tested?
1. Verified the `list` command is updated with the new message in the `--help` command output
2. Verified the `list` command outputs the same list of packages before and after this change (compared my local `devbox` install output to the output in my `devbox shell` with these changes).

