### PR TITLE
[perf] Add flag to fix missing store paths

### DIFF
--- a/internal/boxcli/install.go
+++ b/internal/boxcli/install.go
@@ -15,7 +15,7 @@ import (
 
 type installCmdFlags struct {
 	runCmdFlags
-	fixMissingStorePaths bool
+	tidyLockfile bool
 }
 
 func installCmd() *cobra.Command {
@@ -32,8 +32,9 @@ func installCmd() *cobra.Command {
 
 	flags.config.register(command)
 	command.Flags().BoolVar(
-		&flags.fixMissingStorePaths, "fix-missing-store-paths", false,
+		&flags.tidyLockfile, "tidy-lockfile", false,
 		"Fix missing store paths in the devbox.lock file.",
+		// Could potentially do more in the future.
 	)
 
 	return command
@@ -53,7 +54,7 @@ func installCmdFunc(cmd *cobra.Command, flags installCmdFlags) error {
 	if err = box.Install(ctx); err != nil {
 		return errors.WithStack(err)
 	}
-	if flags.fixMissingStorePaths {
+	if flags.tidyLockfile {
 		if err = box.FixMissingStorePaths(ctx); err != nil {
 			return errors.WithStack(err)
 		}

--- a/internal/boxcli/install.go
+++ b/internal/boxcli/install.go
@@ -11,6 +11,8 @@ import (
 
 	"go.jetpack.io/devbox/internal/devbox"
 	"go.jetpack.io/devbox/internal/devbox/devopt"
+	"go.jetpack.io/devbox/internal/devpkg"
+	"go.jetpack.io/devbox/internal/ux"
 )
 
 type installCmdFlags struct {
@@ -51,6 +53,9 @@ func installCmdFunc(cmd *cobra.Command, flags installCmdFlags) error {
 		return errors.WithStack(err)
 	}
 	ctx := cmd.Context()
+	if flags.tidyLockfile {
+		ctx = ux.HideMessage(ctx, devpkg.MissingStorePathsWarning)
+	}
 	if err = box.Install(ctx); err != nil {
 		return errors.WithStack(err)
 	}

--- a/internal/boxcli/pull.go
+++ b/internal/boxcli/pull.go
@@ -106,7 +106,9 @@ func pullCmdFunc(cmd *cobra.Command, url string, flags *pullCmdFlags) error {
 
 	return installCmdFunc(
 		cmd,
-		runCmdFlags{config: configFlags{pathFlag: pathFlag{path: flags.config.path}}},
+		installCmdFlags{
+			runCmdFlags: runCmdFlags{config: configFlags{pathFlag: pathFlag{path: flags.config.path}}},
+		},
 	)
 }
 

--- a/internal/devbox/devbox.go
+++ b/internal/devbox/devbox.go
@@ -838,6 +838,7 @@ func (d *Devbox) StartProcessManager(
 // some additional processing. The computeEnv environment won't necessarily
 // represent the final "devbox run" or "devbox shell" environments.
 func (d *Devbox) computeEnv(ctx context.Context, usePrintDevEnvCache bool) (map[string]string, error) {
+	defer debug.FunctionTimer().End()
 	defer trace.StartRegion(ctx, "devboxComputeEnv").End()
 
 	// Append variables from current env if --pure is not passed

--- a/internal/devbox/nixprofile.go
+++ b/internal/devbox/nixprofile.go
@@ -16,6 +16,7 @@ import (
 //
 // It also removes any packages from the nix profile that are no longer in the buildInputs.
 func (d *Devbox) syncNixProfileFromFlake(ctx context.Context) error {
+	defer debug.FunctionTimer().End()
 	// Get the computed Devbox environment from the generated flake
 	env, err := d.computeEnv(ctx, false /*usePrintDevEnvCache*/)
 	if err != nil {

--- a/internal/devbox/packages.go
+++ b/internal/devbox/packages.go
@@ -648,6 +648,9 @@ func (d *Devbox) moveAllowInsecureFromLockfile(writer io.Writer, lockfile *lock.
 func (d *Devbox) FixMissingStorePaths(ctx context.Context) error {
 	packages := d.InstallablePackages()
 	for _, pkg := range packages {
+		if pkg.IsRunX() {
+			continue
+		}
 		existingStorePaths, err := pkg.GetResolvedStorePaths()
 		if err != nil {
 			return err

--- a/internal/devbox/packages.go
+++ b/internal/devbox/packages.go
@@ -335,6 +335,7 @@ func (d *Devbox) updateLockfile(recomputeState bool) error {
 // - the generated flake
 // - the nix-profile
 func (d *Devbox) recomputeState(ctx context.Context) error {
+	defer debug.FunctionTimer().End()
 	if err := shellgen.GenerateForPrintEnv(ctx, d); err != nil {
 		return err
 	}
@@ -642,4 +643,47 @@ func (d *Devbox) moveAllowInsecureFromLockfile(writer io.Writer, lockfile *lock.
 	)
 
 	return nil
+}
+
+func (d *Devbox) FixMissingStorePaths(ctx context.Context) error {
+	packages := d.InstallablePackages()
+	for _, pkg := range packages {
+		existingStorePaths, err := pkg.GetResolvedStorePaths()
+		if err != nil {
+			return err
+		}
+
+		if len(existingStorePaths) > 0 {
+			continue
+		}
+
+		installables, err := pkg.Installables()
+		if err != nil {
+			return err
+		}
+
+		outputs := []lock.Output{}
+		for _, installable := range installables {
+			storePaths, err := nix.StorePathsFromInstallable(ctx, installable, pkg.HasAllowInsecure())
+			if err != nil {
+				return err
+			}
+			if len(storePaths) == 0 {
+				return fmt.Errorf("no store paths found for package %s", pkg.Raw)
+			}
+			for _, storePath := range storePaths {
+				parts := nix.NewStorePathParts(storePath)
+				outputs = append(outputs, lock.Output{
+					Path: storePath,
+					Name: parts.Output,
+					// Ugh, not sure this is true, but it's more true than not.
+					Default: true,
+				})
+			}
+		}
+		if err = d.lockfile.SetOutputsForPackage(pkg.Raw, outputs); err != nil {
+			return err
+		}
+	}
+	return d.lockfile.Save()
 }

--- a/internal/devbox/update.go
+++ b/internal/devbox/update.go
@@ -75,6 +75,12 @@ func (d *Devbox) Update(ctx context.Context, opts devopt.UpdateOpts) error {
 	// It will return an error if .devbox/gen/flake is missing
 	// TODO: Remove this if it's not needed.
 	_ = nix.FlakeUpdate(shellgen.FlakePath(d))
+
+	// fix any missing store paths.
+	if err = d.FixMissingStorePaths(ctx); err != nil {
+		return errors.WithStack(err)
+	}
+
 	return plugin.Update()
 }
 

--- a/internal/devpkg/package.go
+++ b/internal/devpkg/package.go
@@ -736,6 +736,9 @@ func (p *Package) GetResolvedStorePaths() ([]string, error) {
 	return storePaths, nil
 }
 
+const MissingStorePathsWarning = "Outputs for %s are not in lockfile. To fix this issue and improve performance, please run " +
+	"`devbox install --tidy-lockfile`\n"
+
 func (p *Package) GetStorePaths(ctx context.Context, w io.Writer) ([]string, error) {
 	storePathsForPackage, err := p.GetResolvedStorePaths()
 	if err != nil || len(storePathsForPackage) > 0 {
@@ -744,12 +747,7 @@ func (p *Package) GetStorePaths(ctx context.Context, w io.Writer) ([]string, err
 
 	if p.IsDevboxPackage {
 		// No fast path, we need to query nix.
-		ux.Fwarning(
-			w,
-			"Outputs for %s are not in lockfile. To fix this issue and improve performance, please run "+
-				"`devbox install --tidy-lockfile`\n",
-			p.Raw,
-		)
+		ux.FHidableWarning(ctx, w, MissingStorePathsWarning, p.Raw)
 	}
 
 	installables, err := p.Installables()

--- a/internal/devpkg/package.go
+++ b/internal/devpkg/package.go
@@ -746,7 +746,8 @@ func (p *Package) GetStorePaths(ctx context.Context, w io.Writer) ([]string, err
 	// TODO we should give people the option to add paths to lockfile.
 	ux.Fwarning(
 		w,
-		"Outputs for %s are not in lockfile. Fetching store paths from nix, this may take a while\n",
+		"Outputs for %s are not in lockfile. Fetching store paths from nix, this may take a while.\n"+
+			"To fix this issue, please run `devbox install --fix-missing-store-paths`\n",
 		p.Raw,
 	)
 

--- a/internal/devpkg/package.go
+++ b/internal/devpkg/package.go
@@ -742,14 +742,16 @@ func (p *Package) GetStorePaths(ctx context.Context, w io.Writer) ([]string, err
 		return storePathsForPackage, err
 	}
 
-	// No fast path, we need to query nix.
-	// TODO we should give people the option to add paths to lockfile.
-	ux.Fwarning(
-		w,
-		"Outputs for %s are not in lockfile. Fetching store paths from nix, this may take a while.\n"+
-			"To fix this issue, please run `devbox install --fix-missing-store-paths`\n",
-		p.Raw,
-	)
+	if p.IsDevboxPackage {
+		// No fast path, we need to query nix.
+		ux.Fwarning(
+			w,
+			"Outputs for %s are not in lockfile. Fetching store paths from nix\n"+
+				"To fix this issue and improve performance, please run "+
+				"`devbox install --fix-missing-store-paths`\n",
+			p.Raw,
+		)
+	}
 
 	installables, err := p.Installables()
 	if err != nil {

--- a/internal/devpkg/package.go
+++ b/internal/devpkg/package.go
@@ -746,9 +746,8 @@ func (p *Package) GetStorePaths(ctx context.Context, w io.Writer) ([]string, err
 		// No fast path, we need to query nix.
 		ux.Fwarning(
 			w,
-			"Outputs for %s are not in lockfile. Fetching store paths from nix\n"+
-				"To fix this issue and improve performance, please run "+
-				"`devbox install --fix-missing-store-paths`\n",
+			"Outputs for %s are not in lockfile. To fix this issue and improve performance, please run "+
+				"`devbox install --tidy-lockfile`\n",
 			p.Raw,
 		)
 	}

--- a/internal/lock/lockfile.go
+++ b/internal/lock/lockfile.go
@@ -14,6 +14,7 @@ import (
 	"github.com/samber/lo"
 	"go.jetpack.io/devbox/internal/cachehash"
 	"go.jetpack.io/devbox/internal/devpkg/pkgtype"
+	"go.jetpack.io/devbox/internal/nix"
 	"go.jetpack.io/devbox/internal/searcher"
 	"go.jetpack.io/pkg/runx/impl/types"
 
@@ -197,6 +198,21 @@ func (f *File) IsUpToDateAndInstalled(isFish bool) (bool, error) {
 		ConfigHash: configHash,
 		IsFish:     isFish,
 	})
+}
+
+func (f *File) SetOutputsForPackage(pkg string, outputs []Output) error {
+	p, err := f.Resolve(pkg)
+	if err != nil {
+		return err
+	}
+	if p.Systems == nil {
+		p.Systems = map[string]*SystemInfo{}
+	}
+	if p.Systems[nix.System()] == nil {
+		p.Systems[nix.System()] = &SystemInfo{}
+	}
+	p.Systems[nix.System()].Outputs = outputs
+	return f.Save()
 }
 
 func (f *File) isDirty() (bool, error) {

--- a/internal/nix/nixprofile/profile.go
+++ b/internal/nix/nixprofile/profile.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/samber/lo"
+	"go.jetpack.io/devbox/internal/debug"
 	"go.jetpack.io/devbox/internal/devpkg"
 	"go.jetpack.io/devbox/internal/lock"
 	"go.jetpack.io/devbox/internal/nix"
@@ -23,6 +24,7 @@ func ProfileListItems(
 	writer io.Writer,
 	profileDir string,
 ) ([]*NixProfileListItem, error) {
+	defer debug.FunctionTimer().End()
 	output, err := nix.ProfileList(writer, profileDir, true /*useJSON*/)
 	if err != nil {
 		// fallback to legacy profile list

--- a/internal/nix/profiles.go
+++ b/internal/nix/profiles.go
@@ -38,6 +38,7 @@ type ProfileInstallArgs struct {
 }
 
 func ProfileInstall(ctx context.Context, args *ProfileInstallArgs) error {
+	defer debug.FunctionTimer().End()
 	if !IsInsecureAllowed() && PackageIsInsecure(args.Installable) {
 		knownVulnerabilities := PackageKnownVulnerabilities(args.Installable)
 		errString := fmt.Sprintf("Package %s is insecure. \n\n", args.Installable)
@@ -78,6 +79,7 @@ func ProfileInstall(ctx context.Context, args *ProfileInstallArgs) error {
 // ProfileRemove removes packages from a profile.
 // WARNING, don't use indexes, they are not supported by nix 2.20+
 func ProfileRemove(profilePath string, packageNames ...string) error {
+	defer debug.FunctionTimer().End()
 	cmd := command(
 		append([]string{
 			"profile", "remove",

--- a/internal/nix/storepath.go
+++ b/internal/nix/storepath.go
@@ -13,23 +13,23 @@ type StorePathParts struct {
 	Hash    string
 	Name    string
 	Version string
+	Output  string
 }
 
 // NewStorePathParts splits a Nix store path into its hash, name and version
 // components in the same way that Nix does.
 //
 // See https://nixos.org/manual/nix/stable/language/builtins.html#builtins-parseDrvName
-//
-// TODO: store paths can also have `-{output}` suffixes, which need to be handled below.
 func NewStorePathParts(path string) StorePathParts {
 	path = strings.TrimPrefix(path, "/nix/store/")
-	// path is now <hash>-<name>-<version
+	// path is now <hash>-<name>-<version>[-output]
 
 	hash, name := path[:32], path[33:]
 	dashIndex := 0
 	for i, r := range name {
 		if dashIndex != 0 && !unicode.IsLetter(r) {
-			return StorePathParts{Hash: hash, Name: name[:dashIndex], Version: name[i:]}
+			version, output, _ := strings.Cut(name[i:], "-")
+			return StorePathParts{Hash: hash, Name: name[:dashIndex], Version: version, Output: output}
 		}
 		dashIndex = 0
 		if r == '-' {

--- a/internal/nix/storepath_test.go
+++ b/internal/nix/storepath_test.go
@@ -35,6 +35,16 @@ func TestStorePathParts(t *testing.T) {
 				Name: "coreutils",
 			},
 		},
+		// With output
+		{
+			storePath: "/nix/store/0z1zq1zq1zq1zq1zq1zq1zq1zq1zq1zq-foo-1.0.0-bar",
+			expected: StorePathParts{
+				Hash:    "0z1zq1zq1zq1zq1zq1zq1zq1zq1zq1zq",
+				Name:    "foo",
+				Version: "1.0.0",
+				Output:  "bar",
+			},
+		},
 	}
 
 	for _, testCase := range testCases {

--- a/internal/ux/messages.go
+++ b/internal/ux/messages.go
@@ -4,6 +4,7 @@
 package ux
 
 import (
+	"context"
 	"fmt"
 	"io"
 
@@ -28,4 +29,25 @@ func Fwarning(w io.Writer, format string, a ...any) {
 func Ferror(w io.Writer, format string, a ...any) {
 	color.New(color.FgHiRed).Fprint(w, "Error: ")
 	fmt.Fprintf(w, format, a...)
+}
+
+// Hidable messages allow the use of context to disable a message. Messages can be hidden
+// by their format string.
+
+type ctxKey string
+
+func HideMessage(ctx context.Context, format string) context.Context {
+	return context.WithValue(ctx, ctxKey(format), true)
+}
+
+func FHidableWarning(ctx context.Context, w io.Writer, format string, a ...any) {
+	if isHidden(ctx, format) {
+		return
+	}
+	Fwarning(w, format, a...)
+}
+
+func isHidden(ctx context.Context, format string) bool {
+	isHidden, _ := ctx.Value(ctxKey(format)).(bool)
+	return isHidden
 }


### PR DESCRIPTION
## Summary

Adds new `--tidy-lockfile` flag that can be used with install. It fills in any missing store paths in lockfile, improving future performance. 

I'm not 100% convinced this works in all cases. My two biggest concerns would be:

* I'm setting all outputs to default.
* re derivation name parsing: Not 100% sure we can rely on versions never having dashes.

## How was it tested?

* unit test
* Manually removed store paths form lockfile and tried to install. Got warning, ran with flag.