### PR TITLE
Only notify users about Venv Activation on setup

### DIFF
--- a/plugins/pip/venvShellHook.sh
+++ b/plugins/pip/venvShellHook.sh
@@ -3,6 +3,6 @@
 if ! [ -d "$VENV_DIR" ]; then
     echo "Creating new venv environment in path: '${VENV_DIR}'"
     python3 -m venv "$VENV_DIR"
+    echo "You can activate the virtual environment by running '. \$VENV_DIR/bin/activate' (for fish shell, replace '.' with 'source')" >&2
 fi
 
-echo "You can activate the virtual environment by running '. \$VENV_DIR/bin/activate' (for fish shell, replace '.' with 'source')" >&2


### PR DESCRIPTION
## Summary

Only prompt the user about activating their Python Virtual Env on setup, and not on every shell activation

## How was it tested?

Build + test on python
