### PR TITLE
Add new --pcflags option to devbox services up

### DIFF
--- a/internal/boxcli/services.go
+++ b/internal/boxcli/services.go
@@ -239,7 +239,7 @@ func startProcessManager(
 		args,
 		devopt.ProcessComposeOpts{
 			Background: flags.background,
-			Flags:      flags.processComposeFlags,
+			ExtraFlags: flags.processComposeFlags,
 		},
 	)
 }

--- a/internal/boxcli/services.go
+++ b/internal/boxcli/services.go
@@ -154,8 +154,6 @@ func startServices(cmd *cobra.Command, services []string, flags servicesCmdFlags
 		Environment: flags.config.environment,
 		Env:         env,
 		Stderr:      cmd.ErrOrStderr(),
-		// TODO: Should we allow these options to be passed here like we do for service up?
-		ProcessComposeOpts: &devopt.ProcessComposeOpts{Background: true},
 	})
 	if err != nil {
 		return errors.WithStack(err)
@@ -205,8 +203,6 @@ func restartServices(
 		Environment: flags.config.environment,
 		Env:         env,
 		Stderr:      cmd.ErrOrStderr(),
-		// TODO: Should we allow these options to be passed here like we do for service up?
-		ProcessComposeOpts: &devopt.ProcessComposeOpts{Background: true},
 	})
 	if err != nil {
 		return errors.WithStack(err)
@@ -225,16 +221,13 @@ func startProcessManager(
 	if err != nil {
 		return err
 	}
+
 	box, err := devbox.Open(&devopt.Opts{
-		Dir:         servicesFlags.config.path,
-		Env:         env,
-		Environment: servicesFlags.config.environment,
-		Stderr:      cmd.ErrOrStderr(),
-		ProcessComposeOpts: &devopt.ProcessComposeOpts{
-			CustomFile: flags.processComposeFile,
-			Flags:      flags.processComposeFlags,
-			Background: flags.background,
-		},
+		Dir:                      servicesFlags.config.path,
+		Env:                      env,
+		Environment:              servicesFlags.config.environment,
+		Stderr:                   cmd.ErrOrStderr(),
+		CustomProcessComposeFile: flags.processComposeFile,
 	})
 	if err != nil {
 		return errors.WithStack(err)
@@ -244,5 +237,9 @@ func startProcessManager(
 		cmd.Context(),
 		servicesFlags.runInCurrentShell,
 		args,
+		devopt.ProcessComposeOpts{
+			Background: flags.background,
+			Flags:      flags.processComposeFlags,
+		},
 	)
 }

--- a/internal/devbox/devbox.go
+++ b/internal/devbox/devbox.go
@@ -746,7 +746,7 @@ func (d *Devbox) StartProcessManager(
 		if processComposeOpts.Background {
 			args = append(args, "--background")
 		}
-		for _, flag := range processComposeOpts.Flags {
+		for _, flag := range processComposeOpts.ExtraFlags {
 			args = append(args, "--pcflags", flag)
 		}
 
@@ -825,7 +825,7 @@ func (d *Devbox) configureProcessCompose(ctx context.Context, processComposeOpts
 	return &services.ProcessComposeOpts{
 		BinPath:    processComposePath,
 		Background: processComposeOpts.Background,
-		Flags:      processComposeOpts.Flags,
+		ExtraFlags: processComposeOpts.ExtraFlags,
 	}, nil
 }
 

--- a/internal/devbox/devopt/devboxopts.go
+++ b/internal/devbox/devopt/devboxopts.go
@@ -9,14 +9,20 @@ import (
 // - omit suffix Opts for other structs that are composed into an Opts struct
 
 type Opts struct {
-	Dir                      string
-	Env                      map[string]string
-	Environment              string
-	PreservePathStack        bool
-	Pure                     bool
-	IgnoreWarnings           bool
-	CustomProcessComposeFile string
-	Stderr                   io.Writer
+	Dir                string
+	Env                map[string]string
+	Environment        string
+	PreservePathStack  bool
+	Pure               bool
+	IgnoreWarnings     bool
+	ProcessComposeOpts *ProcessComposeOpts
+	Stderr             io.Writer
+}
+
+type ProcessComposeOpts struct {
+	CustomFile string
+	Flags      []string
+	Background bool
 }
 
 type GenerateOpts struct {

--- a/internal/devbox/devopt/devboxopts.go
+++ b/internal/devbox/devopt/devboxopts.go
@@ -20,7 +20,7 @@ type Opts struct {
 }
 
 type ProcessComposeOpts struct {
-	Flags      []string
+	ExtraFlags []string
 	Background bool
 }
 

--- a/internal/devbox/devopt/devboxopts.go
+++ b/internal/devbox/devopt/devboxopts.go
@@ -9,18 +9,17 @@ import (
 // - omit suffix Opts for other structs that are composed into an Opts struct
 
 type Opts struct {
-	Dir                string
-	Env                map[string]string
-	Environment        string
-	PreservePathStack  bool
-	Pure               bool
-	IgnoreWarnings     bool
-	ProcessComposeOpts *ProcessComposeOpts
-	Stderr             io.Writer
+	Dir                      string
+	Env                      map[string]string
+	Environment              string
+	PreservePathStack        bool
+	Pure                     bool
+	IgnoreWarnings           bool
+	CustomProcessComposeFile string
+	Stderr                   io.Writer
 }
 
 type ProcessComposeOpts struct {
-	CustomFile string
 	Flags      []string
 	Background bool
 }

--- a/internal/services/manager.go
+++ b/internal/services/manager.go
@@ -154,11 +154,10 @@ func StartProcessManager(
 		flags = append(flags, "-f", s.ProcessComposePath)
 	}
 
-	if len(processComposeConfig.Flags) > 0 {
-		flags = append(flags, processComposeConfig.Flags...)
-	}
+	flags = append(flags, processComposeConfig.Flags...)
 
 	if processComposeConfig.Background {
+		flags = append(flags, "-t=false")
 		cmd := exec.Command(processComposeConfig.BinPath, flags...)
 		return runProcessManagerInBackground(cmd, config, port, projectDir)
 	}

--- a/internal/services/manager.go
+++ b/internal/services/manager.go
@@ -42,7 +42,7 @@ type globalProcessComposeConfig struct {
 
 type ProcessComposeOpts struct {
 	BinPath    string
-	Flags      []string
+	ExtraFlags []string
 	Background bool
 }
 
@@ -154,7 +154,7 @@ func StartProcessManager(
 		flags = append(flags, "-f", s.ProcessComposePath)
 	}
 
-	flags = append(flags, processComposeConfig.Flags...)
+	flags = append(flags, processComposeConfig.ExtraFlags...)
 
 	if processComposeConfig.Background {
 		flags = append(flags, "-t=false")

--- a/internal/services/manager.go
+++ b/internal/services/manager.go
@@ -40,6 +40,12 @@ type globalProcessComposeConfig struct {
 	File      *os.File `json:"-"`
 }
 
+type ProcessComposeOpts struct {
+	BinPath    string
+	Flags      []string
+	Background bool
+}
+
 func newGlobalProcessComposeConfig() *globalProcessComposeConfig {
 	return &globalProcessComposeConfig{Instances: map[string]instance{}}
 }
@@ -98,13 +104,11 @@ func openGlobalConfigFile() (*os.File, error) {
 }
 
 func StartProcessManager(
-	ctx context.Context,
 	w io.Writer,
 	requestedServices []string,
 	availableServices Services,
 	projectDir string,
-	processComposeBinPath string,
-	processComposeBackground bool,
+	processComposeConfig ProcessComposeOpts,
 ) error {
 	// Check if process-compose is already running
 	if ProcessManagerIsRunning(projectDir) {
@@ -150,13 +154,16 @@ func StartProcessManager(
 		flags = append(flags, "-f", s.ProcessComposePath)
 	}
 
-	if processComposeBackground {
-		flags = append(flags, "-t=false")
-		cmd := exec.Command(processComposeBinPath, flags...)
+	if len(processComposeConfig.Flags) > 0 {
+		flags = append(flags, processComposeConfig.Flags...)
+	}
+
+	if processComposeConfig.Background {
+		cmd := exec.Command(processComposeConfig.BinPath, flags...)
 		return runProcessManagerInBackground(cmd, config, port, projectDir)
 	}
 
-	cmd := exec.Command(processComposeBinPath, flags...)
+	cmd := exec.Command(processComposeConfig.BinPath, flags...)
 	return runProcessManagerInForeground(cmd, config, port, projectDir, w)
 }
 


### PR DESCRIPTION
## Summary
Add new `--pcflags` option which provides flags directly to process-compose
## Motivation
https://github.com/jetify-com/devbox/issues/2105
## Usage
The `--pcflags` flag must be provided in front of each flag as shown below:
```
devbox services up ${service} \
--pcflags ${flag1} \
--pcflags ${flag2} \
...
```
## How was it tested?
1. Added debugging print statement in `manager.go`, right before providing the flags to process-compose, to ensure that the flags are being passed down as expected to process-compose.
2. Verified that `devbox services up nginx` shows the process-compose UI but `devbox serviecs up nginx --pcflags -t=false` does not show the UI.