### PR TITLE
internal/nix: improve command error handling

### DIFF
--- a/internal/nix/cache.go
+++ b/internal/nix/cache.go
@@ -18,8 +18,7 @@ func CopyInstallableToCache(
 	env []string,
 ) error {
 	fmt.Fprintf(out, "Copying %s to %s\n", installable, to)
-	cmd := commandContext(
-		ctx,
+	cmd := command(
 		"copy", "--to", to,
 		// --impure makes NIXPKGS_ALLOW_* environment variables work.
 		"--impure",
@@ -35,5 +34,5 @@ func CopyInstallableToCache(
 	cmd.Stderr = out
 	cmd.Env = append(allowUnfreeEnv(allowInsecureEnv(os.Environ())), env...)
 
-	return cmd.Run()
+	return cmd.Run(ctx)
 }

--- a/internal/nix/command.go
+++ b/internal/nix/command.go
@@ -1,18 +1,256 @@
 package nix
 
 import (
+	"bytes"
 	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
 	"os/exec"
+	"slices"
+	"strconv"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
 )
 
-func command(args ...string) *exec.Cmd {
-	return commandContext(context.Background(), args...)
+type cmd struct {
+	Args cmdArgs
+	Env  []string
+
+	Stdin  io.Reader
+	Stdout io.Writer
+	Stderr io.Writer
+
+	execCmd     *exec.Cmd
+	execCmdOnce sync.Once
 }
 
-func commandContext(ctx context.Context, args ...string) *exec.Cmd {
-	cmd := exec.CommandContext(ctx, "nix", args...)
-	cmd.Args = append(cmd.Args, ExperimentalFlags()...)
+func command(args ...any) *cmd {
+	cmd := &cmd{
+		Args: append(cmdArgs{
+			"nix",
+			"--extra-experimental-features", "ca-derivations",
+			"--option", "experimental-features", "nix-command flakes fetch-closure",
+		}, args...),
+	}
 	return cmd
+}
+
+func (c *cmd) CombinedOutput(ctx context.Context) ([]byte, error) {
+	out, err := c.initExecCommand(ctx).CombinedOutput()
+	return out, c.error(ctx, err)
+}
+
+func (c *cmd) Output(ctx context.Context) ([]byte, error) {
+	out, err := c.initExecCommand(ctx).Output()
+	return out, c.error(ctx, err)
+}
+
+func (c *cmd) Run(ctx context.Context) error {
+	return c.error(ctx, c.initExecCommand(ctx).Run())
+}
+
+func (c *cmd) String() string {
+	return c.Args.String()
+}
+
+func (c *cmd) initExecCommand(ctx context.Context) *exec.Cmd {
+	c.execCmdOnce.Do(func() {
+		args := c.Args.StringSlice()
+		c.execCmd = exec.CommandContext(ctx, args[0], args[1:]...)
+		c.execCmd.Env = c.Env
+		c.execCmd.Stdin = c.Stdin
+		c.execCmd.Stdout = c.Stdout
+		c.execCmd.Stderr = c.Stderr
+
+		c.execCmd.Cancel = func() error {
+			// Try to let Nix exit gracefully by sending an
+			// interrupt instead of the default behavior of killing
+			// it.
+			err := c.execCmd.Process.Signal(os.Interrupt)
+			if errors.Is(err, os.ErrProcessDone) {
+				// Nix already exited; execCmd.Wait will use the
+				// exit code.
+				return err
+			}
+			if err != nil {
+				// We failed to send SIGINT, so kill the process
+				// instead.
+				//
+				// - If Nix already exited, Kill will return
+				//   os.ErrProcessDone and execCmd.Wait will use
+				//   the exit code.
+				// - Otherwise, execCmd.Wait will always return
+				//   an error.
+				return c.execCmd.Process.Kill()
+			}
+
+			// We sent the SIGINT successfully. It's still possible
+			// for Nix to exit successfully, so return
+			// os.ErrProcessDone so that execCmd.Wait uses the exit
+			// code instead of ctx.Err.
+			return os.ErrProcessDone
+		}
+		// Kill Nix if it doesn't exit within 15 seconds of Devbox
+		// sending an interrupt.
+		c.execCmd.WaitDelay = 15 * time.Second
+	})
+	return c.execCmd
+}
+
+func (c *cmd) error(ctx context.Context, err error) error {
+	if err == nil {
+		return nil
+	}
+
+	cmdErr := &cmdError{err: err}
+	if errors.Is(err, exec.ErrNotFound) {
+		cmdErr.msg = fmt.Sprintf("nix: %s not found in $PATH", c.Args[0])
+	}
+
+	switch {
+	case errors.Is(ctx.Err(), context.Canceled):
+		cmdErr.msg = "nix: command canceled"
+	case errors.Is(ctx.Err(), context.DeadlineExceeded):
+		cmdErr.msg = "nix: command timed out"
+	default:
+		cmdErr.msg = "nix: command error"
+	}
+	cmdErr.msg += ": " + c.String()
+
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		if stderr := c.stderrExcerpt(exitErr.Stderr); len(stderr) != 0 {
+			cmdErr.msg += ": " + stderr
+		}
+		if exitErr.Exited() {
+			cmdErr.msg += fmt.Sprintf(": exit code %d", exitErr.ExitCode())
+			return cmdErr
+		}
+		if stat, ok := exitErr.Sys().(syscall.WaitStatus); ok && stat.Signaled() {
+			cmdErr.msg += fmt.Sprintf(": exit due to signal %d (%[1]s)", stat.Signal())
+			return cmdErr
+		}
+	}
+
+	if !errors.Is(err, ctx.Err()) {
+		cmdErr.msg += ": " + err.Error()
+	}
+	return cmdErr
+}
+
+func (*cmd) stderrExcerpt(stderr []byte) string {
+	stderr = bytes.TrimSpace(stderr)
+	if len(stderr) == 0 {
+		return ""
+	}
+
+	lines := bytes.Split(stderr, []byte("\n"))
+	slices.Reverse(lines)
+	for _, line := range lines {
+		line = bytes.TrimSpace(line)
+		after, found := bytes.CutPrefix(line, []byte("error: "))
+		if !found {
+			continue
+		}
+		after = bytes.TrimSpace(after)
+		if len(after) == 0 {
+			continue
+		}
+		stderr = after
+		break
+
+	}
+
+	excerpt := string(stderr)
+	if !strconv.CanBackquote(excerpt) {
+		quoted := strconv.Quote(excerpt)
+		excerpt = quoted[1 : len(quoted)-1]
+	}
+	return excerpt
+}
+
+type cmdArgs []any
+
+func appendArgs[E any](args cmdArgs, new []E) cmdArgs {
+	for _, elem := range new {
+		args = append(args, elem)
+	}
+	return args
+}
+
+func (c cmdArgs) StringSlice() []string {
+	s := make([]string, len(c))
+	for i := range c {
+		s[i] = fmt.Sprint(c[i])
+	}
+	return s
+}
+
+func (c cmdArgs) String() string {
+	if len(c) == 0 {
+		return ""
+	}
+
+	sb := &strings.Builder{}
+	c.writeQuoted(sb, fmt.Sprint(c[0]))
+	if len(c) == 1 {
+		return sb.String()
+	}
+
+	for _, arg := range c[1:] {
+		sb.WriteByte(' ')
+		c.writeQuoted(sb, fmt.Sprint(arg))
+	}
+	return sb.String()
+}
+
+func (cmdArgs) writeQuoted(dst *strings.Builder, str string) {
+	needsQuote := strings.ContainsAny(str, ";\"'()$|&><` \t\r\n\\#{~*?[=")
+	if !needsQuote {
+		dst.WriteString(str)
+		return
+	}
+
+	canSingleQuote := !strings.Contains(str, "'")
+	if canSingleQuote {
+		dst.WriteByte('\'')
+		dst.WriteString(str)
+		dst.WriteByte('\'')
+		return
+	}
+
+	dst.WriteByte('"')
+	for _, r := range str {
+		switch r {
+		// Special characters inside double quotes:
+		// https://pubs.opengroup.org/onlinepubs/009604499/utilities/xcu_chap02.html#tag_02_02_03
+		case '$', '`', '"', '\\':
+			dst.WriteRune('\\')
+		}
+		dst.WriteRune(r)
+	}
+	dst.WriteByte('"')
+}
+
+type cmdError struct {
+	msg string
+	err error
+}
+
+func (c *cmdError) Redact() string {
+	return c.Error()
+}
+
+func (c *cmdError) Error() string {
+	return c.msg
+}
+
+func (c *cmdError) Unwrap() error {
+	return c.err
 }
 
 func allowUnfreeEnv(curEnv []string) []string {

--- a/internal/nix/config.go
+++ b/internal/nix/config.go
@@ -37,8 +37,8 @@ type ConfigField[T any] struct {
 func CurrentConfig(ctx context.Context) (Config, error) {
 	// `nix show-config` is deprecated in favor of `nix config show`, but we
 	// want to remain compatible with older Nix versions.
-	cmd := commandContext(ctx, "show-config", "--json")
-	out, err := cmd.Output()
+	cmd := command("show-config", "--json")
+	out, err := cmd.Output(ctx)
 	var exitErr *exec.ExitError
 	if errors.As(err, &exitErr) && len(exitErr.Stderr) != 0 {
 		return Config{}, redact.Errorf("command %s: %v: %s", redact.Safe(cmd), err, exitErr.Stderr)

--- a/internal/nix/eval.go
+++ b/internal/nix/eval.go
@@ -1,6 +1,7 @@
 package nix
 
 import (
+	"context"
 	"encoding/json"
 	"os"
 	"strconv"
@@ -8,7 +9,7 @@ import (
 
 func EvalPackageName(path string) (string, error) {
 	cmd := command("eval", "--raw", path+".name")
-	out, err := cmd.Output()
+	out, err := cmd.Output(context.TODO())
 	if err != nil {
 		return "", err
 	}
@@ -18,7 +19,7 @@ func EvalPackageName(path string) (string, error) {
 // PackageIsInsecure is a fun little nix eval that maybe works.
 func PackageIsInsecure(path string) bool {
 	cmd := command("eval", path+".meta.insecure")
-	out, err := cmd.Output()
+	out, err := cmd.Output(context.TODO())
 	if err != nil {
 		// We can't know for sure, but probably not.
 		return false
@@ -33,7 +34,7 @@ func PackageIsInsecure(path string) bool {
 
 func PackageKnownVulnerabilities(path string) []string {
 	cmd := command("eval", path+".meta.knownVulnerabilities")
-	out, err := cmd.Output()
+	out, err := cmd.Output(context.TODO())
 	if err != nil {
 		// We can't know for sure, but probably not.
 		return nil
@@ -51,7 +52,7 @@ func PackageKnownVulnerabilities(path string) []string {
 // to determine if a package if a package can be installed in system.
 func Eval(path string) ([]byte, error) {
 	cmd := command("eval", "--raw", path)
-	return cmd.CombinedOutput()
+	return cmd.CombinedOutput(context.TODO())
 }
 
 func AllowInsecurePackages() {

--- a/internal/nix/nixpkgs.go
+++ b/internal/nix/nixpkgs.go
@@ -4,12 +4,12 @@
 package nix
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
 	"io/fs"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -38,17 +38,16 @@ func EnsureNixpkgsPrefetched(w io.Writer, commit string) error {
 	}
 
 	fmt.Fprintf(w, "Ensuring nixpkgs registry is downloaded.\n")
-	cmd := exec.Command(
-		"nix", "flake", "prefetch",
+	cmd := command(
+		"flake", "prefetch",
 		FlakeNixpkgs(commit),
 	)
-	cmd.Args = append(cmd.Args, ExperimentalFlags()...)
 	cmd.Stdout = w
 	cmd.Stderr = cmd.Stdout
-	if err := cmd.Run(); err != nil {
+	if err := cmd.Run(context.TODO()); err != nil {
 		fmt.Fprintf(w, "Ensuring nixpkgs registry is downloaded: ")
 		color.New(color.FgRed).Fprintf(w, "Fail\n")
-		return errors.Wrapf(err, "Command: %s", cmd)
+		return err
 	}
 	fmt.Fprintf(w, "Ensuring nixpkgs registry is downloaded: ")
 	color.New(color.FgGreen).Fprintf(w, "Success\n")
@@ -73,11 +72,10 @@ func nixpkgsCommitFileContents() (map[string]string, error) {
 
 func saveToNixpkgsCommitFile(commit string, commitToLocation map[string]string) error {
 	// Make a query to get the /nix/store path for this commit hash.
-	cmd := exec.Command("nix", "flake", "prefetch", "--json",
+	cmd := command("flake", "prefetch", "--json",
 		FlakeNixpkgs(commit),
 	)
-	cmd.Args = append(cmd.Args, ExperimentalFlags()...)
-	out, err := cmd.Output()
+	out, err := cmd.Output(context.TODO())
 	if err != nil {
 		return errors.WithStack(err)
 	}

--- a/internal/nix/search.go
+++ b/internal/nix/search.go
@@ -1,10 +1,10 @@
 package nix
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
-	"os/exec"
 	"regexp"
 	"strings"
 	"time"
@@ -99,18 +99,13 @@ func searchSystem(url, system string) (map[string]*Info, error) {
 	}
 
 	// The `^` is added to indicate we want to show all packages
-	cmd := exec.Command("nix", "search", url, "^" /*regex*/, "--json")
-	cmd.Args = append(cmd.Args, ExperimentalFlags()...)
+	cmd := command("search", url, "^" /*regex*/, "--json")
 	if system != "" {
 		cmd.Args = append(cmd.Args, "--system", system)
 	}
 	debug.Log("running command: %s\n", cmd)
-	out, err := cmd.Output()
+	out, err := cmd.Output(context.TODO())
 	if err != nil {
-		if exitErr := (&exec.ExitError{}); errors.As(err, &exitErr) {
-			err = fmt.Errorf("nix search exit code: %d, stderr: %s, original error: %w", exitErr.ExitCode(), exitErr.Stderr, err)
-		}
-
 		// for now, assume all errors are invalid packages.
 		// TODO: check the error string for "did not find attribute" and
 		// return ErrPackageNotFound only for that case.

--- a/internal/nix/upgrade.go
+++ b/internal/nix/upgrade.go
@@ -4,26 +4,18 @@
 package nix
 
 import (
+	"context"
 	"os"
-	"os/exec"
 
-	"go.jetpack.io/devbox/internal/redact"
 	"go.jetpack.io/devbox/internal/ux"
 )
 
 func ProfileUpgrade(ProfileDir, indexOrName string) error {
-	cmd := command(
+	return command(
 		"profile", "upgrade",
 		"--profile", ProfileDir,
 		indexOrName,
-	)
-	out, err := cmd.CombinedOutput()
-	if err != nil {
-		return redact.Errorf(
-			"error running \"nix profile upgrade\": %s: %w", out, err,
-		)
-	}
-	return nil
+	).Run(context.TODO())
 }
 
 func FlakeUpdate(ProfileDir string) error {
@@ -32,16 +24,10 @@ func FlakeUpdate(ProfileDir string) error {
 		return err
 	}
 	ux.Finfo(os.Stderr, "Running \"nix flake update\"\n")
-	cmd := exec.Command("nix", "flake", "update")
+	cmd := command("flake", "update")
 	if version.AtLeast(Version2_19) {
 		cmd.Args = append(cmd.Args, "--flake")
 	}
 	cmd.Args = append(cmd.Args, ProfileDir)
-	cmd.Args = append(cmd.Args, ExperimentalFlags()...)
-	out, err := cmd.CombinedOutput()
-	if err != nil {
-		return redact.Errorf(
-			"error running \"nix flake update\": %s: %w", out, err)
-	}
-	return nil
+	return cmd.Run(context.TODO())
 }


### PR DESCRIPTION
Add a new `cmd` type that wraps `exec.Cmd` and provides better error handling when a Nix command fails.

Calls to `commandContext`, `exec.Command` and `exec.CommandContext` are consolidated into the `command` function, which now returns a `*cmd` instead of an `*exec.Cmd`. The `cmd.Run` and related methods return an error that provides more detail about the command in the following format:

	nix: command ("error"|"canceled"|"timed out"): <shell command>: <stderr>: <exec error>

The shell command in the error is a properly-escaped shell string that can be copy/pasted to re-run the command.

If Nix prints a line with the prefix "error: " to stderr, then the error will include that line in its message. If there are multiple lines with that prefix, it only includes the last one. Otherwise, it will include `exec.ExitError.Stderr` with control characters escaped.

When the command exits on its own, the error includes the exit code. If a signal (either from Devbox or the system) terminates the command, the error includes the signal name instead of a -1 exit code.

Below are some examples of how errors will look in logs and Sentry.

Missing package:

> nix: command error: nix --extra-experimental-features ca-derivations --option experimental-features 'nix-command flakes fetch-closure' search 'flake:nixpkgs#torpalorp' ^ --json: flake 'flake:nixpkgs' does not provide attribute 'packages.aarch64-darwin.torpalorp', 'legacyPackages.aarch64-darwin.torpalorp' or 'torpalorp': exit code 1

Bad flake reference:

> nix --extra-experimental-features ca-derivations --option experimental-features 'nix-command flakes fetch-closure' path-info github:blah/thisisnotarepo --json --impure: unable to download 'https://api.github.com/repos/blah/thisisnotarepo/commits/HEAD': HTTP error 404: exit code 1

Killed process:

> nix: command error: nix --extra-experimental-features ca-derivations --option experimental-features 'nix-command flakes fetch-closure' build --impure --no-link /nix/store/vz0f0ydykljjji91a94sq8jskh3lpl4h-rustc-wrapper-1.77.2 /nix/store/0r6hm57fmlzhngn76v7vh7vzfp7qrsq8-rustc-wrapper-1.77.2-man: exit due to signal 9 (killed)