### PR TITLE
all: use log/slog for debug logs

### DIFF
--- a/internal/boxcli/featureflag/feature.go
+++ b/internal/boxcli/featureflag/feature.go
@@ -4,12 +4,12 @@
 package featureflag
 
 import (
+	"log/slog"
 	"os"
 	"strconv"
 	"testing"
 
 	"go.jetpack.io/devbox/internal/build"
-	"go.jetpack.io/devbox/internal/debug"
 	"go.jetpack.io/devbox/internal/envir"
 )
 
@@ -54,7 +54,7 @@ func (f *feature) Enabled() bool {
 			status = "disabled"
 		}
 		if !logMap[f.name] {
-			debug.Log("Feature %q %s via environment variable.", f.name, status)
+			slog.Debug("Feature %q %s via environment variable.", f.name, status)
 			logMap[f.name] = true
 		}
 		return on

--- a/internal/boxcli/midcobra/debug.go
+++ b/internal/boxcli/midcobra/debug.go
@@ -5,6 +5,7 @@ package midcobra
 
 import (
 	"errors"
+	"log/slog"
 	"os/exec"
 	"strconv"
 
@@ -64,7 +65,7 @@ func (d *DebugMiddleware) postRun(cmd *cobra.Command, args []string, runErr erro
 	st := debug.EarliestStackTrace(runErr)
 	var exitErr *exec.ExitError
 	if errors.As(runErr, &exitErr) {
-		debug.Log("Command stderr: %s\n", exitErr.Stderr)
+		slog.Error("command error", "stderr", exitErr.Stderr, "execid", telemetry.ExecutionID, "stack", st)
 	}
-	debug.Log("\nExecutionID:%s\n%+v\n", telemetry.ExecutionID, st)
+	slog.Error("command error", "execid", telemetry.ExecutionID, "stack", st)
 }

--- a/internal/boxcli/run.go
+++ b/internal/boxcli/run.go
@@ -5,6 +5,7 @@ package boxcli
 
 import (
 	"fmt"
+	"log/slog"
 	"slices"
 	"strings"
 
@@ -13,7 +14,6 @@ import (
 	"github.com/spf13/pflag"
 
 	"go.jetpack.io/devbox/internal/boxcli/usererr"
-	"go.jetpack.io/devbox/internal/debug"
 	"go.jetpack.io/devbox/internal/devbox"
 	"go.jetpack.io/devbox/internal/devbox/devopt"
 	"go.jetpack.io/devbox/internal/redact"
@@ -65,7 +65,7 @@ func listScripts(cmd *cobra.Command, flags runCmdFlags) []string {
 		IgnoreWarnings: true,
 	})
 	if err != nil {
-		debug.Log("failed to open devbox: %v", err)
+		slog.Error("failed to open devbox", "err", err)
 		return nil
 	}
 
@@ -90,8 +90,7 @@ func runScriptCmd(cmd *cobra.Command, args []string, flags runCmdFlags) error {
 	if err != nil {
 		return redact.Errorf("error parsing script arguments: %w", err)
 	}
-	debug.Log("script: %s", script)
-	debug.Log("script args: %v", scriptArgs)
+	slog.Debug("run script", "script", script, "args", scriptArgs)
 
 	env, err := flags.Env(path)
 	if err != nil {

--- a/internal/boxcli/secrets.go
+++ b/internal/boxcli/secrets.go
@@ -180,9 +180,6 @@ func secretsDownloadCmd(commonFlags *secretsFlags) *cobra.Command {
 			if err != nil {
 				return errors.WithStack(err)
 			}
-			if err != nil {
-				return errors.WithStack(err)
-			}
 			absPaths, err := fileutil.EnsureAbsolutePaths(args)
 			if err != nil {
 				return errors.WithStack(err)
@@ -208,9 +205,6 @@ func secretsUploadCmd(commonFlags *secretsFlags) *cobra.Command {
 		},
 		RunE: func(cmd *cobra.Command, paths []string) error {
 			secrets, err := commonFlags.envsec(cmd)
-			if err != nil {
-				return errors.WithStack(err)
-			}
 			if err != nil {
 				return errors.WithStack(err)
 			}

--- a/internal/cloud/mutagen/install.go
+++ b/internal/cloud/mutagen/install.go
@@ -5,13 +5,13 @@ package mutagen
 
 import (
 	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"runtime"
 
 	"github.com/cavaliergopher/grab/v3"
 
-	"go.jetpack.io/devbox/internal/debug"
 	"go.jetpack.io/devbox/internal/fileutil"
 )
 
@@ -31,7 +31,7 @@ func InstallMutagenOnce(binPath string) error {
 }
 
 func Install(url, installDir string) error {
-	debug.Log("installing mutagen from %s to %s", url, installDir)
+	slog.Debug("installing mutagen from %s to %s", url, installDir)
 	err := os.MkdirAll(installDir, 0o755)
 	if err != nil {
 		return err

--- a/internal/cloud/mutagen/wrapper.go
+++ b/internal/cloud/mutagen/wrapper.go
@@ -7,13 +7,13 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"os"
 	"os/exec"
 	"strings"
 
 	"github.com/pkg/errors"
 
-	"go.jetpack.io/devbox/internal/debug"
 	"go.jetpack.io/devbox/internal/xdg"
 )
 
@@ -73,7 +73,7 @@ func List(envVars map[string]string, names ...string) ([]Session, error) {
 	debugPrintExecCmd(cmd)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
-		debug.Log("List error: %s, and out: %s", err, string(out))
+		slog.Debug("list error", "err", err, "out", string(out))
 		if e := (&exec.ExitError{}); errors.As(err, &e) {
 			errMsg := strings.TrimSpace(string(out))
 			// Special handle the case where no sessions are found:
@@ -151,11 +151,11 @@ func execMutagenOut(args []string, envVars map[string]string) ([]byte, error) {
 	debugPrintExecCmd(cmd)
 
 	if err := cmd.Run(); err != nil {
-		debug.Log(
-			"execMutagen error: %s, stdout: %s, stderr: %s",
-			err,
-			stdout.String(),
-			stderr.String(),
+		slog.Debug(
+			"execMutagen error",
+			"err", err,
+			"stdout", stdout.String(),
+			"stderr", stderr.String(),
 		)
 		if e := (&exec.ExitError{}); errors.As(err, &e) {
 			return nil, errors.New(strings.TrimSpace(stderr.String()))
@@ -163,7 +163,7 @@ func execMutagenOut(args []string, envVars map[string]string) ([]byte, error) {
 		return nil, err
 	}
 
-	debug.Log("execMutagen worked for cmd: %s", cmd)
+	slog.Debug("execMutagen worked for cmd", "cmd", cmd)
 	return stdout.Bytes(), nil
 }
 
@@ -175,7 +175,7 @@ func debugPrintExecCmd(cmd *exec.Cmd) {
 			envPrint = fmt.Sprintf("%s, %s", envPrint, cmdEnv)
 		}
 	}
-	debug.Log("running mutagen cmd %s with MUTAGEN env: %s", cmd.String(), envPrint)
+	slog.Debug("running mutagen cmd %s with MUTAGEN env: %s", cmd.String(), envPrint)
 }
 
 // envAsKeyValueStrings prepares the env-vars in key=value format to add to the command to be run

--- a/internal/cloud/openssh/sshshim/command.go
+++ b/internal/cloud/openssh/sshshim/command.go
@@ -6,6 +6,7 @@ package sshshim
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"os"
 
 	"go.jetpack.io/devbox/internal/debug"
@@ -26,11 +27,11 @@ func Execute(ctx context.Context, args []string) int {
 
 func execute(ctx context.Context, args []string) error {
 	EnableDebug() // Always enable for now.
-	debug.Log("os.Args: %v", args)
+	slog.Debug("sshshim.execute", "args", args)
 
 	alive, err := EnsureLiveVMOrTerminateMutagenSessions(ctx, args[1:])
 	if err != nil {
-		debug.Log("ensureLiveVMOrTerminateMutagenSessions error: %v", err)
+		slog.Error("ensureLiveVMOrTerminateMutagenSessions error", "err", err)
 		fmt.Fprintf(os.Stderr, "%v", err)
 		return err
 	}
@@ -39,7 +40,7 @@ func execute(ctx context.Context, args []string) error {
 	}
 
 	if err := InvokeSSHOrSCPCommand(args); err != nil {
-		debug.Log("InvokeSSHorSCPCommand error: %v", err)
+		slog.Debug("InvokeSSHorSCPCommand error", "err", err)
 		fmt.Fprintf(os.Stderr, "%v", err)
 		return err
 	}

--- a/internal/cloud/openssh/sshshim/invoke.go
+++ b/internal/cloud/openssh/sshshim/invoke.go
@@ -4,14 +4,13 @@
 package sshshim
 
 import (
+	"log/slog"
 	"os"
 	"os/exec"
 	"strings"
 	"syscall"
 
 	"github.com/pkg/errors"
-
-	"go.jetpack.io/devbox/internal/debug"
 )
 
 func InvokeSSHOrSCPCommand(args []string) error {
@@ -39,7 +38,7 @@ func InvokeSSHOrSCPCommand(args []string) error {
 	//       strings (i.e., argv[0]) should contain the filename associated
 	//       with the file being executed.
 	args[0] = executablePath
-	debug.Log("invoking %s with args: %v", args[0], args)
+	slog.Debug("invoking %s with args: %v", args[0], args)
 
 	// Choose syscall.Exec instead of exec.Cmd so that we preserve the exit code
 	// and environment, and the current process is replaced by ssh.

--- a/internal/cloud/openssh/sshshim/logger.go
+++ b/internal/cloud/openssh/sshshim/logger.go
@@ -9,6 +9,7 @@ package sshshim
 import (
 	"fmt"
 	"io"
+	"log/slog"
 	"os"
 	"path/filepath"
 
@@ -29,7 +30,7 @@ func EnableDebug() {
 		fmt.Fprintf(os.Stderr, "failed to init ssh log file: %s", err)
 	}
 	debug.Enable()
-	debug.Log("started sshshim\n")
+	slog.Debug("started sshshim\n")
 }
 
 // logFile captures output for logging and when there is a failure

--- a/internal/devbox/dir.go
+++ b/internal/devbox/dir.go
@@ -4,12 +4,12 @@
 package devbox
 
 import (
+	"log/slog"
 	"os"
 	"path/filepath"
 
 	"github.com/pkg/errors"
 	"go.jetpack.io/devbox/internal/boxcli/usererr"
-	"go.jetpack.io/devbox/internal/debug"
 	"go.jetpack.io/devbox/internal/devconfig/configfile"
 	"go.jetpack.io/devbox/internal/fileutil"
 )
@@ -19,7 +19,7 @@ import (
 //
 // If it doesn't find any devbox.json, then an error is returned.
 func findProjectDir(path string) (string, error) {
-	debug.Log("findProjectDir: path is %s\n", path)
+	slog.Debug("finding devbox config", "path", path)
 
 	// Sanitize the directory and use the absolute path as canonical form
 	absPath, err := filepath.Abs(path)
@@ -63,7 +63,7 @@ func findProjectDirFromParentDirSearch(
 	cur := absPath
 	// Search parent directories for a devbox.json
 	for cur != root {
-		debug.Log("finding devbox config in dir: %s\n", cur)
+		slog.Debug("finding devbox config", "dir", cur)
 		if configExistsIn(cur) {
 			return cur, nil
 		}

--- a/internal/devbox/generate/devcontainer_util.go
+++ b/internal/devbox/generate/devcontainer_util.go
@@ -12,6 +12,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -21,7 +22,6 @@ import (
 
 	"github.com/samber/lo"
 	"go.jetpack.io/devbox/internal/boxcli/usererr"
-	"go.jetpack.io/devbox/internal/debug"
 	"go.jetpack.io/devbox/internal/devbox/devopt"
 )
 
@@ -199,7 +199,7 @@ func (g *Options) getDevcontainerContent() *devcontainerObject {
 	// match only python3 or python3xx as package names
 	py3pattern, err := regexp.Compile(`(python3)$|(python3[0-9]{1,2})$`)
 	if err != nil {
-		debug.Log("Failed to compile regex")
+		slog.Debug("Failed to compile regex")
 		return nil
 	}
 	for _, pkg := range g.Pkgs {

--- a/internal/devbox/nixprofile.go
+++ b/internal/devbox/nixprofile.go
@@ -3,6 +3,7 @@ package devbox
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"strings"
 
 	"github.com/samber/lo"
@@ -54,7 +55,7 @@ func (d *Devbox) syncNixProfileFromFlake(ctx context.Context) error {
 			storePath := nix.NewStorePathParts(p)
 			packagesToRemove = append(packagesToRemove, fmt.Sprintf("%s@%s", storePath.Name, storePath.Version))
 		}
-		debug.Log("Removing packages from nix profile: %s\n", strings.Join(packagesToRemove, ", "))
+		slog.Debug("removing packages from nix profile", "pkgs", strings.Join(packagesToRemove, ", "))
 
 		if err := nix.ProfileRemove(profilePath, remove...); err != nil {
 			return err

--- a/internal/devbox/packages.go
+++ b/internal/devbox/packages.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"runtime/trace"
@@ -353,7 +354,7 @@ func (d *Devbox) profilePath() (string, error) {
 	absPath := filepath.Join(d.projectDir, nix.ProfilePath)
 
 	if err := resetProfileDirForFlakes(absPath); err != nil {
-		debug.Log("ERROR: resetProfileDirForFlakes error: %v\n", err)
+		slog.Error("resetProfileDirForFlakes error", "err", err)
 	}
 
 	return absPath, errors.WithStack(os.MkdirAll(filepath.Dir(absPath), 0o755))
@@ -519,7 +520,7 @@ func (d *Devbox) appendExtraSubstituters(ctx context.Context, args *nix.BuildArg
 
 	caches, err := nixcache.CachedReadCaches(ctx)
 	if err != nil {
-		debug.Log("error getting list of caches from the Jetify API, assuming the user doesn't have access to any: %v", err)
+		slog.Error("error getting list of caches from the Jetify API, assuming the user doesn't have access to any", "err", err)
 		return nil
 	}
 	if len(caches) == 0 {
@@ -528,7 +529,7 @@ func (d *Devbox) appendExtraSubstituters(ctx context.Context, args *nix.BuildArg
 
 	err = nixcache.Configure(ctx)
 	if errors.Is(err, setup.ErrAlreadyRefused) {
-		debug.Log("user previously refused to configure nix cache, not re-prompting")
+		slog.Debug("user previously refused to configure nix cache, not re-prompting")
 		return nil
 	}
 	if errors.Is(err, setup.ErrUserRefused) {
@@ -543,7 +544,7 @@ func (d *Devbox) appendExtraSubstituters(ctx context.Context, args *nix.BuildArg
 	// Other errors indicate we couldn't update nix.conf, so just warn and
 	// continue by building from source if necessary.
 	if err != nil {
-		debug.Log("error configuring nix cache: %v", err)
+		slog.Error("error configuring nix cache", "err", err)
 		ux.Fwarning(d.stderr, "Devbox was unable to configure Nix to use the Jetify Nix cache. Some packages might be built from source.\n")
 		return nil
 	}

--- a/internal/devbox/update_test.go
+++ b/internal/devbox/update_test.go
@@ -195,7 +195,7 @@ func TestUpdateOtherSysInfoIsReplaced(t *testing.T) {
 	require.Equal(t, "store_path2", lockfile.Packages[raw].Systems[sys2].Outputs[0].Path)
 }
 
-func currentSystem(_t *testing.T) string {
+func currentSystem(*testing.T) string {
 	sys := nix.System() // NOTE: we could mock this too, if it helps.
 	return sys
 }

--- a/internal/lock/resolve.go
+++ b/internal/lock/resolve.go
@@ -6,6 +6,7 @@ package lock
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"sync"
 	"time"
 
@@ -13,7 +14,6 @@ import (
 	"github.com/samber/lo"
 	"go.jetpack.io/devbox/internal/boxcli/featureflag"
 	"go.jetpack.io/devbox/internal/boxcli/usererr"
-	"go.jetpack.io/devbox/internal/debug"
 	"go.jetpack.io/devbox/internal/devpkg/pkgtype"
 	"go.jetpack.io/devbox/internal/nix"
 	"go.jetpack.io/devbox/internal/redact"
@@ -172,12 +172,7 @@ func buildLockSystemInfos(pkg *searcher.PackageVersion) (map[string]*SystemInfo,
 			path, err := nix.StorePathFromHashPart(ctx, sysInfo.StoreHash, "https://cache.nixos.org")
 			if err != nil {
 				// Should we report this to sentry to collect data?
-				debug.Log(
-					"Failed to resolve store path for %s with storeHash %s. Error is %s.\n",
-					sysName,
-					sysInfo.StoreHash,
-					err,
-				)
+				slog.Error("failed to resolve store path", "system", sysName, "store_hash", sysInfo.StoreHash, "err", err)
 				// Instead of erroring, we can just skip this package. It can install via the slow path.
 				return nil
 			}

--- a/internal/nix/build.go
+++ b/internal/nix/build.go
@@ -3,6 +3,7 @@ package nix
 import (
 	"context"
 	"io"
+	"log/slog"
 	"os"
 	"strings"
 
@@ -33,7 +34,7 @@ func Build(ctx context.Context, args *BuildArgs, installables ...string) error {
 	}
 	cmd.Env = append(allowUnfreeEnv(os.Environ()), args.Env...)
 	if args.AllowInsecure {
-		debug.Log("Setting Allow-insecure env-var\n")
+		slog.Debug("Setting Allow-insecure env-var\n")
 		cmd.Env = allowInsecureEnv(cmd.Env)
 	}
 
@@ -44,6 +45,6 @@ func Build(ctx context.Context, args *BuildArgs, installables ...string) error {
 	cmd.Stdout = args.Writer
 	cmd.Stderr = args.Writer
 
-	debug.Log("Running cmd: %s\n", cmd)
+	slog.Debug("running cmd", "cmd", cmd)
 	return cmd.Run(ctx)
 }

--- a/internal/nix/config.go
+++ b/internal/nix/config.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"os"
 	"os/exec"
 	"os/user"
@@ -14,7 +15,6 @@ import (
 	"slices"
 	"strings"
 
-	"go.jetpack.io/devbox/internal/debug"
 	"go.jetpack.io/devbox/internal/redact"
 )
 
@@ -83,7 +83,7 @@ func (c Config) IsUserTrusted(ctx context.Context, username string) (bool, error
 		group, err := user.LookupGroup(groupName)
 		var unknownErr user.UnknownGroupError
 		if errors.As(err, &unknownErr) {
-			debug.Log("skipping unknown trusted-user group %q found in nix.conf", groupName)
+			slog.Debug("skipping unknown trusted-user group found in nix.conf", "group", groupName)
 			continue
 		}
 		if err != nil {

--- a/internal/nix/nix.go
+++ b/internal/nix/nix.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/fs"
+	"log/slog"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -77,7 +78,7 @@ func (*Nix) PrintDevEnv(ctx context.Context, args *PrintDevEnvArgs) (*PrintDevEn
 		cmd := command("print-dev-env", "--json",
 			"path:"+flakeDirResolved,
 		)
-		debug.Log("Running print-dev-env cmd: %s\n", cmd)
+		slog.Debug("running print-dev-env cmd", "cmd", cmd)
 		data, err = cmd.Output(ctx)
 		if insecure, insecureErr := IsExitErrorInsecurePackage(err, "" /*pkgName*/, "" /*installable*/); insecure {
 			return nil, insecureErr
@@ -337,7 +338,7 @@ func runNixVersion() (VersionInfo, error) {
 		return VersionInfo{}, redact.Errorf("nix command: %s: %v", redact.Safe(cmd), err)
 	}
 
-	debug.Log("nix --version --debug output:\n%s", out)
+	slog.Debug("nix --version --debug output", "out", out)
 	return parseVersionInfo(out)
 }
 

--- a/internal/nix/profiles.go
+++ b/internal/nix/profiles.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
+	"log/slog"
 	"os"
 	"path/filepath"
 
@@ -71,7 +72,7 @@ func ProfileInstall(ctx context.Context, args *ProfileInstallArgs) error {
 	cmd.Stdout = args.Writer
 	cmd.Stderr = args.Writer
 
-	debug.Log("running command: %s\n", cmd)
+	slog.Debug("running command", "cmd", cmd)
 	return cmd.Run(ctx)
 }
 

--- a/internal/nix/run.go
+++ b/internal/nix/run.go
@@ -6,12 +6,12 @@ package nix
 import (
 	"errors"
 	"fmt"
+	"log/slog"
 	"os"
 	"os/exec"
 
 	"go.jetpack.io/devbox/internal/boxcli/usererr"
 	"go.jetpack.io/devbox/internal/cmdutil"
-	"go.jetpack.io/devbox/internal/debug"
 )
 
 func RunScript(projectDir, cmdWithArgs string, env map[string]string) error {
@@ -33,7 +33,7 @@ func RunScript(projectDir, cmdWithArgs string, env map[string]string) error {
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 
-	debug.Log("Executing: %v", cmd.Args)
+	slog.Debug("executing script", "cmd", cmd.Args)
 	// Report error as exec error when executing scripts.
 	return usererr.NewExecError(cmd.Run())
 }

--- a/internal/nix/search.go
+++ b/internal/nix/search.go
@@ -4,13 +4,13 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"os"
 	"regexp"
 	"strings"
 	"time"
 
 	"github.com/pkg/errors"
-	"go.jetpack.io/devbox/internal/debug"
 	"go.jetpack.io/devbox/internal/xdg"
 	"go.jetpack.io/pkg/filecache"
 )
@@ -103,7 +103,7 @@ func searchSystem(url, system string) (map[string]*Info, error) {
 	if system != "" {
 		cmd.Args = append(cmd.Args, "--system", system)
 	}
-	debug.Log("running command: %s\n", cmd)
+	slog.Debug("running command", "cmd", cmd)
 	out, err := cmd.Output(context.TODO())
 	if err != nil {
 		// for now, assume all errors are invalid packages.

--- a/internal/nix/store.go
+++ b/internal/nix/store.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"os"
 	"os/exec"
 	"strings"
@@ -30,11 +31,11 @@ func StorePathsFromInstallable(ctx context.Context, installable string, allowIns
 	cmd.Env = allowUnfreeEnv(os.Environ())
 
 	if allowInsecure {
-		debug.Log("Setting Allow-insecure env-var\n")
+		slog.Debug("Setting Allow-insecure env-var\n")
 		cmd.Env = allowInsecureEnv(cmd.Env)
 	}
 
-	debug.Log("Running cmd %s", cmd)
+	slog.Debug("running cmd", "cmd", cmd)
 	resultBytes, err := cmd.Output(ctx)
 	if err != nil {
 		return nil, err
@@ -56,7 +57,7 @@ func StorePathsAreInStore(ctx context.Context, storePaths []string) (map[string]
 	}
 	cmd := command("path-info", "--offline", "--json")
 	cmd.Args = appendArgs(cmd.Args, storePaths)
-	debug.Log("Running cmd %s", cmd)
+	slog.Debug("running cmd", "cmd", cmd)
 	output, err := cmd.Output(ctx)
 	if err != nil {
 		return nil, err

--- a/internal/nix/writer.go
+++ b/internal/nix/writer.go
@@ -5,9 +5,8 @@ package nix
 
 import (
 	"io"
+	"log/slog"
 	"strings"
-
-	"go.jetpack.io/devbox/internal/debug"
 )
 
 // packageInstallIgnore will skip lines that have the strings in the keys of this map.
@@ -38,7 +37,7 @@ func (*PackageInstallWriter) ignore(line string) bool {
 	for filter, shouldLog := range packageInstallIgnore {
 		if strings.Contains(line, filter) {
 			if shouldLog {
-				debug.Log("Hiding output for user: %s", line)
+				slog.Debug("hiding output from user", "line", line)
 			}
 			return true
 		}

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -8,6 +8,7 @@ import (
 	"cmp"
 	"encoding/json"
 	"io/fs"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"slices"
@@ -16,7 +17,6 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/tailscale/hujson"
-	"go.jetpack.io/devbox/internal/debug"
 	"go.jetpack.io/devbox/internal/devconfig/configfile"
 	"go.jetpack.io/devbox/internal/devpkg"
 	"go.jetpack.io/devbox/internal/lock"
@@ -82,7 +82,7 @@ func (m *Manager) CreateFilesForConfig(cfg *Config) error {
 		return err
 	}
 
-	debug.Log("Creating files for package %q create files", pkg)
+	slog.Debug("creating files for package", "pkg", pkg)
 	for filePath, contentPath := range cfg.CreateFiles {
 		if !m.shouldCreateFile(locked, filePath) {
 			continue
@@ -118,7 +118,7 @@ func (m *Manager) createFile(
 	filePath, contentPath, virtenvPath string,
 ) error {
 	name := pkg.CanonicalName()
-	debug.Log("Creating file %q from contentPath: %q", filePath, contentPath)
+	slog.Debug("Creating file %q from contentPath: %q", filePath, contentPath)
 	content, err := pkg.FileContent(contentPath)
 	if err != nil {
 		return errors.WithStack(err)

--- a/internal/shellgen/flake_input.go
+++ b/internal/shellgen/flake_input.go
@@ -3,13 +3,13 @@ package shellgen
 import (
 	"context"
 	"errors"
+	"log/slog"
 	"runtime/trace"
 	"slices"
 	"strings"
 
 	"github.com/samber/lo"
 	"go.jetpack.io/devbox/internal/boxcli/featureflag"
-	"go.jetpack.io/devbox/internal/debug"
 	"go.jetpack.io/devbox/internal/devpkg"
 	"go.jetpack.io/devbox/internal/nix"
 )
@@ -172,7 +172,7 @@ func flakeInputs(ctx context.Context, packages []*devpkg.Package) []flakeInput {
 			// TODO(savil): return error?
 			cached, err := pkg.IsInBinaryCache()
 			if err != nil {
-				debug.Log("error checking if package is in binary cache: %v", err)
+				slog.Error("error checking if package is in binary cache", "err", err)
 			}
 			if err == nil && cached {
 				continue

--- a/internal/shellgen/scripts.go
+++ b/internal/shellgen/scripts.go
@@ -3,6 +3,7 @@ package shellgen
 import (
 	"bytes"
 	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
@@ -94,7 +95,7 @@ func WriteScriptsToFiles(devbox devboxer) error {
 		if _, ok := written[scriptName]; !ok && !entry.IsDir() {
 			err := os.Remove(ScriptPath(devbox.ProjectDir(), scriptName))
 			if err != nil {
-				debug.Log("failed to clean up script file %s, error = %s", entry.Name(), err) // no need to fail run
+				slog.Debug("failed to clean up script file %s, error = %s", entry.Name(), err) // no need to fail run
 			}
 		}
 	}

--- a/testscripts/testrunner/examplesrunner.go
+++ b/testscripts/testrunner/examplesrunner.go
@@ -3,6 +3,7 @@ package testrunner
 import (
 	"fmt"
 	"io/fs"
+	"log/slog"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -13,7 +14,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/rogpeppe/go-internal/testscript"
 
-	"go.jetpack.io/devbox/internal/debug"
 	"go.jetpack.io/devbox/internal/devconfig"
 	"go.jetpack.io/devbox/internal/envir"
 )
@@ -105,7 +105,7 @@ func runSingleDevboxTestscript(t *testing.T, dir, projectDir string) {
 		}
 
 		// copy all the files and folders of the devbox-project being tested to the workdir
-		debug.Log("copying projectDir: %s to env.WorkDir: %s\n", projectDir, envs.WorkDir)
+		slog.Debug("copying projectDir: %s to env.WorkDir: %s\n", projectDir, envs.WorkDir)
 		// implementation detail: the period at the end of the projectDir/.
 		// is important to ensure this works for both mac and linux.
 		// Ref.https://dev.to/ackshaey/macos-vs-linux-the-cp-command-will-trip-you-up-2p00
@@ -113,12 +113,12 @@ func runSingleDevboxTestscript(t *testing.T, dir, projectDir string) {
 		cmd := exec.Command("rm", "-rf", projectDir+"/.devbox")
 		err = cmd.Run()
 		if err != nil {
-			debug.Log("failed %s before doing cp", cmd)
+			slog.Error("failed %s before doing cp", "cmd", cmd, "err", err)
 			return errors.WithStack(err)
 		}
 
 		cmd = exec.Command("cp", "-r", projectDir+"/.", envs.WorkDir)
-		debug.Log("Running cmd: %s\n", cmd)
+		slog.Debug("running cmd", "cmd", cmd)
 		err = cmd.Run()
 		return errors.WithStack(err)
 	}
@@ -152,7 +152,7 @@ func generateTestscript(t *testing.T, dir, projectDir string) (string, error) {
 
 	// Copy the testscript file to the temp-dir
 	runTestScriptPath := filepath.Join("testrunner", scriptName)
-	debug.Log("copying run_test.test.txt from %s to %s\n", runTestScriptPath, testscriptDir)
+	slog.Debug("copying run_test.test.txt from %s to %s\n", runTestScriptPath, testscriptDir)
 	// Using os's cp command for expediency.
 	err = exec.Command("cp", runTestScriptPath, testscriptDir+"/"+scriptNameForProject).Run()
 	return testscriptDir, errors.WithStack(err)


### PR DESCRIPTION
We currently use `debug.Log` for all log messages, which in turn uses the stdlib log package. This change removes the `debug.Log` function and instead initializes a `*slog.Logger` as the default logger. All `debug.Log` calls are now `slog.Debug` or `slog.Error` calls.