### PR TITLE
internal/nix: log all command starts and exits

### DIFF
--- a/internal/nix/build.go
+++ b/internal/nix/build.go
@@ -44,7 +44,5 @@ func Build(ctx context.Context, args *BuildArgs, installables ...string) error {
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = args.Writer
 	cmd.Stderr = args.Writer
-
-	slog.Debug("running cmd", "cmd", cmd)
 	return cmd.Run(ctx)
 }

--- a/internal/nix/profiles.go
+++ b/internal/nix/profiles.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
-	"log/slog"
 	"os"
 	"path/filepath"
 
@@ -71,8 +70,6 @@ func ProfileInstall(ctx context.Context, args *ProfileInstallArgs) error {
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = args.Writer
 	cmd.Stderr = args.Writer
-
-	slog.Debug("running command", "cmd", cmd)
 	return cmd.Run(ctx)
 }
 

--- a/internal/nix/search.go
+++ b/internal/nix/search.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log/slog"
 	"os"
 	"regexp"
 	"strings"
@@ -103,7 +102,6 @@ func searchSystem(url, system string) (map[string]*Info, error) {
 	if system != "" {
 		cmd.Args = append(cmd.Args, "--system", system)
 	}
-	slog.Debug("running command", "cmd", cmd)
 	out, err := cmd.Output(context.TODO())
 	if err != nil {
 		// for now, assume all errors are invalid packages.

--- a/internal/nix/store.go
+++ b/internal/nix/store.go
@@ -35,7 +35,6 @@ func StorePathsFromInstallable(ctx context.Context, installable string, allowIns
 		cmd.Env = allowInsecureEnv(cmd.Env)
 	}
 
-	slog.Debug("running cmd", "cmd", cmd)
 	resultBytes, err := cmd.Output(ctx)
 	if err != nil {
 		return nil, err
@@ -57,7 +56,6 @@ func StorePathsAreInStore(ctx context.Context, storePaths []string) (map[string]
 	}
 	cmd := command("path-info", "--offline", "--json")
 	cmd.Args = appendArgs(cmd.Args, storePaths)
-	slog.Debug("running cmd", "cmd", cmd)
 	output, err := cmd.Output(ctx)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Write logs whenever a Nix command is about to start and after it exits. Make `cmd` a `slog.LogValuer` so that it writes structured log attributes grouped under a `cmd` prefix.

Example logs and attributes (line breaks added for readability):

	msg="nix command starting"
		cmd.args="nix --extra-experimental-features ca-derivations --option experimental-features 'nix-command flakes fetch-closure' eval --impure --raw --expr builtins.currentSystem"
		cmd.path=/nix/var/nix/profiles/default/bin/nix

	msg="nix command exited"
		cmd.args="nix --extra-experimental-features ca-derivations --option experimental-features 'nix-command flakes fetch-closure' eval --impure --raw --expr builtins.currentSystem"
		cmd.path=/nix/var/nix/profiles/default/bin/nix
		cmd.pid=68672
		cmd.code=0
		cmd.dur=34.296041ms

Command exits are always logged at the debug level, even if the command exits with a non-zero exit code. This is because some commands might be expected to fail (for example, when checking if a path exists in the store).