### PR TITLE
[docker] fix docker release image

### DIFF
--- a/.github/workflows/docker-image-release.yml
+++ b/.github/workflows/docker-image-release.yml
@@ -55,7 +55,7 @@ jobs:
           context: ./internal/devbox/generate/tmpl/
           file: ./internal/devbox/generate/tmpl/DevboxImageDockerfile
           build-args: |
-            DEVBOX_USE_VERSION=${{ inputs.tag }}
+            DEVBOX_VERSION=${{ inputs.tag }}
           push: true
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
@@ -65,7 +65,7 @@ jobs:
           context: ./internal/devbox/generate/tmpl/
           file: ./internal/devbox/generate/tmpl/DevboxImageDockerfileRootUser
           build-args: |
-            DEVBOX_USE_VERSION=${{ inputs.tag }}
+            DEVBOX_VERSION=${{ inputs.tag }}
           push: true
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.metaroot.outputs.tags }}

--- a/.github/workflows/docker-image-release.yml
+++ b/.github/workflows/docker-image-release.yml
@@ -9,7 +9,7 @@ on:
       tag:
         description: 'tag name'
         required: true
-        default: 'undefined'
+        default: ''
         type: string
 
 jobs:
@@ -18,8 +18,6 @@ jobs:
     steps:
       - name: Check out the repo
         uses: actions/checkout@v4
-        with:
-          ref: ${{ inputs.tag || github.ref }}
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
       - name: Docker meta
@@ -29,9 +27,7 @@ jobs:
           images: |
             jetpackio/devbox
           tags: |
-            type=semver,pattern={{version}},value=${{ inputs.tag }}
-          flavor: |
-            latest=${{ !inputs.tag && true || false }}
+            type=raw,value=${{ inputs.tag || github.ref_name }}
       - name: Docker meta root
         id: metaroot
         uses: docker/metadata-action@v5
@@ -39,9 +35,7 @@ jobs:
           images: |
             jetpackio/devbox-root-user
           tags: |
-            type=semver,pattern={{version}},value=${{ inputs.tag }}
-          flavor: |
-            latest=${{ !inputs.tag && true || false }}
+            type=raw,value=${{ inputs.tag || github.ref_name }}
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
       - name: Login to Docker Hub
@@ -55,7 +49,7 @@ jobs:
           context: ./internal/devbox/generate/tmpl/
           file: ./internal/devbox/generate/tmpl/DevboxImageDockerfile
           build-args: |
-            DEVBOX_VERSION=${{ inputs.tag || github.ref }}
+            DEVBOX_USE_VERSION=${{ inputs.tag || github.ref_name }}
           push: true
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
@@ -65,7 +59,7 @@ jobs:
           context: ./internal/devbox/generate/tmpl/
           file: ./internal/devbox/generate/tmpl/DevboxImageDockerfileRootUser
           build-args: |
-            DEVBOX_VERSION=${{ inputs.tag || github.ref }}
+            DEVBOX_USE_VERSION=${{ inputs.tag || github.ref_name }}
           push: true
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.metaroot.outputs.tags }}

--- a/.github/workflows/docker-image-release.yml
+++ b/.github/workflows/docker-image-release.yml
@@ -28,6 +28,8 @@ jobs:
             jetpackio/devbox
           tags: |
             type=raw,value=${{ inputs.tag || github.ref_name }}
+          flavor: |
+            latest=false
       - name: Docker meta root
         id: metaroot
         uses: docker/metadata-action@v5
@@ -36,6 +38,8 @@ jobs:
             jetpackio/devbox-root-user
           tags: |
             type=raw,value=${{ inputs.tag || github.ref_name }}
+          flavor: |
+            latest=false
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
       - name: Login to Docker Hub

--- a/.github/workflows/docker-image-release.yml
+++ b/.github/workflows/docker-image-release.yml
@@ -29,9 +29,9 @@ jobs:
           images: |
             jetpackio/devbox
           tags: |
-            type=semver,pattern={{version}}
+            type=semver,pattern={{version}},value=${{ inputs.tag }}
           flavor: |
-            latest=${{ inputs.tag && true || false }}
+            latest=${{ !inputs.tag && true || false }}
       - name: Docker meta root
         id: metaroot
         uses: docker/metadata-action@v5
@@ -39,9 +39,9 @@ jobs:
           images: |
             jetpackio/devbox-root-user
           tags: |
-            type=semver,pattern={{version}}
+            type=semver,pattern={{version}},value=${{ inputs.tag }}
           flavor: |
-            latest=${{ inputs.tag && true || false }}
+            latest=${{ !inputs.tag && true || false }}
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
       - name: Login to Docker Hub

--- a/.github/workflows/docker-image-release.yml
+++ b/.github/workflows/docker-image-release.yml
@@ -18,8 +18,8 @@ jobs:
     steps:
       - name: Check out the repo
         uses: actions/checkout@v4
-        # with:
-        #   ref: ${{ inputs.tag || github.ref }}
+        with:
+          ref: ${{ inputs.tag || github.ref }}
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
       - name: Docker meta

--- a/.github/workflows/docker-image-release.yml
+++ b/.github/workflows/docker-image-release.yml
@@ -18,8 +18,8 @@ jobs:
     steps:
       - name: Check out the repo
         uses: actions/checkout@v4
-        with:
-          ref: ${{ inputs.tag || github.ref }}
+        # with:
+        #   ref: ${{ inputs.tag || github.ref }}
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
       - name: Docker meta

--- a/.github/workflows/docker-image-release.yml
+++ b/.github/workflows/docker-image-release.yml
@@ -55,7 +55,7 @@ jobs:
           context: ./internal/devbox/generate/tmpl/
           file: ./internal/devbox/generate/tmpl/DevboxImageDockerfile
           build-args: |
-            DEVBOX_VERSION=${{ inputs.tag }}
+            DEVBOX_VERSION=${{ inputs.tag || github.ref }}
           push: true
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
@@ -65,7 +65,7 @@ jobs:
           context: ./internal/devbox/generate/tmpl/
           file: ./internal/devbox/generate/tmpl/DevboxImageDockerfileRootUser
           build-args: |
-            DEVBOX_VERSION=${{ inputs.tag }}
+            DEVBOX_VERSION=${{ inputs.tag || github.ref }}
           push: true
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.metaroot.outputs.tags }}

--- a/internal/devbox/generate/tmpl/DevboxImageDockerfile
+++ b/internal/devbox/generate/tmpl/DevboxImageDockerfile
@@ -25,17 +25,17 @@ ENV DEVBOX_USE_VERSION ${DEVBOX_VERSION}
 RUN wget --quiet --output-document=/dev/stdout https://get.jetify.com/devbox   | bash -s -- -f
 RUN chown -R "${DEVBOX_USER}:${DEVBOX_USER}" /usr/local/bin/devbox
 # stop launcher from auto updating
-RUN mkdir -p $HOME/.config/devbox/ && echo "false" > $HOME/.config/devbox/auto_update
+# RUN mkdir -p $HOME/.config/devbox/ && echo "false" > $HOME/.config/devbox/auto_update
 
 # run a devbox command to make launcher download devbox binary
 RUN devbox version
 
 # replace binary with launcher
-USER root
-RUN if [ $(uname -m) = "aarch64" ]; \
-    then mv -f /home/devbox/.cache/devbox/bin/${DEVBOX_VERSION}_linux_arm64/devbox /usr/local/bin; \
-    else mv -f /home/devbox/.cache/devbox/bin/${DEVBOX_VERSION}_linux_amd64/devbox /usr/local/bin; \
-    fi
-USER $DEVBOX_USER
+# USER root
+# RUN if [ $(uname -m) = "aarch64" ]; \
+#     then mv -f /home/devbox/.cache/devbox/bin/${DEVBOX_VERSION}_linux_arm64/devbox /usr/local/bin; \
+#     else mv -f /home/devbox/.cache/devbox/bin/${DEVBOX_VERSION}_linux_amd64/devbox /usr/local/bin; \
+#     fi
+# USER $DEVBOX_USER
 
 CMD ["devbox", "version", "-v"]

--- a/internal/devbox/generate/tmpl/DevboxImageDockerfile
+++ b/internal/devbox/generate/tmpl/DevboxImageDockerfile
@@ -33,11 +33,10 @@ RUN devbox version
 # replace binary with launcher
 USER root
 RUN ls /home/devbox/.cache/devbox/bin/
-RUN if [ $(uname -m) = "aarch64" ]; then
-    mv -f /home/devbox/.cache/devbox/bin/${DEVBOX_VERSION}_linux_arm64/devbox /usr/local/bin
-else
-    mv -f /home/devbox/.cache/devbox/bin/${DEVBOX_VERSION}_linux_amd64/devbox /usr/local/bin
-fi
+RUN if [ $(uname -m) = "aarch64" ]; \
+    then mv -f /home/devbox/.cache/devbox/bin/${DEVBOX_VERSION}_linux_arm64/devbox /usr/local/bin \
+    else mv -f /home/devbox/.cache/devbox/bin/${DEVBOX_VERSION}_linux_amd64/devbox /usr/local/bin \
+    fi
 
 USER $DEVBOX_USER
 

--- a/internal/devbox/generate/tmpl/DevboxImageDockerfile
+++ b/internal/devbox/generate/tmpl/DevboxImageDockerfile
@@ -26,7 +26,13 @@ RUN wget --quiet --output-document=/dev/stdout https://get.jetify.com/devbox   |
 RUN chown -R "${DEVBOX_USER}:${DEVBOX_USER}" /usr/local/bin/devbox
 # stop launcher from auto updating
 RUN mkdir -p $HOME/.config/devbox/ && echo "false" > $HOME/.config/devbox/auto_update
+
 # run a devbox command to make launcher download devbox binary
 RUN devbox version
+
+# replace binary with launcher
+USER root
+RUN mv -f /home/devbox/.cache/devbox/bin/${DEVBOX_VERSION}_linux_arm64/devbox /usr/local/bin
+USER $DEVBOX_USER
 
 CMD ["devbox", "version", "-v"]

--- a/internal/devbox/generate/tmpl/DevboxImageDockerfile
+++ b/internal/devbox/generate/tmpl/DevboxImageDockerfile
@@ -24,18 +24,8 @@ ENV PATH="/home/${DEVBOX_USER}/.nix-profile/bin:$PATH"
 ENV DEVBOX_USE_VERSION=$DEVBOX_USE_VERSION
 RUN wget --quiet --output-document=/dev/stdout https://get.jetify.com/devbox   | bash -s -- -f
 RUN chown -R "${DEVBOX_USER}:${DEVBOX_USER}" /usr/local/bin/devbox
-# stop launcher from auto updating
-# RUN mkdir -p $HOME/.config/devbox/ && echo "false" > $HOME/.config/devbox/auto_update
 
 # run a devbox command to make launcher download devbox binary
 RUN devbox version
-
-# replace binary with launcher
-# USER root
-# RUN if [ $(uname -m) = "aarch64" ]; \
-#     then mv -f /home/devbox/.cache/devbox/bin/${DEVBOX_VERSION}_linux_arm64/devbox /usr/local/bin; \
-#     else mv -f /home/devbox/.cache/devbox/bin/${DEVBOX_VERSION}_linux_amd64/devbox /usr/local/bin; \
-#     fi
-# USER $DEVBOX_USER
 
 CMD ["devbox", "version", "-v"]

--- a/internal/devbox/generate/tmpl/DevboxImageDockerfile
+++ b/internal/devbox/generate/tmpl/DevboxImageDockerfile
@@ -34,8 +34,8 @@ RUN devbox version
 USER root
 RUN ls /home/devbox/.cache/devbox/bin/
 RUN if [ $(uname -m) = "aarch64" ]; \
-    then mv -f /home/devbox/.cache/devbox/bin/${DEVBOX_VERSION}_linux_arm64/devbox /usr/local/bin \
-    else mv -f /home/devbox/.cache/devbox/bin/${DEVBOX_VERSION}_linux_amd64/devbox /usr/local/bin \
+    then mv -f /home/devbox/.cache/devbox/bin/${DEVBOX_VERSION}_linux_arm64/devbox /usr/local/bin; \
+    else mv -f /home/devbox/.cache/devbox/bin/${DEVBOX_VERSION}_linux_amd64/devbox /usr/local/bin; \
     fi
 
 USER $DEVBOX_USER

--- a/internal/devbox/generate/tmpl/DevboxImageDockerfile
+++ b/internal/devbox/generate/tmpl/DevboxImageDockerfile
@@ -32,12 +32,10 @@ RUN devbox version
 
 # replace binary with launcher
 USER root
-RUN ls /home/devbox/.cache/devbox/bin/
 RUN if [ $(uname -m) = "aarch64" ]; \
     then mv -f /home/devbox/.cache/devbox/bin/${DEVBOX_VERSION}_linux_arm64/devbox /usr/local/bin; \
     else mv -f /home/devbox/.cache/devbox/bin/${DEVBOX_VERSION}_linux_amd64/devbox /usr/local/bin; \
     fi
-
 USER $DEVBOX_USER
 
 CMD ["devbox", "version", "-v"]

--- a/internal/devbox/generate/tmpl/DevboxImageDockerfile
+++ b/internal/devbox/generate/tmpl/DevboxImageDockerfile
@@ -1,7 +1,7 @@
 FROM debian:stable-slim
 
 # Optional arg to install custom devbox version
-ARG DEVBOX_USE_VERSION
+ARG DEVBOX_VERSION
 
 # Step 1: Installing dependencies
 RUN apt-get update
@@ -21,8 +21,12 @@ RUN . ~/.nix-profile/etc/profile.d/nix.sh
 ENV PATH="/home/${DEVBOX_USER}/.nix-profile/bin:$PATH"
 
 # Step 3: Installing devbox
-ENV DEVBOX_USE_VERSION=$DEVBOX_USE_VERSION
+ENV DEVBOX_USE_VERSION ${DEVBOX_VERSION}
 RUN wget --quiet --output-document=/dev/stdout https://get.jetify.com/devbox   | bash -s -- -f
 RUN chown -R "${DEVBOX_USER}:${DEVBOX_USER}" /usr/local/bin/devbox
+# stop launcher from auto updating
+RUN mkdir -p $HOME/.config/devbox/ && echo "false" > $HOME/.config/devbox/auto_update
+# run a devbox command to make launcher download devbox binary
+RUN devbox version
 
-CMD ["devbox", "version"]
+CMD ["devbox", "version", "-v"]

--- a/internal/devbox/generate/tmpl/DevboxImageDockerfile
+++ b/internal/devbox/generate/tmpl/DevboxImageDockerfile
@@ -32,6 +32,7 @@ RUN devbox version
 
 # replace binary with launcher
 USER root
+RUN ls /home/devbox/.cache/devbox/bin/
 RUN mv -f /home/devbox/.cache/devbox/bin/${DEVBOX_VERSION}_linux_arm64/devbox /usr/local/bin
 USER $DEVBOX_USER
 

--- a/internal/devbox/generate/tmpl/DevboxImageDockerfile
+++ b/internal/devbox/generate/tmpl/DevboxImageDockerfile
@@ -33,7 +33,7 @@ RUN devbox version
 # replace binary with launcher
 USER root
 RUN ls /home/devbox/.cache/devbox/bin/
-RUN mv -f /home/devbox/.cache/devbox/bin/${DEVBOX_VERSION}_linux_arm64/devbox /usr/local/bin
+RUN mv -f /home/devbox/.cache/devbox/bin/${DEVBOX_VERSION}_linux_amd64/devbox /usr/local/bin
 USER $DEVBOX_USER
 
 CMD ["devbox", "version", "-v"]

--- a/internal/devbox/generate/tmpl/DevboxImageDockerfile
+++ b/internal/devbox/generate/tmpl/DevboxImageDockerfile
@@ -21,7 +21,7 @@ RUN . ~/.nix-profile/etc/profile.d/nix.sh
 ENV PATH="/home/${DEVBOX_USER}/.nix-profile/bin:$PATH"
 
 # Step 3: Installing devbox
-ENV DEVBOX_USE_VERSION=${DEVBOX_USE_VERSION}
+ENV DEVBOX_USE_VERSION=$DEVBOX_USE_VERSION
 RUN wget --quiet --output-document=/dev/stdout https://get.jetify.com/devbox   | bash -s -- -f
 RUN chown -R "${DEVBOX_USER}:${DEVBOX_USER}" /usr/local/bin/devbox
 # stop launcher from auto updating

--- a/internal/devbox/generate/tmpl/DevboxImageDockerfile
+++ b/internal/devbox/generate/tmpl/DevboxImageDockerfile
@@ -33,7 +33,12 @@ RUN devbox version
 # replace binary with launcher
 USER root
 RUN ls /home/devbox/.cache/devbox/bin/
-RUN mv -f /home/devbox/.cache/devbox/bin/${DEVBOX_VERSION}_linux_arm64/devbox /usr/local/bin
+RUN if [ $(uname -m) = "aarch64" ]; then
+    mv -f /home/devbox/.cache/devbox/bin/${DEVBOX_VERSION}_linux_arm64/devbox /usr/local/bin
+else
+    mv -f /home/devbox/.cache/devbox/bin/${DEVBOX_VERSION}_linux_amd64/devbox /usr/local/bin
+fi
+
 USER $DEVBOX_USER
 
 CMD ["devbox", "version", "-v"]

--- a/internal/devbox/generate/tmpl/DevboxImageDockerfile
+++ b/internal/devbox/generate/tmpl/DevboxImageDockerfile
@@ -1,7 +1,7 @@
 FROM debian:stable-slim
 
 # Optional arg to install custom devbox version
-ARG DEVBOX_VERSION
+ARG DEVBOX_USE_VERSION
 
 # Step 1: Installing dependencies
 RUN apt-get update
@@ -21,7 +21,7 @@ RUN . ~/.nix-profile/etc/profile.d/nix.sh
 ENV PATH="/home/${DEVBOX_USER}/.nix-profile/bin:$PATH"
 
 # Step 3: Installing devbox
-ENV DEVBOX_USE_VERSION=${DEVBOX_VERSION}
+ENV DEVBOX_USE_VERSION=${DEVBOX_USE_VERSION}
 RUN wget --quiet --output-document=/dev/stdout https://get.jetify.com/devbox   | bash -s -- -f
 RUN chown -R "${DEVBOX_USER}:${DEVBOX_USER}" /usr/local/bin/devbox
 # stop launcher from auto updating

--- a/internal/devbox/generate/tmpl/DevboxImageDockerfile
+++ b/internal/devbox/generate/tmpl/DevboxImageDockerfile
@@ -33,7 +33,7 @@ RUN devbox version
 # replace binary with launcher
 USER root
 RUN ls /home/devbox/.cache/devbox/bin/
-RUN mv -f /home/devbox/.cache/devbox/bin/${DEVBOX_VERSION}_linux_amd64/devbox /usr/local/bin
+RUN mv -f /home/devbox/.cache/devbox/bin/${DEVBOX_VERSION}_linux_arm64/devbox /usr/local/bin
 USER $DEVBOX_USER
 
 CMD ["devbox", "version", "-v"]

--- a/internal/devbox/generate/tmpl/DevboxImageDockerfile
+++ b/internal/devbox/generate/tmpl/DevboxImageDockerfile
@@ -21,7 +21,7 @@ RUN . ~/.nix-profile/etc/profile.d/nix.sh
 ENV PATH="/home/${DEVBOX_USER}/.nix-profile/bin:$PATH"
 
 # Step 3: Installing devbox
-ENV DEVBOX_USE_VERSION ${DEVBOX_VERSION}
+ENV DEVBOX_USE_VERSION=${DEVBOX_VERSION}
 RUN wget --quiet --output-document=/dev/stdout https://get.jetify.com/devbox   | bash -s -- -f
 RUN chown -R "${DEVBOX_USER}:${DEVBOX_USER}" /usr/local/bin/devbox
 # stop launcher from auto updating

--- a/internal/devbox/generate/tmpl/DevboxImageDockerfileRootUser
+++ b/internal/devbox/generate/tmpl/DevboxImageDockerfileRootUser
@@ -1,7 +1,7 @@
 FROM debian:stable-slim
 
 # Optional arg to install custom devbox version
-ARG DEVBOX_VERSION
+ARG DEVBOX_USE_VERSION
 
 # Step 1: Installing dependencies
 RUN apt-get update
@@ -15,17 +15,17 @@ RUN . ~/.nix-profile/etc/profile.d/nix.sh
 ENV PATH="/root/.nix-profile/bin:$PATH"
 
 # Step 3: Installing devbox
-ENV DEVBOX_USE_VERSION ${DEVBOX_VERSION}
+ENV DEVBOX_USE_VERSION ${DEVBOX_USE_VERSION}
 RUN wget --quiet --output-document=/dev/stdout https://get.jetify.com/devbox   | bash -s -- -f
 # stop launcher from auto updating
-RUN mkdir -p $HOME/.config/devbox/ && echo "false" > $HOME/.config/devbox/auto_update
+# RUN mkdir -p $HOME/.config/devbox/ && echo "false" > $HOME/.config/devbox/auto_update
 # run a devbox command to make launcher download devbox binary
 RUN devbox version
 
 # replace binary with launcher
-RUN if [ $(uname -m) = "aarch64" ]; \
-    then mv -f $HOME/.cache/devbox/bin/${DEVBOX_VERSION}_linux_arm64/devbox /usr/local/bin; \
-    else mv -f $HOME/.cache/devbox/bin/${DEVBOX_VERSION}_linux_amd64/devbox /usr/local/bin; \
-    fi
+# RUN if [ $(uname -m) = "aarch64" ]; \
+#     then mv -f $HOME/.cache/devbox/bin/${DEVBOX_USE_VERSION}_linux_arm64/devbox /usr/local/bin; \
+#     else mv -f $HOME/.cache/devbox/bin/${DEVBOX_USE_VERSION}_linux_amd64/devbox /usr/local/bin; \
+#     fi
 
 CMD ["devbox", "version", "-v"]

--- a/internal/devbox/generate/tmpl/DevboxImageDockerfileRootUser
+++ b/internal/devbox/generate/tmpl/DevboxImageDockerfileRootUser
@@ -22,4 +22,10 @@ RUN mkdir -p $HOME/.config/devbox/ && echo "false" > $HOME/.config/devbox/auto_u
 # run a devbox command to make launcher download devbox binary
 RUN devbox version
 
+# replace binary with launcher
+RUN if [ $(uname -m) = "aarch64" ]; \
+    then mv -f $HOME/.cache/devbox/bin/${DEVBOX_VERSION}_linux_arm64/devbox /usr/local/bin; \
+    else mv -f $HOME/.cache/devbox/bin/${DEVBOX_VERSION}_linux_amd64/devbox /usr/local/bin; \
+    fi
+
 CMD ["devbox", "version", "-v"]

--- a/internal/devbox/generate/tmpl/DevboxImageDockerfileRootUser
+++ b/internal/devbox/generate/tmpl/DevboxImageDockerfileRootUser
@@ -1,7 +1,7 @@
 FROM debian:stable-slim
 
 # Optional arg to install custom devbox version
-ARG DEVBOX_USE_VERSION
+ARG DEVBOX_VERSION
 
 # Step 1: Installing dependencies
 RUN apt-get update
@@ -15,7 +15,11 @@ RUN . ~/.nix-profile/etc/profile.d/nix.sh
 ENV PATH="/root/.nix-profile/bin:$PATH"
 
 # Step 3: Installing devbox
-ENV DEVBOX_USE_VERSION=$DEVBOX_USE_VERSION
+ENV DEVBOX_USE_VERSION ${DEVBOX_VERSION}
 RUN wget --quiet --output-document=/dev/stdout https://get.jetify.com/devbox   | bash -s -- -f
+# stop launcher from auto updating
+RUN mkdir -p $HOME/.config/devbox/ && echo "false" > $HOME/.config/devbox/auto_update
+# run a devbox command to make launcher download devbox binary
+RUN devbox version
 
-CMD ["devbox", "version"]
+CMD ["devbox", "version", "-v"]

--- a/internal/devbox/generate/tmpl/DevboxImageDockerfileRootUser
+++ b/internal/devbox/generate/tmpl/DevboxImageDockerfileRootUser
@@ -15,7 +15,7 @@ RUN . ~/.nix-profile/etc/profile.d/nix.sh
 ENV PATH="/root/.nix-profile/bin:$PATH"
 
 # Step 3: Installing devbox
-ENV DEVBOX_USE_VERSION ${DEVBOX_USE_VERSION}
+ENV DEVBOX_USE_VERSION=$DEVBOX_USE_VERSION
 RUN wget --quiet --output-document=/dev/stdout https://get.jetify.com/devbox   | bash -s -- -f
 # stop launcher from auto updating
 # RUN mkdir -p $HOME/.config/devbox/ && echo "false" > $HOME/.config/devbox/auto_update

--- a/internal/devbox/generate/tmpl/DevboxImageDockerfileRootUser
+++ b/internal/devbox/generate/tmpl/DevboxImageDockerfileRootUser
@@ -17,15 +17,7 @@ ENV PATH="/root/.nix-profile/bin:$PATH"
 # Step 3: Installing devbox
 ENV DEVBOX_USE_VERSION=$DEVBOX_USE_VERSION
 RUN wget --quiet --output-document=/dev/stdout https://get.jetify.com/devbox   | bash -s -- -f
-# stop launcher from auto updating
-# RUN mkdir -p $HOME/.config/devbox/ && echo "false" > $HOME/.config/devbox/auto_update
 # run a devbox command to make launcher download devbox binary
 RUN devbox version
-
-# replace binary with launcher
-# RUN if [ $(uname -m) = "aarch64" ]; \
-#     then mv -f $HOME/.cache/devbox/bin/${DEVBOX_USE_VERSION}_linux_arm64/devbox /usr/local/bin; \
-#     else mv -f $HOME/.cache/devbox/bin/${DEVBOX_USE_VERSION}_linux_amd64/devbox /usr/local/bin; \
-#     fi
 
 CMD ["devbox", "version", "-v"]


### PR DESCRIPTION
## Summary
This PR addresses the issue of our previous approach to only publish the latest version of devbox with `:latest` tag in dockerhub. It achieves 2 things:
1. fixes the previously broken github action to release a docker image after every tag creation.
2. updates the dockerfile so that devbox binary doesn't automatically upgrade to latest version upon first use. This allows docker pulls have fixed versions.


## How was it tested?
Already tested on releasing 0.10.7 version to dockerhub as test.
- `docker pull jetpackio/devbox:0.10.7`
- `docker run jetpackio/devbox:0.10.7`
- confirm output shows devbox version 0.10.7 and doesn't upgrade to latest version.
- same for devbox-root-user
