### PR TITLE
[CI] Update go-releaser action

### DIFF
--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -72,7 +72,7 @@ jobs:
         with:
           distribution: goreleaser
           version: latest
-          args: release --rm-dist --skip-publish --skip-announce --snapshot
+          args: release --clean --skip-publish --skip-announce --snapshot
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TELEMETRY_KEY: ${{ secrets.TELEMETRY_KEY }}
@@ -138,7 +138,7 @@ jobs:
         with:
           distribution: goreleaser
           version: latest
-          args: release --rm-dist
+          args: release --clean
         env:
           DISCORD_WEBHOOK_ID: ${{ secrets.DISCORD_WEBHOOK_ID }}
           DISCORD_WEBHOOK_TOKEN: ${{ secrets.DISCORD_WEBHOOK_TOKEN }}


### PR DESCRIPTION
`--rm-dist` flag is deprecated in newer versions of Goreleaser in favor of `clean`: https://goreleaser.com/deprecations/#-rm-dist 

Release action was failing due to the deprecated flag. This PR replaces it with the new clean flag

## Summary

## How was it tested?
