### PR TITLE
[devbox] run: skip re-computing Devbox State if in devbox shell

### DIFF
--- a/internal/devbox/devbox.go
+++ b/internal/devbox/devbox.go
@@ -249,9 +249,9 @@ func (d *Devbox) RunScript(ctx context.Context, cmdName string, cmdArgs []string
 		// Skip ensureStateIsUpToDate if we are already in a shell of this devbox-project
 		env = envir.PairsToMap(os.Environ())
 
-		// This env-var signifies that init-hooks have already run in this shell.
-		// We set this to ensure that init-hooks do NOT re-run.
-		env["__DEVBOX_INIT_HOOK_"+d.ProjectDirHash()] = "true"
+		// We set this to ensure that init-hooks do NOT re-run. They would have
+		// run when initializing the Devbox Environment in the current shell.
+		env[d.SkipInitHookEnvName()] = "true"
 	} else {
 		var err error
 		env, err = d.ensureStateIsUpToDateAndComputeEnv(ctx)

--- a/internal/devbox/devbox.go
+++ b/internal/devbox/devbox.go
@@ -248,6 +248,10 @@ func (d *Devbox) RunScript(ctx context.Context, cmdName string, cmdArgs []string
 	if d.IsEnvEnabled() {
 		// Skip ensureStateIsUpToDate if we are already in a shell of this devbox-project
 		env = envir.PairsToMap(os.Environ())
+
+		// This env-var signifies that init-hooks have already run in this shell.
+		// We set this to ensure that init-hooks do NOT re-run.
+		env["__DEVBOX_INIT_HOOK_"+d.ProjectDirHash()] = "true"
 	} else {
 		var err error
 		env, err = d.ensureStateIsUpToDateAndComputeEnv(ctx)

--- a/internal/devbox/devbox.go
+++ b/internal/devbox/devbox.go
@@ -243,9 +243,17 @@ func (d *Devbox) RunScript(ctx context.Context, cmdName string, cmdArgs []string
 	}
 
 	lock.SetIgnoreShellMismatch(true)
-	env, err := d.ensureStateIsUpToDateAndComputeEnv(ctx)
-	if err != nil {
-		return err
+
+	var env map[string]string
+	if d.IsEnvEnabled() {
+		// Skip ensureStateIsUpToDate if we are already in a shell of this devbox-project
+		env = envir.PairsToMap(os.Environ())
+	} else {
+		var err error
+		env, err = d.ensureStateIsUpToDateAndComputeEnv(ctx)
+		if err != nil {
+			return err
+		}
 	}
 
 	// Used to determine whether we're inside a shell (e.g. to prevent shell inception)

--- a/internal/devbox/envvars.go
+++ b/internal/devbox/envvars.go
@@ -78,3 +78,7 @@ func (d *Devbox) IsEnvEnabled() bool {
 	pathStack := envpath.Stack(fakeEnv, envir.PairsToMap(os.Environ()))
 	return pathStack.Has(d.ProjectDirHash())
 }
+
+func (d *Devbox) SkipInitHookEnvName() string {
+	return "__DEVBOX_SKIP_INIT_HOOK_" + d.ProjectDirHash()
+}

--- a/internal/shellgen/scripts.go
+++ b/internal/shellgen/scripts.go
@@ -2,14 +2,13 @@ package shellgen
 
 import (
 	"bytes"
+	_ "embed"
 	"fmt"
 	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
 	"text/template"
-
-	_ "embed"
 
 	"github.com/pkg/errors"
 	"go.jetpack.io/devbox/internal/boxcli/featureflag"
@@ -30,9 +29,9 @@ var initHookWrapperTmpl = template.Must(template.New("init-hook-wrapper").Parse(
 
 const scriptsDir = ".devbox/gen/scripts"
 
-// HooksFilename is the name of the file that contains a wrapper of the
-// project's init-hooks and plugin hooks
 const (
+	// HooksFilename is the name of the file that contains a wrapper of the
+	// project's init-hooks and plugin hooks
 	HooksFilename    = ".hooks"
 	rawHooksFilename = ".raw-hooks"
 )

--- a/internal/shellgen/tmpl/init-hook-wrapper.tmpl
+++ b/internal/shellgen/tmpl/init-hook-wrapper.tmpl
@@ -1,9 +1,0 @@
-{{/*
-Wrapping the hooks ensures that any script called within doesn't trigger more
-init hooks.
-Code here should be fish and POSIX compatible. That's why we use export to 
-remove the value
-*/ -}}
-export {{ .InitHookHash }}=true
-. {{ .RawHooksFile }}
-export {{ .InitHookHash }}=""

--- a/internal/shellgen/tmpl/script-wrapper.tmpl
+++ b/internal/shellgen/tmpl/script-wrapper.tmpl
@@ -7,8 +7,7 @@
     scripts. (though users can run a fish script within their script)
 */ -}}
 
-if [ -z "${{ .InitHookHash }}" ]; then
-    {{/* init hooks will export InitHookHash ensuring no recursive sourcing*/ -}}
+if [ -z "${{ .SkipInitHookHash }}" ]; then
     . {{ .InitHookPath }}
 fi
 


### PR DESCRIPTION
## Summary

This PR implements a change to the semantics of `devbox run`.
BEFORE:
`devbox run` would always ensure that the Devbox State and Environment is up-to-date.
AFTER:
`devbox run` will only do so when _outside_ a Devbox Environment (i.e. `devbox shell` or equivalent like direnv-enabled shell).

The motivation is two fold:
1. Speed. Users often want to just run a quick script, this slows them down.
2. Users often have init-hooks which are more appropriate for one-time setup, rather than when running a utility script inside a `devbox shell` that has already been set up appropriately.

This was shared in the Discord channel for feedback: https://discord.com/channels/903306922852245526/1009933892385517619/1248724103750483978

Notably, the focus there was on skipping the init-hooks, but in this PR, we are going one-step beyond that to ensure the Devbox State itself is not re-computed. The reason is that rather than _partially_ updating the Devbox State and Environment (partially, because init-hooks are part of setting up the environment) we'd rather eschew the step entirely. This feels more straightforward for users to reason about.

## How was it tested?

Did a basic sanity test in two scenarios:

1. Running the script in a `devbox shell` or direnv-enabled environment does NOT recompute the Devbox state.
2. Repeated the sanity test when outside of the Devbox environment, and confirmed it does recompute the Devbox state.