### PR TITLE
[RFC][Devbox] computeEnv: remove __ETC_PROFILE_NIX_SOURCED=1

### DIFF
--- a/internal/devbox/devbox.go
+++ b/internal/devbox/devbox.go
@@ -892,10 +892,6 @@ func (d *Devbox) computeEnv(ctx context.Context, usePrintDevEnvCache bool) (map[
 		env[key] = val.Value.(string)
 	}
 
-	// These variables are only needed for shell, but we include them here in the computed env
-	// for both shell and run in order to be as identical as possible.
-	env["__ETC_PROFILE_NIX_SOURCED"] = "1" // Prevent user init file from loading nix profiles
-
 	slog.Debug("nix environment PATH", "path", env)
 
 	env["PATH"] = envpath.JoinPathLists(

--- a/testscripts/run/env.test.txt
+++ b/testscripts/run/env.test.txt
@@ -11,10 +11,6 @@ stdout 'test-user'
 exec devbox run echo '$FOO'
 stdout 'bar'
 
-# Fixed/hard-coded vars are set
-exec devbox run echo '$__ETC_PROFILE_NIX_SOURCED'
-stdout '1'
-
 # DEVBOX_* vars are passed through
 env DEVBOX_FOO=baz
 exec devbox run echo '$DEVBOX_FOO'


### PR DESCRIPTION
## Summary

This was introduced in #635 (cc @ipince). I don't think its needed anymore. 
It seems to be used in the `/nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh` script, at the very top to prevent re-execution:
```
  1 # Only execute this file once per shell.
  2 if [ -n "${__ETC_PROFILE_NIX_SOURCED:-}" ]; then return; fi
  3 __ETC_PROFILE_NIX_SOURCED=1
  4
```
Perhaps it has other use-cases as well? RFC.


From my casual usage of a Devbox binary built with this change, it all seems to still work fine.



## How was it tested?
