### PR TITLE
[devbox global] add `--omit-nix-env` flag for shellenv/shell/run commands

### DIFF
--- a/internal/boxcli/global.go
+++ b/internal/boxcli/global.go
@@ -28,17 +28,10 @@ func globalCmd() *cobra.Command {
 		PersistentPostRunE: ensureGlobalEnvEnabled,
 	}
 
-	shellEnv := shellEnvCmd()
-	// For `devbox shellenv` the default value of recompute is true.
-	// Change the default value to false for `devbox global shellenv` only.
-	shellEnv.Flag("recompute").DefValue = "false" // Needed for help text
-	if err := shellEnv.Flag("recompute").Value.Set("false"); err != nil {
-		// This will never panic because internally it just does
-		// `strconv.ParseBool("false")` which is always valid.
-		// If this were to change, we'll immediately detect this during development
-		// since this code always runs on any devbox command (and will fix it).
-		panic(errors.WithStack(err))
-	}
+	shellEnv := shellEnvCmd(
+		withEnvForPackageBins(true),
+		withRecompute(false),
+	)
 
 	addCommandAndHideConfigFlag(globalCmd, addCmd())
 	addCommandAndHideConfigFlag(globalCmd, installCmd())

--- a/internal/boxcli/global.go
+++ b/internal/boxcli/global.go
@@ -28,20 +28,19 @@ func globalCmd() *cobra.Command {
 		PersistentPostRunE: ensureGlobalEnvEnabled,
 	}
 
-	shellEnv := shellEnvCmd(
-		withEnvForPackageBins(true),
-		withRecompute(false),
-	)
-
 	addCommandAndHideConfigFlag(globalCmd, addCmd())
 	addCommandAndHideConfigFlag(globalCmd, installCmd())
 	addCommandAndHideConfigFlag(globalCmd, pathCmd())
 	addCommandAndHideConfigFlag(globalCmd, pullCmd())
 	addCommandAndHideConfigFlag(globalCmd, pushCmd())
 	addCommandAndHideConfigFlag(globalCmd, removeCmd())
-	addCommandAndHideConfigFlag(globalCmd, runCmd())
+	addCommandAndHideConfigFlag(globalCmd, runCmd(runFlagDefaults{
+		omitNixEnv: true,
+	}))
 	addCommandAndHideConfigFlag(globalCmd, servicesCmd(persistentPreRunE))
-	addCommandAndHideConfigFlag(globalCmd, shellEnv)
+	addCommandAndHideConfigFlag(globalCmd, shellEnvCmd(shellenvFlagDefaults{
+		omitNixEnv: true,
+	}))
 	addCommandAndHideConfigFlag(globalCmd, updateCmd())
 	addCommandAndHideConfigFlag(globalCmd, listCmd())
 

--- a/internal/boxcli/root.go
+++ b/internal/boxcli/root.go
@@ -71,12 +71,14 @@ func RootCmd() *cobra.Command {
 	command.AddCommand(listCmd())
 	command.AddCommand(logCmd())
 	command.AddCommand(removeCmd())
-	command.AddCommand(runCmd())
+	command.AddCommand(runCmd(runFlagDefaults{}))
 	command.AddCommand(searchCmd())
 	command.AddCommand(servicesCmd())
 	command.AddCommand(setupCmd())
-	command.AddCommand(shellCmd())
-	command.AddCommand(shellEnvCmd())
+	command.AddCommand(shellCmd(shellFlagDefaults{}))
+	command.AddCommand(shellEnvCmd(shellenvFlagDefaults{
+		recomputeEnv: true,
+	}))
 	command.AddCommand(updateCmd())
 	command.AddCommand(versionCmd())
 	// Preview commands

--- a/internal/boxcli/run.go
+++ b/internal/boxcli/run.go
@@ -22,11 +22,18 @@ import (
 type runCmdFlags struct {
 	envFlag
 	config      configFlags
+	omitNixEnv  bool
 	pure        bool
 	listScripts bool
 }
 
-func runCmd() *cobra.Command {
+// runFlagDefaults are the flag default values that differ
+// from the `devbox` command versus `devbox global` command.
+type runFlagDefaults struct {
+	omitNixEnv bool
+}
+
+func runCmd(defaults runFlagDefaults) *cobra.Command {
 	flags := runCmdFlags{}
 	command := &cobra.Command{
 		Use:   "run [<script> | <cmd>]",
@@ -50,6 +57,11 @@ func runCmd() *cobra.Command {
 		&flags.pure, "pure", false, "if this flag is specified, devbox runs the script in an isolated environment inheriting almost no variables from the current environment. A few variables, in particular HOME, USER and DISPLAY, are retained.")
 	command.Flags().BoolVarP(
 		&flags.listScripts, "list", "l", false, "list all scripts defined in devbox.json")
+	command.Flags().BoolVar(
+		&flags.omitNixEnv, "omit-nix-env", defaults.omitNixEnv,
+		"shell environment will omit the env-vars from print-dev-env",
+	)
+	_ = command.Flags().MarkHidden("omit-nix-env")
 
 	command.ValidArgs = listScripts(command, flags)
 
@@ -102,6 +114,7 @@ func runScriptCmd(cmd *cobra.Command, args []string, flags runCmdFlags) error {
 		Dir:         path,
 		Environment: flags.config.environment,
 		Stderr:      cmd.ErrOrStderr(),
+		OmitNixEnv:  flags.omitNixEnv,
 		Pure:        flags.pure,
 		Env:         env,
 	})

--- a/internal/boxcli/shell.go
+++ b/internal/boxcli/shell.go
@@ -17,12 +17,19 @@ import (
 
 type shellCmdFlags struct {
 	envFlag
-	config   configFlags
-	printEnv bool
-	pure     bool
+	config     configFlags
+	omitNixEnv bool
+	printEnv   bool
+	pure       bool
 }
 
-func shellCmd() *cobra.Command {
+// shellFlagDefaults are the flag default values that differ
+// from the `devbox` command versus `devbox global` command.
+type shellFlagDefaults struct {
+	omitNixEnv bool
+}
+
+func shellCmd(defaults shellFlagDefaults) *cobra.Command {
 	flags := shellCmdFlags{}
 	command := &cobra.Command{
 		Use:   "shell",
@@ -41,6 +48,11 @@ func shellCmd() *cobra.Command {
 		&flags.printEnv, "print-env", false, "print script to setup shell environment")
 	command.Flags().BoolVar(
 		&flags.pure, "pure", false, "if this flag is specified, devbox creates an isolated shell inheriting almost no variables from the current environment. A few variables, in particular HOME, USER and DISPLAY, are retained.")
+	command.Flags().BoolVar(
+		&flags.omitNixEnv, "omit-nix-env", defaults.omitNixEnv,
+		"shell environment will omit the env-vars from print-dev-env",
+	)
+	_ = command.Flags().MarkHidden("omit-nix-env")
 
 	flags.config.register(command)
 	flags.envFlag.register(command)
@@ -57,6 +69,7 @@ func runShellCmd(cmd *cobra.Command, flags shellCmdFlags) error {
 		Dir:         flags.config.path,
 		Env:         env,
 		Environment: flags.config.environment,
+		OmitNixEnv:  flags.omitNixEnv,
 		Pure:        flags.pure,
 		Stderr:      cmd.ErrOrStderr(),
 	})

--- a/internal/devbox/devbox.go
+++ b/internal/devbox/devbox.go
@@ -898,8 +898,6 @@ func (d *Devbox) computeEnv(ctx context.Context, usePrintDevEnvCache bool) (map[
 	originalEnv := make(map[string]string, len(env))
 	maps.Copy(originalEnv, env)
 
-	// TODO: look up callers of computeEnv to ensure we properly cache print-dev-env
-	// when needed in the product flows
 	if !d.omitNixEnv {
 		nixEnv, err := d.execPrintDevEnv(ctx, usePrintDevEnvCache)
 		if err != nil {

--- a/internal/devbox/devbox.go
+++ b/internal/devbox/devbox.go
@@ -59,6 +59,7 @@ const (
 type Devbox struct {
 	cfg                      *devconfig.Config
 	env                      map[string]string
+	envForPackageBins        bool
 	environment              string
 	lockfile                 *lock.File
 	nix                      nix.Nixer
@@ -97,6 +98,7 @@ func Open(opts *devopt.Opts) (*Devbox, error) {
 	box := &Devbox{
 		cfg:                      cfg,
 		env:                      opts.Env,
+		envForPackageBins:        opts.EnvForPackageBins,
 		environment:              environment,
 		nix:                      &nix.Nix{},
 		projectDir:               projectDir,
@@ -791,6 +793,61 @@ func (d *Devbox) StartProcessManager(
 	)
 }
 
+func (d *Devbox) execPrintDevEnv(ctx context.Context, usePrintDevEnvCache bool) (map[string]string, error) {
+	var spinny *spinner.Spinner
+	if !usePrintDevEnvCache {
+		spinny = spinner.New(spinner.CharSets[11], 100*time.Millisecond, spinner.WithWriter(d.stderr))
+		spinny.FinalMSG = "✓ Computed the Devbox environment.\n"
+		spinny.Suffix = " Computing the Devbox environment...\n"
+		spinny.Start()
+	}
+
+	vaf, err := d.nix.PrintDevEnv(ctx, &nix.PrintDevEnvArgs{
+		FlakeDir:             d.flakeDir(),
+		PrintDevEnvCachePath: d.nixPrintDevEnvCachePath(),
+		UsePrintDevEnvCache:  usePrintDevEnvCache,
+	})
+	if spinny != nil {
+		spinny.Stop()
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	// Add environment variables from "nix print-dev-env" except for a few
+	// special ones we need to ignore.
+	env := map[string]string{}
+	for key, val := range vaf.Variables {
+		// We only care about "exported" because the var and array types seem to only be used by nix-defined
+		// functions that we don't need (like genericBuild). For reference, each type translates to bash as follows:
+		// var: export VAR=VAL
+		// exported: export VAR=VAL
+		// array: declare -a VAR=('VAL1' 'VAL2' )
+		if val.Type != "exported" {
+			continue
+		}
+
+		// SSL_CERT_FILE is a special-case. We only ignore it if it's
+		// set to a specific value. This emulates the behavior of
+		// "nix develop".
+		if key == "SSL_CERT_FILE" && val.Value.(string) == "/no-cert-file.crt" {
+			continue
+		}
+
+		// Certain variables get set to invalid values after Nix builds
+		// the shell environment. For example, HOME=/homeless-shelter
+		// and TMPDIR points to a missing directory. We want to ignore
+		// those values and just use the values from the current
+		// environment instead.
+		if ignoreDevEnvVar[key] {
+			continue
+		}
+
+		env[key] = val.Value.(string)
+	}
+	return env, nil
+}
+
 // computeEnv computes the set of environment variables that define a Devbox
 // environment. The "devbox run" and "devbox shell" commands source these
 // variables into a shell before executing a command or showing an interactive
@@ -841,58 +898,19 @@ func (d *Devbox) computeEnv(ctx context.Context, usePrintDevEnvCache bool) (map[
 	originalEnv := make(map[string]string, len(env))
 	maps.Copy(originalEnv, env)
 
-	var spinny *spinner.Spinner
-	if !usePrintDevEnvCache {
-		spinny = spinner.New(spinner.CharSets[11], 100*time.Millisecond, spinner.WithWriter(d.stderr))
-		spinny.FinalMSG = "✓ Computed the Devbox environment.\n"
-		spinny.Suffix = " Computing the Devbox environment...\n"
-		spinny.Start()
-	}
-
-	vaf, err := d.nix.PrintDevEnv(ctx, &nix.PrintDevEnvArgs{
-		FlakeDir:             d.flakeDir(),
-		PrintDevEnvCachePath: d.nixPrintDevEnvCachePath(),
-		UsePrintDevEnvCache:  usePrintDevEnvCache,
-	})
-	if spinny != nil {
-		spinny.Stop()
-	}
-	if err != nil {
-		return nil, err
-	}
-
-	// Add environment variables from "nix print-dev-env" except for a few
-	// special ones we need to ignore.
-	for key, val := range vaf.Variables {
-		// We only care about "exported" because the var and array types seem to only be used by nix-defined
-		// functions that we don't need (like genericBuild). For reference, each type translates to bash as follows:
-		// var: export VAR=VAL
-		// exported: export VAR=VAL
-		// array: declare -a VAR=('VAL1' 'VAL2' )
-		if val.Type != "exported" {
-			continue
+	// TODO: look up callers of computeEnv to ensure we properly cache print-dev-env
+	// when needed in the product flows
+	if !d.envForPackageBins {
+		nixEnv, err := d.execPrintDevEnv(ctx, usePrintDevEnvCache)
+		if err != nil {
+			return nil, err
 		}
 
-		// SSL_CERT_FILE is a special-case. We only ignore it if it's
-		// set to a specific value. This emulates the behavior of
-		// "nix develop".
-		if key == "SSL_CERT_FILE" && val.Value.(string) == "/no-cert-file.crt" {
-			continue
+		for k, v := range nixEnv {
+			env[k] = v
 		}
-
-		// Certain variables get set to invalid values after Nix builds
-		// the shell environment. For example, HOME=/homeless-shelter
-		// and TMPDIR points to a missing directory. We want to ignore
-		// those values and just use the values from the current
-		// environment instead.
-		if ignoreDevEnvVar[key] {
-			continue
-		}
-
-		env[key] = val.Value.(string)
 	}
-
-	slog.Debug("nix environment PATH", "path", env)
+	slog.Debug("nix environment PATH", "path", env["PATH"])
 
 	env["PATH"] = envpath.JoinPathLists(
 		nix.ProfileBinPath(d.projectDir),
@@ -979,9 +997,8 @@ func (d *Devbox) computeEnv(ctx context.Context, usePrintDevEnvCache bool) (map[
 	return env, d.addHashToEnv(env)
 }
 
-// ensureStateIsUpToDateAndComputeEnv will return a map of the env-vars for the Devbox  Environment
+// ensureStateIsUpToDateAndComputeEnv will return a map of the env-vars for the Devbox Environment
 // while ensuring these reflect the current (up to date) state of the project.
-// TODO: find a better name for this function.
 func (d *Devbox) ensureStateIsUpToDateAndComputeEnv(
 	ctx context.Context,
 ) (map[string]string, error) {

--- a/internal/devbox/devbox.go
+++ b/internal/devbox/devbox.go
@@ -59,7 +59,7 @@ const (
 type Devbox struct {
 	cfg                      *devconfig.Config
 	env                      map[string]string
-	envForPackageBins        bool
+	omitNixEnv               bool
 	environment              string
 	lockfile                 *lock.File
 	nix                      nix.Nixer
@@ -98,7 +98,7 @@ func Open(opts *devopt.Opts) (*Devbox, error) {
 	box := &Devbox{
 		cfg:                      cfg,
 		env:                      opts.Env,
-		envForPackageBins:        opts.EnvForPackageBins,
+		omitNixEnv:               opts.OmitNixEnv,
 		environment:              environment,
 		nix:                      &nix.Nix{},
 		projectDir:               projectDir,
@@ -900,7 +900,7 @@ func (d *Devbox) computeEnv(ctx context.Context, usePrintDevEnvCache bool) (map[
 
 	// TODO: look up callers of computeEnv to ensure we properly cache print-dev-env
 	// when needed in the product flows
-	if !d.envForPackageBins {
+	if !d.omitNixEnv {
 		nixEnv, err := d.execPrintDevEnv(ctx, usePrintDevEnvCache)
 		if err != nil {
 			return nil, err

--- a/internal/devbox/devopt/devboxopts.go
+++ b/internal/devbox/devopt/devboxopts.go
@@ -9,9 +9,13 @@ import (
 // - omit suffix Opts for other structs that are composed into an Opts struct
 
 type Opts struct {
-	Dir                      string
-	Env                      map[string]string
-	Environment              string
+	Dir         string
+	Env         map[string]string
+	Environment string
+	// EnvForPackageBins will create the Devbox environment from print-dev-env
+	// such that it is optimized for executing binaries, and not for developing
+	// software using dependencies installed in the Devbox environment.
+	EnvForPackageBins        bool
 	PreservePathStack        bool
 	Pure                     bool
 	IgnoreWarnings           bool

--- a/internal/devbox/devopt/devboxopts.go
+++ b/internal/devbox/devopt/devboxopts.go
@@ -9,13 +9,10 @@ import (
 // - omit suffix Opts for other structs that are composed into an Opts struct
 
 type Opts struct {
-	Dir         string
-	Env         map[string]string
-	Environment string
-	// EnvForPackageBins will create the Devbox environment from print-dev-env
-	// such that it is optimized for executing binaries, and not for developing
-	// software using dependencies installed in the Devbox environment.
-	EnvForPackageBins        bool
+	Dir                      string
+	Env                      map[string]string
+	Environment              string
+	OmitNixEnv               bool
 	PreservePathStack        bool
 	Pure                     bool
 	IgnoreWarnings           bool

--- a/internal/devbox/nixprofile.go
+++ b/internal/devbox/nixprofile.go
@@ -19,18 +19,19 @@ import (
 // It also removes any packages from the nix profile that are no longer in the buildInputs.
 func (d *Devbox) syncNixProfileFromFlake(ctx context.Context) error {
 	defer debug.FunctionTimer().End()
-	// Get the computed Devbox environment from the generated flake
-	env, err := d.computeEnv(ctx, false /*usePrintDevEnvCache*/)
+	// Get the buildInputs from the generated flake
+	env, err := d.execPrintDevEnv(ctx, false /*usePrintDevEnvCache*/)
 	if err != nil {
 		return err
 	}
+	buildInputs := env["buildInputs"]
 
 	// Get the store-paths of the packages we want installed in the nix profile
 	wantStorePaths := []string{}
-	if env["buildInputs"] != "" {
+	if buildInputs != "" {
 		// env["buildInputs"] can be empty string if there are no packages in the project
 		// if buildInputs is empty, then we don't want wantStorePaths to be an array with a single "" entry
-		wantStorePaths = strings.Split(env["buildInputs"], " ")
+		wantStorePaths = strings.Split(buildInputs, " ")
 	}
 
 	profilePath, err := d.profilePath()


### PR DESCRIPTION
…vars

## Summary

In this PR, we change `devbox global` shell environment to omit the env-vars from `nix print-dev-env`. Instead, we rely on the `nix profile` that Devbox manages to introduce the global packages into `PATH`. As before, `nix profile` continues to be generated from the `buildInputs` from `nix print-dev-env <devbox-generated-flake>`.

The motivation is:
1. `devbox global` adds a bunch of nix stdenv packages to the top of your `$PATH` variable, which can cause conflicts when trying to compile or build projects on your machine. 
2. `devbox global` also sets a global `PYTHONPATH` variable that interferes with other packages, as well as python scripts that are installed/running on the host. This global `PYTHONPATH` is unnecessary because any python binaries installed by the user are already wrapped with the `PYTHONPATH`


Implementation notes:
- Sets `Devbox.envForPackageBins` boolean setting that controls whether the Devbox Environment is optimized for executing package binaries, or for developing software using the packages.
   - [x] see if this can be passed down as a function parameter (see #2159)
- Adds `flagDefaultOptions` to `shellEnvCmd`. This is a nicer way of overriding the defaults in global, even for the `--recompute` flag that we had done before.
- Refactors code into a `devbox.execPrintDevEnv` function to remove some of the complexity from the `devbox.computeEnv` function (thanks to finger-wagging by our linter tool ;) ).

TODO:
- [x] Verify `omitNixEnv` is still properly handling the useNixPrintDevEnvCache call paths

## How was it tested?

CICD tests should pass

TODO:
- [x] Ensure the python global scenario works
- [x] Ensure we can use common packages (fzf, ripgrep, etc.) in `devbox global`
- [x] Thanks to @gcurtis vetted this PR helps resolve issues with a couple of repos:
   (rust: https://github.com/zed-industries/zed.git) and (golang with cgo: [github.com/Code-Hex/vz/example/macOS](http://github.com/Code-Hex/vz/example/macOS))

