### PR TITLE
boxcli: devbox cache enable

### DIFF
--- a/internal/boxcli/auth.go
+++ b/internal/boxcli/auth.go
@@ -38,7 +38,7 @@ func loginCmd() *cobra.Command {
 		Short: "Login to devbox",
 		Args:  cobra.ExactArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			c, err := identity.AuthClient()
+			c, err := identity.AuthClient(identity.AuthRedirectDefault)
 			if err != nil {
 				return err
 			}
@@ -62,7 +62,7 @@ func logoutCmd() *cobra.Command {
 		Short: "Logout from devbox",
 		Args:  cobra.ExactArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			c, err := identity.AuthClient()
+			c, err := identity.AuthClient(identity.AuthRedirectDefault)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
Don't merge until the new cloud.jetify.com/team/cache URL is live.

---

Add a `devbox cache enable` subcommand that:

1. Opens a browser and performs the login flow is the user isn't logged in.
2. Configures Nix to use the Jetify cache if it isn't already.

The login flow redirects to the new cloud.jetify.com/team/cache URL to let the user know the cache is enabled.