### PR TITLE
[Devbox] introduce devopt.EnvOptions

### DIFF
--- a/internal/boxcli/run.go
+++ b/internal/boxcli/run.go
@@ -73,7 +73,6 @@ func listScripts(cmd *cobra.Command, flags runCmdFlags) []string {
 		Dir:            flags.config.path,
 		Environment:    flags.config.environment,
 		Stderr:         cmd.ErrOrStderr(),
-		Pure:           flags.pure,
 		IgnoreWarnings: true,
 	})
 	if err != nil {
@@ -114,15 +113,17 @@ func runScriptCmd(cmd *cobra.Command, args []string, flags runCmdFlags) error {
 		Dir:         path,
 		Environment: flags.config.environment,
 		Stderr:      cmd.ErrOrStderr(),
-		OmitNixEnv:  flags.omitNixEnv,
-		Pure:        flags.pure,
 		Env:         env,
 	})
 	if err != nil {
 		return redact.Errorf("error reading devbox.json: %w", err)
 	}
 
-	if err := box.RunScript(cmd.Context(), script, scriptArgs); err != nil {
+	envOpts := devopt.EnvOptions{
+		OmitNixEnv: flags.omitNixEnv,
+		Pure:       flags.pure,
+	}
+	if err := box.RunScript(cmd.Context(), envOpts, script, scriptArgs); err != nil {
 		return redact.Errorf("error running script %q in Devbox: %w", script, err)
 	}
 	return nil

--- a/internal/boxcli/shell.go
+++ b/internal/boxcli/shell.go
@@ -69,8 +69,6 @@ func runShellCmd(cmd *cobra.Command, flags shellCmdFlags) error {
 		Dir:         flags.config.path,
 		Env:         env,
 		Environment: flags.config.environment,
-		OmitNixEnv:  flags.omitNixEnv,
-		Pure:        flags.pure,
 		Stderr:      cmd.ErrOrStderr(),
 	})
 	if err != nil {
@@ -93,7 +91,10 @@ func runShellCmd(cmd *cobra.Command, flags shellCmdFlags) error {
 		return shellInceptionErrorMsg("devbox shell")
 	}
 
-	return box.Shell(cmd.Context())
+	return box.Shell(cmd.Context(), devopt.EnvOptions{
+		OmitNixEnv: flags.omitNixEnv,
+		Pure:       flags.pure,
+	})
 }
 
 func shellInceptionErrorMsg(cmdPath string) error {

--- a/internal/boxcli/shellenv.go
+++ b/internal/boxcli/shellenv.go
@@ -95,13 +95,10 @@ func shellEnvFunc(
 		return "", err
 	}
 	box, err := devbox.Open(&devopt.Opts{
-		Dir:               flags.config.path,
-		Environment:       flags.config.environment,
-		OmitNixEnv:        flags.omitNixEnv,
-		Stderr:            cmd.ErrOrStderr(),
-		PreservePathStack: flags.preservePathStack,
-		Pure:              flags.pure,
-		Env:               env,
+		Dir:         flags.config.path,
+		Environment: flags.config.environment,
+		Stderr:      cmd.ErrOrStderr(),
+		Env:         env,
 	})
 	if err != nil {
 		return "", err
@@ -115,8 +112,13 @@ func shellEnvFunc(
 
 	envStr, err := box.EnvExports(cmd.Context(), devopt.EnvExportsOpts{
 		DontRecomputeEnvironment: !flags.recomputeEnv,
-		NoRefreshAlias:           flags.noRefreshAlias,
-		RunHooks:                 flags.runInitHook,
+		EnvOptions: devopt.EnvOptions{
+			OmitNixEnv:        flags.omitNixEnv,
+			PreservePathStack: flags.preservePathStack,
+			Pure:              flags.pure,
+		},
+		NoRefreshAlias: flags.noRefreshAlias,
+		RunHooks:       flags.runInitHook,
 	})
 	if err != nil {
 		return "", err

--- a/internal/devbox/devbox_test.go
+++ b/internal/devbox/devbox_test.go
@@ -46,7 +46,6 @@ func testShellPlan(t *testing.T, testPath string) {
 		_, err := Open(&devopt.Opts{
 			Dir:    baseDir,
 			Stderr: os.Stderr,
-			Pure:   false,
 		})
 		assert.NoErrorf(err, "%s should be a valid devbox project", baseDir)
 	})
@@ -71,7 +70,7 @@ func TestComputeEnv(t *testing.T) {
 	d := devboxForTesting(t)
 	d.nix = &testNix{}
 	ctx := context.Background()
-	env, err := d.computeEnv(ctx, false /*use cache*/)
+	env, err := d.computeEnv(ctx, false /*use cache*/, devopt.EnvOptions{})
 	require.NoError(t, err, "computeEnv should not fail")
 	assert.NotNil(t, env, "computeEnv should return a valid env")
 }
@@ -80,7 +79,7 @@ func TestComputeDevboxPathIsIdempotent(t *testing.T) {
 	devbox := devboxForTesting(t)
 	devbox.nix = &testNix{"/tmp/my/path"}
 	ctx := context.Background()
-	env, err := devbox.computeEnv(ctx, false /*use cache*/)
+	env, err := devbox.computeEnv(ctx, false /*use cache*/, devopt.EnvOptions{})
 	require.NoError(t, err, "computeEnv should not fail")
 	path := env["PATH"]
 	assert.NotEmpty(t, path, "path should not be nil")
@@ -90,7 +89,7 @@ func TestComputeDevboxPathIsIdempotent(t *testing.T) {
 	t.Setenv(envpath.PathStackEnv, env[envpath.PathStackEnv])
 	t.Setenv(envpath.Key(devbox.ProjectDirHash()), env[envpath.Key(devbox.ProjectDirHash())])
 
-	env, err = devbox.computeEnv(ctx, false /*use cache*/)
+	env, err = devbox.computeEnv(ctx, false /*use cache*/, devopt.EnvOptions{})
 	require.NoError(t, err, "computeEnv should not fail")
 	path2 := env["PATH"]
 
@@ -101,7 +100,7 @@ func TestComputeDevboxPathWhenRemoving(t *testing.T) {
 	devbox := devboxForTesting(t)
 	devbox.nix = &testNix{"/tmp/my/path"}
 	ctx := context.Background()
-	env, err := devbox.computeEnv(ctx, false /*use cache*/)
+	env, err := devbox.computeEnv(ctx, false /*use cache*/, devopt.EnvOptions{})
 	require.NoError(t, err, "computeEnv should not fail")
 	path := env["PATH"]
 	assert.NotEmpty(t, path, "path should not be nil")
@@ -113,7 +112,7 @@ func TestComputeDevboxPathWhenRemoving(t *testing.T) {
 	t.Setenv(envpath.Key(devbox.ProjectDirHash()), env[envpath.Key(devbox.ProjectDirHash())])
 
 	devbox.nix.(*testNix).path = ""
-	env, err = devbox.computeEnv(ctx, false /*use cache*/)
+	env, err = devbox.computeEnv(ctx, false /*use cache*/, devopt.EnvOptions{})
 	require.NoError(t, err, "computeEnv should not fail")
 	path2 := env["PATH"]
 	assert.NotContains(t, path2, "/tmp/my/path", "path should not contain /tmp/my/path")
@@ -128,7 +127,6 @@ func devboxForTesting(t *testing.T) *Devbox {
 	d, err := Open(&devopt.Opts{
 		Dir:    path,
 		Stderr: os.Stderr,
-		Pure:   false,
 	})
 	require.NoError(t, err, "Open should not fail")
 

--- a/internal/devbox/devopt/devboxopts.go
+++ b/internal/devbox/devopt/devboxopts.go
@@ -12,9 +12,6 @@ type Opts struct {
 	Dir                      string
 	Env                      map[string]string
 	Environment              string
-	OmitNixEnv               bool
-	PreservePathStack        bool
-	Pure                     bool
 	IgnoreWarnings           bool
 	CustomProcessComposeFile string
 	Stderr                   io.Writer
@@ -65,6 +62,17 @@ type UpdateOpts struct {
 
 type EnvExportsOpts struct {
 	DontRecomputeEnvironment bool
+	EnvOptions               EnvOptions
 	NoRefreshAlias           bool
 	RunHooks                 bool
+}
+
+// EnvOptions configure the Devbox Environment in the `computeEnv` function.
+// - These options are commonly set by flags in some Devbox commands
+// like `shellenv`, `shell` and `run`.
+// - The struct is designed for the "common case" to be zero-initialized as `EnvOptions{}`.
+type EnvOptions struct {
+	OmitNixEnv        bool
+	PreservePathStack bool
+	Pure              bool
 }

--- a/internal/devbox/shell.go
+++ b/internal/devbox/shell.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/alessio/shellescape"
 	"github.com/pkg/errors"
+	"go.jetpack.io/devbox/internal/devbox/devopt"
 	"go.jetpack.io/devbox/internal/shellgen"
 	"go.jetpack.io/devbox/internal/telemetry"
 
@@ -70,8 +71,8 @@ type ShellOption func(*DevboxShell)
 
 // NewDevboxShell initializes the DevboxShell struct so it can be used to start a shell environment
 // for the devbox project.
-func NewDevboxShell(devbox *Devbox, opts ...ShellOption) (*DevboxShell, error) {
-	shPath, err := shellPath(devbox)
+func NewDevboxShell(devbox *Devbox, envOpts devopt.EnvOptions, opts ...ShellOption) (*DevboxShell, error) {
+	shPath, err := shellPath(devbox, envOpts)
 	if err != nil {
 		return nil, err
 	}
@@ -87,14 +88,14 @@ func NewDevboxShell(devbox *Devbox, opts ...ShellOption) (*DevboxShell, error) {
 }
 
 // shellPath returns the path to a shell binary, or error if none found.
-func shellPath(devbox *Devbox) (path string, err error) {
+func shellPath(devbox *Devbox, envOpts devopt.EnvOptions) (path string, err error) {
 	defer func() {
 		if err != nil {
 			path = filepath.Clean(path)
 		}
 	}()
 
-	if !devbox.pure {
+	if !envOpts.Pure {
 		// First, check the SHELL environment variable.
 		path = os.Getenv(envir.Shell)
 		if path != "" {


### PR DESCRIPTION
## Summary

From the EnvOptions docblock:
```
// EnvOptions configure the Devbox Environment in the `computeEnv` function.
// - These options are commonly set by flags in some Devbox commands
// like `shellenv`, `shell` and `run`.
// - The struct is designed for the "common case" to be zero-initialized as `EnvOptions{}`.
```

This gets rid of the pseudo-global state in the `Devbox` struct where we were setting `pure`, `preservePathStack` and `omitNixEnv` values.

## How was it tested?

TODO:
- [x] CICD should pass
- [x] Ensure `devbox global` and `devbox` omitNixEnv works as expected
- [x] Ensure `pure` works as expected for `devbox shell --pure`.
