### PR TITLE
[lock-tidy] Put warning behind feature flag

### DIFF
--- a/internal/boxcli/featureflag/tidywarning.go
+++ b/internal/boxcli/featureflag/tidywarning.go
@@ -1,0 +1,6 @@
+// Copyright 2024 Jetify Inc. and contributors. All rights reserved.
+// Use of this source code is governed by the license in the LICENSE file.
+
+package featureflag
+
+var TidyWarning = disable("TIDY_WARNING")

--- a/internal/devpkg/package.go
+++ b/internal/devpkg/package.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/samber/lo"
+	"go.jetpack.io/devbox/internal/boxcli/featureflag"
 	"go.jetpack.io/devbox/internal/boxcli/usererr"
 	"go.jetpack.io/devbox/internal/cachehash"
 	"go.jetpack.io/devbox/internal/debug"
@@ -746,7 +747,7 @@ func (p *Package) GetStorePaths(ctx context.Context, w io.Writer) ([]string, err
 		return storePathsForPackage, err
 	}
 
-	if p.IsDevboxPackage {
+	if featureflag.TidyWarning.Enabled() && p.IsDevboxPackage {
 		// No fast path, we need to query nix.
 		ux.FHidableWarning(ctx, w, MissingStorePathsWarning, p.Raw)
 	}


### PR DESCRIPTION
## Summary

`--tidy-lockfile` is not reliable, so put this warning behind a feature flag until it is fixed.

## How was it tested?

Ran `devbox install` with missing outputs in lockfile, did not see error.
