### PR TITLE
[ux] Improve refresh messaging

### DIFF
--- a/internal/boxcli/shellenv.go
+++ b/internal/boxcli/shellenv.go
@@ -11,6 +11,7 @@ import (
 	"github.com/spf13/cobra"
 	"go.jetpack.io/devbox/internal/devbox"
 	"go.jetpack.io/devbox/internal/devbox/devopt"
+	"go.jetpack.io/devbox/internal/ux"
 )
 
 type shellEnvCmdFlags struct {
@@ -94,6 +95,10 @@ func shellEnvFunc(
 	if err != nil {
 		return "", err
 	}
+	ctx := cmd.Context()
+	if flags.recomputeEnv {
+		ctx = ux.HideMessage(ctx, devbox.StateOutOfDateMessage)
+	}
 	box, err := devbox.Open(&devopt.Opts{
 		Dir:         flags.config.path,
 		Environment: flags.config.environment,
@@ -105,12 +110,12 @@ func shellEnvFunc(
 	}
 
 	if flags.install {
-		if err := box.Install(cmd.Context()); err != nil {
+		if err := box.Install(ctx); err != nil {
 			return "", err
 		}
 	}
 
-	envStr, err := box.EnvExports(cmd.Context(), devopt.EnvExportsOpts{
+	envStr, err := box.EnvExports(ctx, devopt.EnvExportsOpts{
 		DontRecomputeEnvironment: !flags.recomputeEnv,
 		EnvOptions: devopt.EnvOptions{
 			OmitNixEnv:        flags.omitNixEnv,

--- a/internal/devbox/devbox.go
+++ b/internal/devbox/devbox.go
@@ -323,14 +323,11 @@ func (d *Devbox) EnvExports(ctx context.Context, opts devopt.EnvExportsOpts) (st
 	if opts.DontRecomputeEnvironment {
 		upToDate, _ := d.lockfile.IsUpToDateAndInstalled(isFishShell())
 		if !upToDate {
-			cmd := `eval "$(devbox global shellenv --recompute)"`
-			if isFishShell() {
-				cmd = `devbox global shellenv --recompute | source`
-			}
-			ux.Finfo(
+			ux.FHidableWarning(
+				ctx,
 				d.stderr,
-				"Your devbox environment may be out of date. Please run \n\n%s\n\n",
-				cmd,
+				StateOutOfDateMessage,
+				d.refreshAliasOrCommand(),
 			)
 		}
 

--- a/internal/devbox/packages.go
+++ b/internal/devbox/packages.go
@@ -37,6 +37,8 @@ import (
 	"go.jetpack.io/devbox/internal/ux"
 )
 
+var StateOutOfDateMessage = "Your devbox environment may be out of date. Run %s to update it.\n"
+
 // packages.go has functions for adding, removing and getting info about nix
 // packages
 
@@ -285,9 +287,10 @@ func (d *Devbox) ensureStateIsUpToDate(ctx context.Context, mode installMode) er
 	// be out of date after the user installs something. If have direnv active
 	// it should reload automatically so we don't need to refresh.
 	if d.IsEnvEnabled() && !upToDate && !d.IsDirenvActive() {
-		ux.Fwarning(
+		ux.FHidableWarning(
+			ctx,
 			d.stderr,
-			"Your shell environment may be out of date. Run `%s` to update it.\n",
+			StateOutOfDateMessage,
 			d.refreshAliasOrCommand(),
 		)
 	}

--- a/internal/devbox/packages.go
+++ b/internal/devbox/packages.go
@@ -37,7 +37,7 @@ import (
 	"go.jetpack.io/devbox/internal/ux"
 )
 
-var StateOutOfDateMessage = "Your devbox environment may be out of date. Run %s to update it.\n"
+const StateOutOfDateMessage = "Your devbox environment may be out of date. Run %s to update it.\n"
 
 // packages.go has functions for adding, removing and getting info about nix
 // packages

--- a/internal/devbox/refresh.go
+++ b/internal/devbox/refresh.go
@@ -28,7 +28,8 @@ func (d *Devbox) isGlobal() bool {
 // great, we just print out the entire command.
 func (d *Devbox) refreshAliasOrCommand() string {
 	if !d.isRefreshAliasSet() {
-		return d.refreshCmd()
+		// even if alias is not set, it might still be set by the end of this process
+		return fmt.Sprintf("`%s` or `%s`", d.refreshAliasName(), d.refreshCmd())
 	}
 	return d.refreshAliasName()
 }


### PR DESCRIPTION
## Summary

A few improvements:

* Use same refresh command. Previously we were using two different ways of refreshing the environment.
* Display `refresh-global` even if alias is not set (since it will likely be set by the end of the command).
* Don't show the refresh message will calling refresh.

## How was it tested?

* Tested refresh-global on zsh.
* TODO: test refresh-global on fish.
* Calling refresh-global does not show refresh message.
