### PR TITLE
[example] add R example

### DIFF
--- a/examples/data_science/R/.gitignore
+++ b/examples/data_science/R/.gitignore
@@ -1,0 +1,2 @@
+.RData
+.Rhistory

--- a/examples/data_science/R/README.md
+++ b/examples/data_science/R/README.md
@@ -1,0 +1,43 @@
+# R
+
+[R is a free software environment for statistical computing and graphics](https://www.r-project.org/).
+
+[**Example Repo**](https://github.com/jetify-com/devbox/tree/main/examples/data_science/R)
+
+## Adding R to your Project
+
+`devbox add R@4.4.1`, or in your `devbox.json` add:
+
+```json
+  "packages": [
+    "R@4.4.1"
+  ],
+```
+
+This will install R in your shell. You can find other versions of R by running `devbox search R`.
+You can also view the available versions on [Nixhub](https://www.nixhub.io/packages/R).
+
+## Installing Packages
+
+[CRAN](https://cran.r-project.org/) is the main repository of R packages.
+All of the CRAN packages are also available on [Nixhub](https://www.nixhub.io/).
+
+You can install packages by running `devbox add rPackages.package_name`, where `package_name` is the name of the package you would normally install with `install.packages()`.
+Note that for packages with a dot in the name you will need to replace the dot with an underscore, i.e. `data.table` -> `data_table` (see example below).
+
+```json
+{
+    "packages": [
+      "R@4.4.1",
+      "rPackages.data_table@latest",
+      "rPackages.ggplot2@latest",
+      "rPackages.tidyverse@latest"
+    ],
+}
+```
+
+You can access these packages in your R scripts as usual with `library(data.table)``.
+
+In this [example repo](https://github.com/jetify-com/devbox/tree/main/examples/data_science/R), after running `devbox shell`, you can start an R repl with `R` then create an example plot with `source("src/examplePlot.R")`. 
+Alternatively run `Rscript src/examplePlot.R`.
+This will create an `Rplots.pdf` file.

--- a/examples/data_science/R/README.md
+++ b/examples/data_science/R/README.md
@@ -38,6 +38,38 @@ Note that for packages with a dot in the name you will need to replace the dot w
 
 You can access these packages in your R scripts as usual with `library(data.table)``.
 
+## Example script
+
 In this [example repo](https://github.com/jetify-com/devbox/tree/main/examples/data_science/R), after running `devbox shell`, you can start an R repl with `R` then create an example plot with `source("src/examplePlot.R")`. 
 Alternatively run `Rscript src/examplePlot.R`.
 This will create an `Rplots.pdf` file.
+
+## Troubleshooting
+
+If you get warnings like:
+
+> During startup - Warning messages:
+> 1: setting LC_CTYPE failed, using "C"
+> 2: Setting LC_COLLATE failed, using "C"
+> ...
+
+then you need to set your locale.
+Find your locale (outside of a devbox shell) using `locale` in your terminal. You will see something like:
+
+> LANG=en_NZ.UTF-8
+> LANGUAGE=en_NZ:en
+> LC_CTYPE="en_NZ.UTF-8"
+> ...
+
+To set your locale, edit the `init_hook` array in the shell object in `devbox.json` to export two environment variables like below (using your specific locale):
+
+```json
+{
+  "shell": {
+    "init_hook": [
+      "export LANG=en_NZ.UTF-8",
+      "export LC_ALL=en_NZ.UTF-8"
+    ]
+  }
+}
+```

--- a/examples/data_science/R/devbox.json
+++ b/examples/data_science/R/devbox.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://raw.githubusercontent.com/jetify-com/devbox/0.10.6/.schema/devbox.schema.json",
+  "packages": [
+    "R@4.4.1",
+    "rPackages.data_table@latest",
+    "rPackages.ggplot2@latest",
+    "rPackages.tidyverse@latest",
+    "rPackages.dplyr@latest"
+  ],
+  "shell": {
+    "init_hook": [
+      "echo 'Welcome to devbox!' > /dev/null"
+    ],
+    "scripts": {
+      "test": [
+        "echo \"Error: no test specified\" && exit 1"
+      ]
+    }
+  }
+}

--- a/examples/data_science/R/devbox.lock
+++ b/examples/data_science/R/devbox.lock
@@ -1,0 +1,261 @@
+{
+  "lockfile_version": "1",
+  "packages": {
+    "R@4.4.1": {
+      "last_modified": "2024-07-07T16:08:25Z",
+      "resolved": "github:NixOS/nixpkgs/ab82a9612aa45284d4adf69ee81871a389669a9e#R",
+      "source": "devbox-search",
+      "version": "4.4.1",
+      "systems": {
+        "aarch64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/wzkkd1ks11fhs3qmwpqlw2vp9mrj5ybg-R-4.4.1",
+              "default": true
+            },
+            {
+              "name": "tex",
+              "path": "/nix/store/wj95kdg34ymx1mzxfzndqlv9qwl5vil2-R-4.4.1-tex"
+            }
+          ],
+          "store_path": "/nix/store/wzkkd1ks11fhs3qmwpqlw2vp9mrj5ybg-R-4.4.1"
+        },
+        "aarch64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/dhd5x58iq4k202pl0b4dy4rf78214ky7-R-4.4.1",
+              "default": true
+            },
+            {
+              "name": "tex",
+              "path": "/nix/store/zk6lv0ld9grlbijvljc3ny5zcjgrd31s-R-4.4.1-tex"
+            }
+          ],
+          "store_path": "/nix/store/dhd5x58iq4k202pl0b4dy4rf78214ky7-R-4.4.1"
+        },
+        "x86_64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/ci829l73v5j6vq4190pa8xshf8w2zjn8-R-4.4.1",
+              "default": true
+            },
+            {
+              "name": "tex",
+              "path": "/nix/store/zwax67ybxi49wkzm0wpfw45mwjh0wjm0-R-4.4.1-tex"
+            }
+          ],
+          "store_path": "/nix/store/ci829l73v5j6vq4190pa8xshf8w2zjn8-R-4.4.1"
+        },
+        "x86_64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/35ws8rzvrjhg9vr1sv05kh30401c25vw-R-4.4.1",
+              "default": true
+            },
+            {
+              "name": "tex",
+              "path": "/nix/store/sjsnn5mfmng8ki9ggrh00lzy2n7qry7g-R-4.4.1-tex"
+            }
+          ],
+          "store_path": "/nix/store/35ws8rzvrjhg9vr1sv05kh30401c25vw-R-4.4.1"
+        }
+      }
+    },
+    "rPackages.data_table@latest": {
+      "last_modified": "2024-07-07T07:43:47Z",
+      "resolved": "github:NixOS/nixpkgs/b60793b86201040d9dee019a05089a9150d08b5b#rPackages.data_table",
+      "source": "devbox-search",
+      "version": "1.15.4",
+      "systems": {
+        "aarch64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/1znk97633fypym8rzjrp6ylpikbgsq21-r-data.table-1.15.4",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/1znk97633fypym8rzjrp6ylpikbgsq21-r-data.table-1.15.4"
+        },
+        "aarch64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/wgy0m11pxcx0bk3aksr7hhz1gbhc3q44-r-data.table-1.15.4",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/wgy0m11pxcx0bk3aksr7hhz1gbhc3q44-r-data.table-1.15.4"
+        },
+        "x86_64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/4sgbnbs276rrx5r0ixymsrc6x1d3ynj6-r-data.table-1.15.4",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/4sgbnbs276rrx5r0ixymsrc6x1d3ynj6-r-data.table-1.15.4"
+        },
+        "x86_64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/z9k8fdb75qb210cznnx0pxlkmd4r72n1-r-data.table-1.15.4",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/z9k8fdb75qb210cznnx0pxlkmd4r72n1-r-data.table-1.15.4"
+        }
+      }
+    },
+    "rPackages.dplyr@latest": {
+      "last_modified": "2024-07-07T16:08:25Z",
+      "resolved": "github:NixOS/nixpkgs/ab82a9612aa45284d4adf69ee81871a389669a9e#rPackages.dplyr",
+      "source": "devbox-search",
+      "version": "1.1.4",
+      "systems": {
+        "aarch64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/swh5559irfb5cynm7vlrk6s5hyd9b9m6-r-dplyr-1.1.4",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/swh5559irfb5cynm7vlrk6s5hyd9b9m6-r-dplyr-1.1.4"
+        },
+        "aarch64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/vkgs1flmm0m4nx0rgydb00khx485zhm3-r-dplyr-1.1.4",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/vkgs1flmm0m4nx0rgydb00khx485zhm3-r-dplyr-1.1.4"
+        },
+        "x86_64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/79hkls1vz3399fbfhbfkdnpj3zngg0jv-r-dplyr-1.1.4",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/79hkls1vz3399fbfhbfkdnpj3zngg0jv-r-dplyr-1.1.4"
+        },
+        "x86_64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/7lsabh7q1ckp6pv968z64qbbzabkvr68-r-dplyr-1.1.4",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/7lsabh7q1ckp6pv968z64qbbzabkvr68-r-dplyr-1.1.4"
+        }
+      }
+    },
+    "rPackages.ggplot2@latest": {
+      "last_modified": "2024-07-07T16:08:25Z",
+      "resolved": "github:NixOS/nixpkgs/ab82a9612aa45284d4adf69ee81871a389669a9e#rPackages.ggplot2",
+      "source": "devbox-search",
+      "version": "3.5.1",
+      "systems": {
+        "aarch64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/n1zk4gzqdz3wqzsq8zjaia8z18ba3qrz-r-ggplot2-3.5.1",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/n1zk4gzqdz3wqzsq8zjaia8z18ba3qrz-r-ggplot2-3.5.1"
+        },
+        "aarch64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/lvfanffrdx1ghk8a1xxp92rwrpjr7888-r-ggplot2-3.5.1",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/lvfanffrdx1ghk8a1xxp92rwrpjr7888-r-ggplot2-3.5.1"
+        },
+        "x86_64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/dd73mgxzyk2yrra5rn9371ncp74gsa6w-r-ggplot2-3.5.1",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/dd73mgxzyk2yrra5rn9371ncp74gsa6w-r-ggplot2-3.5.1"
+        },
+        "x86_64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/vcw6gbyd4867m0x9qd3d1a4bkx2p21pr-r-ggplot2-3.5.1",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/vcw6gbyd4867m0x9qd3d1a4bkx2p21pr-r-ggplot2-3.5.1"
+        }
+      }
+    },
+    "rPackages.tidyverse@latest": {
+      "last_modified": "2024-07-07T07:43:47Z",
+      "resolved": "github:NixOS/nixpkgs/b60793b86201040d9dee019a05089a9150d08b5b#rPackages.tidyverse",
+      "source": "devbox-search",
+      "version": "2.0.0",
+      "systems": {
+        "aarch64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/p3x6f60xsrva2qbadjivk8bwr41s3xkb-r-tidyverse-2.0.0",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/p3x6f60xsrva2qbadjivk8bwr41s3xkb-r-tidyverse-2.0.0"
+        },
+        "aarch64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/raffylf8yn3saxw0q1vkijh9pl3c9svi-r-tidyverse-2.0.0",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/raffylf8yn3saxw0q1vkijh9pl3c9svi-r-tidyverse-2.0.0"
+        },
+        "x86_64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/622vvcavqwq4jynyw8nkzqspzi0wjivg-r-tidyverse-2.0.0",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/622vvcavqwq4jynyw8nkzqspzi0wjivg-r-tidyverse-2.0.0"
+        },
+        "x86_64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/9j633ss7p6lk1h1szsg0z7rgj0avvv6n-r-tidyverse-2.0.0",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/9j633ss7p6lk1h1szsg0z7rgj0avvv6n-r-tidyverse-2.0.0"
+        }
+      }
+    }
+  }
+}

--- a/examples/data_science/R/src/examplePlot.R
+++ b/examples/data_science/R/src/examplePlot.R
@@ -1,0 +1,19 @@
+# Load the required libraries
+library(data.table)
+library(ggplot2)
+
+# Create example data
+data <- data.table(
+  x = rnorm(100),  # 100 random numbers from a normal distribution
+  y = rnorm(100)   # 100 random numbers from a normal distribution
+)
+
+# Plot the data using ggplot2
+demoPlot <- ggplot(data, aes(x = x, y = y)) +
+  geom_point() +  # Create a scatter plot
+  theme_minimal() +  # Use a minimal theme
+  labs(title = "Scatter Plot of Random Data",
+       x = "X Axis",
+       y = "Y Axis")
+
+print(demoPlot)


### PR DESCRIPTION
## Summary

This adds README and example R script (along with devbox.lock and devbox.json)

## How was it tested?

I tested the example repo on both `aarch64-darwin` and `x86_64-linux` by `cd`'ing into `examples/data_science/R` directory; running `devbox shell` then `Rscript src/examplePlot.R`. I considered the test to have passed if an Rplots.pdf file was produced with a scatterplot image.

This *should* do for most R users. However there is a case that I haven't handled: Sometimes users will want to install packages that are not on CRAN and therefore not on nixpkgs/nixhub.io (e.g. installing packages from github using the `R` package `devtools`). I'm not sure of an easy way to address this yet.

Addresses https://github.com/jetify-com/devbox/issues/2182