### PR TITLE
Change the caddy example port to 8080

### DIFF
--- a/examples/servers/caddy/devbox.d/caddy/Caddyfile
+++ b/examples/servers/caddy/devbox.d/caddy/Caddyfile
@@ -2,11 +2,11 @@
 {
 	admin 0.0.0.0:2020
 	auto_https disable_certs
-	http_port 8800
+	http_port 8080
 	https_port 4443
 }
 
-:8082 {
+:8080 {
 	root * {$CADDY_ROOT_DIR}
 	log {
 		output file {$CADDY_LOG_DIR}/caddy.log

--- a/examples/servers/caddy/devbox.json
+++ b/examples/servers/caddy/devbox.json
@@ -3,7 +3,7 @@
     "caddy@latest"
   ],
   "shell": {
-    "init_hook": null,
+    "init_hook": [],
     "scripts": {
       "start": "caddy run --config=devbox.d/caddy/Caddyfile"
     }


### PR DESCRIPTION
## Summary
TSIA. The caddy example did not work before, as the port `8800` is served, but only port `8082` is defined.

## How was it tested?
devbox run start