### PR TITLE
testscripts: python tests for numpy and psycopg2

### DIFF
--- a/devbox.json
+++ b/devbox.json
@@ -39,6 +39,27 @@
       "test-projects-only": "DEVBOX_RUN_PROJECT_TESTS=1 go test -v -timeout ${DEVBOX_GOLANG_TEST_TIMEOUT:-30m} ./... -run \"TestExamples|TestScriptsWithProjects\"",
       "update-examples":    "devbox run build && go run testscripts/testrunner/updater/main.go",
       "tidy":               "go mod tidy",
+
+      // docker-testscripts runs the testscripts with Docker to exercise
+      // Linux-specific tests. It invokes the test binary directly, so any extra
+      // test runner flags must have their "-test." prefix.
+      //
+      // For example, to only run Python tests:
+      //
+      //   devbox run docker-testscripts -test.run ^TestScripts$/python
+      "docker-testscripts": [
+        "cd testscripts",
+
+        // The Dockerfile looks for a testscripts-$TARGETOS-$TARGETARCH binary
+        // to run the tests. Pre-compiling a static test binary lets us avoid
+        // polluting the container with a Go toolchain or shared libraries that
+        // might interfere with linker tests.
+        "trap 'rm -f testscripts-linux-amd64 testscripts-linux-arm64' EXIT",
+        "GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go test -c -o testscripts-linux-amd64",
+        "GOOS=linux GOARCH=arm64 CGO_ENABLED=0 go test -c -o testscripts-linux-arm64",
+        "image=$(docker build --quiet --tag devbox-ubuntu:noble --platform linux/amd64 .)",
+        "docker run --rm --platform linux/amd64 -e DEVBOX_RUN_FAILING_TESTS -e DEVBOX_RUN_PROJECT_TESTS -e DEVBOX_DEBUG $image \"$@\"",
+      ],
     },
   },
 }

--- a/testscripts/Dockerfile
+++ b/testscripts/Dockerfile
@@ -1,0 +1,40 @@
+# syntax=docker/dockerfile:1
+
+# This Dockerfile is designed to be as distro-agnostic as possible. By default
+# it uses ubuntu:noble as its base image, but this can be overridden by setting
+# the BASEIMAGE and BASETAG build args. This makes it easier to run Devbox tests
+# against different distros/versions without creating a bunch of separate
+# Dockerfiles.
+
+ARG BASEIMAGE=ubuntu
+ARG BASETAG=noble
+
+FROM scratch AS installer
+
+ADD --chmod=0755 --link https://install.determinate.systems/nix/nix-installer-x86_64-linux /nix-installer-linux-amd64
+ADD --chmod=0755 --link https://install.determinate.systems/nix/nix-installer-aarch64-linux /nix-installer-linux-arm64
+
+FROM $BASEIMAGE:$BASETAG
+
+ARG TARGETOS
+ARG TARGETARCH
+
+COPY --from=installer --link /nix-installer-$TARGETOS-$TARGETARCH nix-installer
+RUN <<EOF
+set -e
+
+# Setting this env var is the same as passing --extra-conf to nix-installer.
+export NIX_INSTALLER_EXTRA_CONF="filter-syscalls = false
+sandbox = false"
+
+./nix-installer install linux --no-confirm --logger full --init none
+rm nix-installer
+EOF
+ENV SSL_CERT_FILE=/nix/var/nix/profiles/default/etc/ssl/certs/ca-bundle.crt
+
+COPY --link */*.test.txt /devbox/testscripts/
+COPY --link testscripts-$TARGETOS-$TARGETARCH /devbox/testscripts/test
+
+VOLUME /nix/store
+WORKDIR /devbox/testscripts
+ENTRYPOINT [ "/devbox/testscripts/test" ]

--- a/testscripts/languages/python_missing_so.test.txt
+++ b/testscripts/languages/python_missing_so.test.txt
@@ -1,0 +1,113 @@
+# Python Missing Shared Library Test
+#
+# Install NumPy as a binary wheel using pip and verify that it loads.
+# The PIP_ONLY_BINARY environment variable forces downloading the binary wheel.
+#
+# Naively installing and loading NumPy fails because it cannot find
+# libstdc++.so. The nixpkgs Python interpreter doesn't search standard system
+# paths, so Devbox must patch it or provide the location of native dependencies.
+
+[!env:DEVBOX_RUN_FAILING_TESTS] [linux] skip 'this test doesn''t pass on Linux yet'
+
+exec devbox install
+
+# pip install numpy
+exec devbox run venv -- pip install numpy==2.1.0
+stdout 'Successfully installed numpy'
+
+# run python test script that imports numpy
+exec devbox run venv -- python main.py
+! stderr 'libstdc\+\+\.so\.6: cannot open shared object file: No such file or directory'
+
+-- main.py --
+import numpy
+
+array = numpy.array([1, 2, 3, 4, 5])
+print("Array:", array)
+print("Mean:", numpy.mean(array))
+
+-- devbox.json --
+{
+  "packages": {
+    "python": "latest"
+  },
+  "env": {
+    "PIP_DISABLE_PIP_VERSION_CHECK": "1",
+    "PIP_NO_CACHE_DIR":              "1",
+    "PIP_NO_INPUT":                  "1",
+    "PIP_NO_PYTHON_VERSION_WARNING": "1",
+    "PIP_ONLY_BINARY":               "numpy",
+    "PIP_PROGRESS_BAR":              "off",
+    "PIP_REQUIRE_VIRTUALENV":        "1",
+    "PIP_ROOT_USER_ACTION":          "ignore"
+  },
+  "shell": {
+    "scripts": {
+      "venv": ". $VENV_DIR/bin/activate && \"$@\""
+    }
+  }
+}
+
+-- devbox.lock --
+{
+  "lockfile_version": "1",
+  "packages": {
+    "python@latest": {
+      "last_modified":  "2024-07-07T07:43:47Z",
+      "plugin_version": "0.0.3",
+      "resolved":       "github:NixOS/nixpkgs/b60793b86201040d9dee019a05089a9150d08b5b#python3",
+      "source":         "devbox-search",
+      "version":        "3.12.4",
+      "systems": {
+        "aarch64-darwin": {
+          "outputs": [
+            {
+              "name":    "out",
+              "path":    "/nix/store/3swy1vadi125g0c1vxqp8ykdr749803j-python3-3.12.4",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/3swy1vadi125g0c1vxqp8ykdr749803j-python3-3.12.4"
+        },
+        "aarch64-linux": {
+          "outputs": [
+            {
+              "name":    "out",
+              "path":    "/nix/store/sz2facg15yq3ziqkidb1dkkglwzkkg8a-python3-3.12.4",
+              "default": true
+            },
+            {
+              "name": "debug",
+              "path": "/nix/store/19vjjqg7jbfblqapf63nm9ich1xdq9dx-python3-3.12.4-debug"
+            }
+          ],
+          "store_path": "/nix/store/sz2facg15yq3ziqkidb1dkkglwzkkg8a-python3-3.12.4"
+        },
+        "x86_64-darwin": {
+          "outputs": [
+            {
+              "name":    "out",
+              "path":    "/nix/store/3y5wy1i9nq5293knm23mxsj5l6w41h2l-python3-3.12.4",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/3y5wy1i9nq5293knm23mxsj5l6w41h2l-python3-3.12.4"
+        },
+        "x86_64-linux": {
+          "outputs": [
+            {
+              "name":    "out",
+              "path":    "/nix/store/z7xxy35k7620hs6fn6la5fg2lgklv72l-python3-3.12.4",
+              "default": true
+            },
+            {
+              "name": "debug",
+              "path": "/nix/store/3x6jqv5yw212v8rlwql88cn94dginq32-python3-3.12.4-debug"
+            }
+          ],
+          "store_path": "/nix/store/z7xxy35k7620hs6fn6la5fg2lgklv72l-python3-3.12.4"
+        }
+      }
+    }
+  }
+}

--- a/testscripts/languages/python_old_glibc.test.txt
+++ b/testscripts/languages/python_old_glibc.test.txt
@@ -1,0 +1,215 @@
+# Python Old glibc Test
+#
+# Check that an older version of the Python interpreter (3.7) can import and run
+# pip packages that are built from source.
+
+[!env:DEVBOX_RUN_FAILING_TESTS] [linux] skip 'this test doesn''t pass on Linux yet'
+
+exec devbox install
+
+# pip install psycopg2
+exec devbox run venv -- pip install psycopg2==2.9.5
+stdout 'Successfully installed psycopg2'
+
+# run python test script that imports psycopg2
+exec devbox run venv -- python main.py
+! stderr '.*glibc-2.35-224/lib/libc\.so\.6: version `GLIBC_2.38'' not found \(required by .*/site-packages/psycopg2/_psycopg\.cpython-37m-x86_64-linux-gnu\.so\)'
+
+-- main.py --
+import psycopg2
+
+try:
+    conn = psycopg2.connect(dbname="test", user="postgres")
+except psycopg2.OperationalError:
+    pass
+
+-- devbox.json --
+{
+  "packages": {
+    "python":     "3.7",
+    "postgresql": "15.5"
+  },
+  "env": {
+    "PIP_DISABLE_PIP_VERSION_CHECK": "1",
+    "PIP_NO_CACHE_DIR":              "1",
+    "PIP_NO_INPUT":                  "1",
+    "PIP_NO_PYTHON_VERSION_WARNING": "1",
+    "PIP_PROGRESS_BAR":              "off",
+    "PIP_REQUIRE_VIRTUALENV":        "1",
+    "PIP_ROOT_USER_ACTION":          "ignore"
+  },
+  "shell": {
+    "scripts": {
+      "venv": ". $VENV_DIR/bin/activate && \"$@\""
+    }
+  }
+}
+
+-- devbox.lock --
+{
+  "lockfile_version": "1",
+  "packages": {
+    "postgresql@latest": {
+      "last_modified":  "2024-02-22T01:07:56Z",
+      "plugin_version": "0.0.2",
+      "resolved":       "github:NixOS/nixpkgs/98b00b6947a9214381112bdb6f89c25498db4959#postgresql",
+      "source":         "devbox-search",
+      "version":        "15.5",
+      "systems": {
+        "aarch64-darwin": {
+          "outputs": [
+            {
+              "name":    "out",
+              "path":    "/nix/store/6cn0kmav77wba54xibfg9clqzbpan74b-postgresql-15.5",
+              "default": true
+            },
+            {
+              "name":    "man",
+              "path":    "/nix/store/588y60371pqh3vc9rasjawfwmchpac9d-postgresql-15.5-man",
+              "default": true
+            },
+            {
+              "name": "doc",
+              "path": "/nix/store/dxivb9x0iwssqzz8wsswis9q9r1sjm18-postgresql-15.5-doc"
+            },
+            {
+              "name": "lib",
+              "path": "/nix/store/dbc9hjh5ll5pjgxwl3r9nymdxw7sw8cl-postgresql-15.5-lib"
+            }
+          ]
+        },
+        "aarch64-linux": {
+          "outputs": [
+            {
+              "name":    "out",
+              "path":    "/nix/store/kvpjir3cjbijs2w8b20yzqjq0nsd63mp-postgresql-15.5",
+              "default": true
+            },
+            {
+              "name":    "man",
+              "path":    "/nix/store/4kcdjf0gg9jl4n9kxvj5iq92byry6b7l-postgresql-15.5-man",
+              "default": true
+            },
+            {
+              "name": "debug",
+              "path": "/nix/store/srqwd7alwglrsjclsfnrlx01n69iyy9s-postgresql-15.5-debug"
+            },
+            {
+              "name": "doc",
+              "path": "/nix/store/5fn32sdar6nk5ha9d5zb6rfpndgdbg68-postgresql-15.5-doc"
+            },
+            {
+              "name": "lib",
+              "path": "/nix/store/addi70hgggl75jm74p0s435bfaay6m1w-postgresql-15.5-lib"
+            }
+          ]
+        },
+        "x86_64-darwin": {
+          "outputs": [
+            {
+              "name":    "out",
+              "path":    "/nix/store/v5ym92k3kss1af7n1788653vis1d6qsc-postgresql-15.5",
+              "default": true
+            },
+            {
+              "name":    "man",
+              "path":    "/nix/store/x9hm4ip61cichmhzhzpykzypn3pqkh01-postgresql-15.5-man",
+              "default": true
+            },
+            {
+              "name": "doc",
+              "path": "/nix/store/nd1mhmgpm9w5rfpiibg6m7g4difpl5af-postgresql-15.5-doc"
+            },
+            {
+              "name": "lib",
+              "path": "/nix/store/q8lijs7rmlkx4qssmh0sjyy77f41y2jh-postgresql-15.5-lib"
+            }
+          ]
+        },
+        "x86_64-linux": {
+          "outputs": [
+            {
+              "name":    "out",
+              "path":    "/nix/store/vvd65gjggb2n8wxbsk1cyxx0wpfidagf-postgresql-15.5",
+              "default": true
+            },
+            {
+              "name":    "man",
+              "path":    "/nix/store/88jhk99imah1v19xqkldi1lfyaayni71-postgresql-15.5-man",
+              "default": true
+            },
+            {
+              "name": "lib",
+              "path": "/nix/store/w109qgbl14afcg5akhnahf8r0hkdqqb6-postgresql-15.5-lib"
+            },
+            {
+              "name": "debug",
+              "path": "/nix/store/ia44jr4m4jyf3a48qwpf6vgrr95jig46-postgresql-15.5-debug"
+            },
+            {
+              "name": "doc",
+              "path": "/nix/store/7vfnvfb6scmf23y6yj5zx8p5r3wsgnq5-postgresql-15.5-doc"
+            }
+          ]
+        }
+      }
+    },
+    "python@3.7": {
+      "last_modified":  "2022-12-17T09:19:40Z",
+      "plugin_version": "0.0.3",
+      "resolved":       "github:NixOS/nixpkgs/80c24eeb9ff46aa99617844d0c4168659e35175f#python37",
+      "source":         "devbox-search",
+      "version":        "3.7.16",
+      "systems": {
+        "aarch64-darwin": {
+          "outputs": [
+            {
+              "name":    "out",
+              "path":    "/nix/store/a89sd5jwn01cdg97lkspl8cpf75y5142-python3-3.7.16",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/a89sd5jwn01cdg97lkspl8cpf75y5142-python3-3.7.16"
+        },
+        "aarch64-linux": {
+          "outputs": [
+            {
+              "name":    "out",
+              "path":    "/nix/store/ymrbxfmljyl73rmh5cfk0bzk3ydcbqg8-python3-3.7.16",
+              "default": true
+            },
+            {
+              "name": "debug",
+              "path": "/nix/store/3x7736j3fyw6j9fzn1y9fc0iqyf1rncc-python3-3.7.16-debug"
+            }
+          ],
+          "store_path": "/nix/store/ymrbxfmljyl73rmh5cfk0bzk3ydcbqg8-python3-3.7.16"
+        },
+        "x86_64-darwin": {
+          "outputs": [
+            {
+              "name":    "out",
+              "path":    "/nix/store/i028a4nf177g23ksa7kc63ld9nys17nb-python3-3.7.16",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/i028a4nf177g23ksa7kc63ld9nys17nb-python3-3.7.16"
+        },
+        "x86_64-linux": {
+          "outputs": [
+            {
+              "name":    "out",
+              "path":    "/nix/store/ik7s754pwxhiky396mjagzmjs1kp0wzq-python3-3.7.16",
+              "default": true
+            },
+            {
+              "name": "debug",
+              "path": "/nix/store/l0xi13a88d4vjn8ada3a58zkwm88hq7h-python3-3.7.16-debug"
+            }
+          ],
+          "store_path": "/nix/store/ik7s754pwxhiky396mjagzmjs1kp0wzq-python3-3.7.16"
+        }
+      }
+    }
+  }
+}

--- a/testscripts/testrunner/setupenv.go
+++ b/testscripts/testrunner/setupenv.go
@@ -23,7 +23,10 @@ func setupTestEnv(t *testing.T, envs *testscript.Env) error {
 		return err
 	}
 
-	envs.Setenv(debug.DevboxDebug, os.Getenv(debug.DevboxDebug))
+	propagateEnvVars(envs,
+		debug.DevboxDebug, // to enable extra logging
+		"SSL_CERT_FILE",   // so HTTPS works with Nix-installed certs
+	)
 	return nil
 }
 
@@ -72,4 +75,14 @@ func setupCacheHome(envs *testscript.Env) error {
 	}
 
 	return nil
+}
+
+// propagateEnvVars propagates the values of environment variables to the test
+// environment.
+func propagateEnvVars(env *testscript.Env, vars ...string) {
+	for _, key := range vars {
+		if v, ok := os.LookupEnv(key); ok {
+			env.Setenv(key, v)
+		}
+	}
 }

--- a/testscripts/testrunner/testrunner.go
+++ b/testscripts/testrunner/testrunner.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -93,6 +94,16 @@ func getTestscriptParams(t *testing.T, dir string) testscript.Params {
 			"json.superset":                assertJSONSuperset,
 			"path.order":                   assertPathOrder,
 			"source.path":                  sourcePath,
+		},
+		Condition: func(cond string) (bool, error) {
+			before, key, found := strings.Cut(cond, ":")
+			if found && before == "env" {
+				if v, ok := os.LookupEnv(key); ok {
+					return strconv.ParseBool(v)
+				}
+				return false, nil
+			}
+			return false, fmt.Errorf("unknown condition: %v", cond)
 		},
 	}
 }


### PR DESCRIPTION
Add tests that install Python with Devbox and then run scripts that import numpy
and psycopg2. They currently fail on Linux due to linker errors related to missing shared libraries.

To run the tests on Linux with Docker, run:

	devbox run -e DEVBOX_RUN_FAILING_TESTS=1 docker-testscripts -test.run '^TestScripts$/python'

The new docker-testscripts script in devbox.json runs testscripts in a Docker
container to make it easier to test various Linux distros and architectures.