### PR TITLE
Nixhub Links

### DIFF
--- a/docs/app/docs/nixhub/index.mdx
+++ b/docs/app/docs/nixhub/index.mdx
@@ -17,21 +17,25 @@ import DocCardList from "@theme/DocCardList";
 <span
   className={"theme-doc-version-badge badge badge--secondary"}
   children={"Version: 2.0.0"}
+  style={{marginBottom:'20px'}}
 >
 </span>
 
 # Using the Nixhub API
 
-The Nixhub API lets you search over 1 million package versions for over 100,000 Nix packages. You can use the Nixhub API to search for packages, resolve historic versions, and then install them using Devbox or Nix. Nixhub is designed to be simple and easy to use, and is free to use for personal use. 
+The [**Nixhub**](https://www.nixhub.io) API lets you search over 1 million package versions for over 100,000 Nix packages. You can use the Nixhub API to search for packages, resolve historic versions, and then install them using Devbox or Nix. Nixhub is designed to be simple and easy to use, and is free to use for personal use. 
 
 Nixhub is a RESTful API that uses standard HTTP methods and status codes. Parameters are passed to the API as query parameters, and the API returns JSON responses. The current version does not make use of pagination, though this may be added in the future.
 
+The API is available for free for personal use, subject to rate limiting. If you need a higher rate limit or wish to use Devbox for a commercial project, you can [**request access to our paid tier**](https://form.typeform.com/to/hueeLe9S).
+
+### Endpoints
+
 Nixhub exposes the following endpoints for searching and resolving packages:
 
-- `v2/search` - Search for packages by name
-- `v2/pkg` - Get details and version history for a specific package
-- `v2/resolve` - Resolve a package name and version to a nixpkgs commit and attribute path.
-
+- [`v2/search`](./search-packages.api.mdx) - Search for packages by name
+- [`v2/pkg`](./get-a-package.api.mdx) - Get details and version history for a specific package
+- [`v2/resolve`](./resolve-a-package-version.api.mdx) - Resolve a package name and version to a nixpkgs commit and attribute path.
 
 ### Rate Limits
 
@@ -43,7 +47,15 @@ In order to prevent abuse, personal use of the API is subject to rate limits. AP
 
 If the pool is empty, the API will return a `429 Too Many Requests` status code.
 
-If you have a use case that requires a higher rate limit or would like to use the API for commercial purposes, please Contact Us. 
+:::tip
+
+If you have a use case that requires a higher rate limit or would like to use the API for commercial purposes, please fill out [**this form**](https://form.typeform.com/to/hueeLe9S) to request access.
+
+:::
+
+### Nixhub for Enterprise
+
+Nixhub provides an index of publicly available packages from the [Nixpkgs](https://github.com/nixos/nixpkgs) repository. If you're interested in using Nixhub to index and install private packages or Flakes for your team, we'd love to chat with you. You can request a meeting [**with our team**](https://calendly.com/d/cprm-dq6-y9y/nixhub-enterprise-chat)
 
 ### Versioning
 
@@ -55,5 +67,3 @@ The API is versioned using a `v2` prefix in the URL. All `v2` endpoints are cons
 * [Get Package Details](./get-a-package.api.mdx) - Get details and version history for a specific package
 * [Resolve Package](./resolve-a-package-version.api.mdx) - Resolve the latest available package for a given name and version string
 
-
-      


### PR DESCRIPTION
## Summary

Add links to typeform and calendly on Nixhub Docs page

## How was it tested?

Localhost
