### PR TITLE
[envars] Add DEVBOX_WD env var

### DIFF
--- a/internal/devbox/devbox.go
+++ b/internal/devbox/devbox.go
@@ -704,8 +704,14 @@ func (d *Devbox) computeEnv(
 		env["PATH"],
 	)
 
+	wd, err := os.Getwd()
+	if err != nil {
+		return nil, err
+	}
+
 	// Add helpful env vars for a Devbox project
 	env["DEVBOX_PROJECT_ROOT"] = d.projectDir
+	env["DEVBOX_WD"] = wd
 	env["DEVBOX_CONFIG_DIR"] = d.projectDir + "/devbox.d"
 	env["DEVBOX_PACKAGES_DIR"] = d.projectDir + "/" + nix.ProfilePath
 


### PR DESCRIPTION
## Summary

Adds new `DEVBOX_WD` env var that can be used in scripts and shell. It has the original directory where the devbox command was called. It's useful when the script is directory specific.

## How was it tested?

Added the following script:

`"print-wd": "echo PWD=$PWD DEVBOX_WD=$DEVBOX_WD",`
