### PR TITLE
fix: devbox-plugin.schema.json required properties

### DIFF
--- a/.schema/devbox-plugin.schema.json
+++ b/.schema/devbox-plugin.schema.json
@@ -142,5 +142,5 @@
       }
     }
   },
-  "required": ["name", "version", "readme"]
+  "required": ["name", "version", "description"]
 }


### PR DESCRIPTION
The list had `readme` instead of `description`

## Summary

## How was it tested?
