### PR TITLE
[pkg] Update pkg deps

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -42,7 +42,7 @@ require (
 	github.com/zealic/go2node v0.1.0
 	go.jetify.com/typeid v1.2.0
 	go.jetpack.io/envsec v0.0.16-0.20240604163020-540ad12af899
-	go.jetpack.io/pkg v0.0.0-20240604165525-bc24f2adac25
+	go.jetpack.io/pkg v0.0.0-20240815004735-7649b4283d51
 	golang.org/x/exp v0.0.0-20240604190554-fc45aab8b7f8
 	golang.org/x/mod v0.18.0
 	golang.org/x/oauth2 v0.21.0
@@ -89,7 +89,7 @@ require (
 	github.com/dsnet/compress v0.0.1 // indirect
 	github.com/go-errors/errors v1.5.1 // indirect
 	github.com/go-jose/go-jose/v3 v3.0.3 // indirect
-	github.com/gofrs/uuid/v5 v5.2.0 // indirect
+	github.com/gofrs/uuid/v5 v5.3.0 // indirect
 	github.com/golang/snappy v0.0.4 // indirect
 	github.com/google/btree v1.1.2 // indirect
 	github.com/google/go-github/v53 v53.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -161,6 +161,8 @@ github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0/go.mod h1:fyg78
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/gofrs/uuid/v5 v5.2.0 h1:qw1GMx6/y8vhVsx626ImfKMuS5CvJmhIKKtuyvfajMM=
 github.com/gofrs/uuid/v5 v5.2.0/go.mod h1:CDOjlDMVAtN56jqyRUZh58JT31Tiw7/oQyEXZV+9bD8=
+github.com/gofrs/uuid/v5 v5.3.0 h1:m0mUMr+oVYUdxpMLgSYCZiXe7PuVPnI94+OMeVBNedk=
+github.com/gofrs/uuid/v5 v5.3.0/go.mod h1:CDOjlDMVAtN56jqyRUZh58JT31Tiw7/oQyEXZV+9bD8=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20191227052852-215e87163ea7/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
@@ -383,6 +385,8 @@ go.jetpack.io/envsec v0.0.16-0.20240604163020-540ad12af899 h1:TfmHWWhwKu1jGmSLp8
 go.jetpack.io/envsec v0.0.16-0.20240604163020-540ad12af899/go.mod h1:LOdrWtfvoV9dPSVHWN0onLSqeYAOKrS7k1AzwpZg0X0=
 go.jetpack.io/pkg v0.0.0-20240604165525-bc24f2adac25 h1:orsMDGMS4vwdGy0LjF+2etV9AG83z0/ITCm1AfjltTI=
 go.jetpack.io/pkg v0.0.0-20240604165525-bc24f2adac25/go.mod h1:L2QkDS2uIGGONAElwpoeknyvue5gbuGmMGhZqpB/sE0=
+go.jetpack.io/pkg v0.0.0-20240815004735-7649b4283d51 h1:udl601M1zuLyjqsW4EAJRQ0ruTYq8DXbkcFg27Ydk4I=
+go.jetpack.io/pkg v0.0.0-20240815004735-7649b4283d51/go.mod h1:m65l3dl6aFQdVdSvAvih73ZEfs9ndbFGnw03RVC2HFU=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=
 go.opencensus.io v0.22.2/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=


### PR DESCRIPTION
## Summary

Uses newest version of runx (https://github.com/jetify-com/opensource/pull/368)

cc: @mikael-lindstrom

## How was it tested?

```
rm -rf ~/Library/Caches/runx/pkgs/mvdan
devbox run fmt  # which requires mvdan/gofumpt
```