### PR TITLE
testscripts: skip (known) failing tests on darwin

### DIFF
--- a/testscripts/languages/python_missing_so.test.txt
+++ b/testscripts/languages/python_missing_so.test.txt
@@ -7,7 +7,7 @@
 # libstdc++.so. The nixpkgs Python interpreter doesn't search standard system
 # paths, so Devbox must patch it or provide the location of native dependencies.
 
-[!env:DEVBOX_RUN_FAILING_TESTS] [linux] skip 'this test doesn''t pass on Linux yet'
+[!env:DEVBOX_RUN_FAILING_TESTS] skip 'this test doesn''t pass on Linux yet'
 
 exec devbox install
 

--- a/testscripts/languages/python_old_glibc.test.txt
+++ b/testscripts/languages/python_old_glibc.test.txt
@@ -3,7 +3,7 @@
 # Check that an older version of the Python interpreter (3.7) can import and run
 # pip packages that are built from source.
 
-[!env:DEVBOX_RUN_FAILING_TESTS] [linux] skip 'this test doesn''t pass on Linux yet'
+[!env:DEVBOX_RUN_FAILING_TESTS] skip 'this test doesn''t pass on Linux yet'
 
 exec devbox install
 


### PR DESCRIPTION
The Python linker tests that fail on Linux (which is expected) also fail on darwin. The darwin tests only run in the pre-release job, so it went unnoticed in the original PR.