### PR TITLE
patchpkg: patch missing Python refs on darwin

### DIFF
--- a/internal/devpkg/package.go
+++ b/internal/devpkg/package.go
@@ -187,8 +187,6 @@ func patchGlibcFunc(canonicalName string, mode configfile.PatchMode) func() bool
 		case configfile.PatchNever:
 			patch = false
 		}
-
-		// Check nix.SystemIsLinux() last because it's slow.
 		return patch
 	})
 }

--- a/internal/devpkg/package.go
+++ b/internal/devpkg/package.go
@@ -189,7 +189,7 @@ func patchGlibcFunc(canonicalName string, mode configfile.PatchMode) func() bool
 		}
 
 		// Check nix.SystemIsLinux() last because it's slow.
-		return patch && nix.SystemIsLinux()
+		return patch
 	})
 }
 

--- a/internal/patchpkg/builder.go
+++ b/internal/patchpkg/builder.go
@@ -232,7 +232,7 @@ func (d *DerivationBuilder) needsGlibcPatch(file *bufio.Reader, filePath string)
 
 func (d *DerivationBuilder) findRemovedRefs(ctx context.Context, pkg *packageFS) ([]fileSlice, error) {
 	var refs []fileSlice
-	matches, err := fs.Glob(pkg, "lib/python*/_sysconfigdata__linux*.py")
+	matches, err := fs.Glob(pkg, "lib/python*/_sysconfigdata_*.py")
 	if err != nil {
 		return nil, err
 	}

--- a/internal/shellgen/tmpl/glibc-patch.nix.tmpl
+++ b/internal/shellgen/tmpl/glibc-patch.nix.tmpl
@@ -73,7 +73,10 @@
           builtins.map (drv: drv.outPath) mkTree;
 
         # Programs needed by glibc-patch.bash.
-        inherit (nixpkgs-glibc.legacyPackages."${system}") bash coreutils glibc gnused patchelf ripgrep;
+        inherit (nixpkgs-glibc.legacyPackages."${system}") bash coreutils gnused patchelf ripgrep;
+
+        isLinux = (builtins.match ".*linux.*" system) != null;
+        glibc = if isLinux then nixpkgs-glibc.legacyPackages."${system}".glibc else null;
 
         # Create a package that puts the local devbox binary in the conventional
         # bin subdirectory. This also ensures that the executable is named
@@ -92,7 +95,9 @@
 
         DEVBOX_DEBUG = 1;
         builder = "${devbox}/bin/devbox";
-        args = [ "patch" "--restore-refs" "--glibc" glibc pkg ];
+        args = [ "patch" "--restore-refs" ] ++
+          (if glibc != null then [ "--glibc" "${glibc}" ] else [ ]) ++
+          [ pkg ];
       };
     in
     {


### PR DESCRIPTION
This enables the part of Python patching that restores some build dependencies on macOS. This fixes some `pip install` build errors for packages without needing to manually add dev dependencies on packages like openssl.