### PR TITLE
[Python] Change `.venv` script to be more compatible with IDEs

### DIFF
--- a/plugins/pip/venvShellHook.sh
+++ b/plugins/pip/venvShellHook.sh
@@ -1,8 +1,71 @@
-#!/bin/sh
+STATE_FILE="$DEVBOX_PROJECT_ROOT/.devbox/venv_check_completed"
 
-if ! [ -d "$VENV_DIR" ]; then
-    echo "Creating new venv environment in path: '${VENV_DIR}'"
-    python3 -m venv "$VENV_DIR"
-    echo "You can activate the virtual environment by running '. \$VENV_DIR/bin/activate' (for fish shell, replace '.' with 'source')" >&2
+is_valid_venv() {
+    [ -f "$1/bin/activate" ] && [ -f "$1/bin/python" ]
+}
+
+# Function to check if Python is a symlink to a Devbox Python
+is_devbox_python() {
+    if [ -z "$DEVBOX_PACKAGES_DIR" ]; then
+        echo "DEVBOX_PACKAGES_DIR is not set. Unable to check for Devbox Python."
+        return 1
+    fi
+    local python_path=$(readlink "$1/bin/python")
+    echo $python_path
+    echo $DEVBOX_PACKAGES_DIR
+    [[ $python_path == $DEVBOX_PACKAGES_DIR/bin/python* ]]
+}
+
+# Function to check Python version
+check_python_version() {
+    python_version=$(python -c 'import sys; print(".".join(map(str, sys.version_info[:2])))')
+    if [ "$(printf '%s\n' "3.3" "$python_version" | sort -V | head -n1)" = "3.3" ]; then
+        return 0
+    else
+        return 1
+    fi
+}
+
+# Check if we've already run this script
+if [ -f "$STATE_FILE" ]; then
+    exit 0
 fi
 
+# Check Python version
+if ! check_python_version; then
+    echo "\n\033[1;33m========================================\033[0m"
+    echo "\033[1;33mWARNING: Python version must be > 3.3 to create a virtual environment.\033[0m"
+    echo "\033[1;33m========================================\033[0m"
+    touch "$STATE_FILE"
+    exit 1
+fi
+
+# Check if the directory exists
+if [ -d "$VENV_DIR" ]; then
+    if is_valid_venv "$VENV_DIR"; then
+        if ! is_devbox_python "$VENV_DIR"; then
+            echo "\n\033[1;33m========================================\033[0m"
+            echo "\033[1;33mWARNING: Existing virtual environment doesn't use Devbox Python.\033[0m"
+            echo "\033[1;33m========================================\033[0m"
+            echo "Virtual environment: $VENV_DIR"
+            read -p "Do you want to overwrite it? (y/n) " -n 1 -r
+            echo
+            if [[ $REPLY =~ ^[Yy]$ ]]; then
+                echo "Overwriting existing virtual environment..."
+                rm -rf "$VENV_DIR"
+                python3 -m venv "$VENV_DIR"
+            else
+                echo "Operation cancelled."
+                touch "$STATE_FILE"
+                exit 1
+            fi
+        fi
+    else
+        echo "Directory exists but is not a valid virtual environment. Creating new one..."
+        rm -rf "$VENV_DIR"
+        python -m venv "$VENV_DIR"
+    fi
+else
+    echo "Virtual environment directory doesn't exist. Creating new one..."
+    python -m venv "$VENV_DIR"
+fi

--- a/plugins/pip/venvShellHook.sh
+++ b/plugins/pip/venvShellHook.sh
@@ -22,7 +22,7 @@ if [ -f "$STATE_FILE" ]; then
 fi
 
 # Check that Python version supports venv
-if ! python -c "import venv" &>/dev/null; then
+if ! python -c 'import venv' 1> /dev/null 2> /dev/null; then
     echo "\033[1;33mWARNING: Python version must be > 3.3 to create a virtual environment.\033[0m"
     touch "$STATE_FILE"
     exit 1

--- a/plugins/pip/venvShellHook.sh
+++ b/plugins/pip/venvShellHook.sh
@@ -1,53 +1,18 @@
+#!/bin/sh
 set -eu
 STATE_FILE="$DEVBOX_PROJECT_ROOT/.devbox/venv_check_completed"
-echo $STATE_FILE
 
 is_valid_venv() {
     [ -f "$1/bin/activate" ] && [ -f "$1/bin/python" ]
 }
 
-# Function to check if Python is a symlink to a Devbox Python
-is_devbox_python() {
-    if [ -z "$DEVBOX_PACKAGES_DIR" ]; then
-        echo "DEVBOX_PACKAGES_DIR is not set. Unable to check for Devbox Python."
-        return 1
-    fi
-    local python_path="$1/bin/python"
-    local link_target
-
-    while true; do
-        if [ ! -L "$python_path" ]; then
-            # Not a symlink, we're done
-            break
-        fi
-
-        link_target=$(readlink "$python_path")
-        echo "Checking symlink: $link_target"
-
-        if [[ "$link_target" == /* ]]; then
-            # Absolute path, we're done
-            python_path="$link_target"
-            break
-        elif [[ "$link_target" == python* ]] || [[ "$link_target" == ./* ]] || [[ "$link_target" == ../* ]]; then
-            # Relative path or python symlink, continue resolving
-            python_path=$(dirname "$python_path")/"$link_target"
-        else
-            # Unexpected format, stop here
-            break
-        fi
-    done
-
-    [[ $python_path == $DEVBOX_PACKAGES_DIR/* ]]
+is_devbox_venv() {
+    [ "$1/bin/python" -ef "$DEVBOX_PACKAGES_DIR/bin/python" ]
 }
 
-# Function to check Python version
-check_python_version() {
-    python_version=$(python -c 'import sys; print(".".join(map(str, sys.version_info[:2])))')
-    if [ "$(printf '%s\n' "3.3" "$python_version" | sort -V | head -n1)" = "3.3" ]; then
-        return 0
-    else
-        return 1
-    fi
+create_venv() {
+    python -m venv "$VENV_DIR" --clear
+    echo "*\n.*" >> "$VENV_DIR/.gitignore"
 }
 
 # Check if we've already run this script
@@ -56,8 +21,8 @@ if [ -f "$STATE_FILE" ]; then
     exit 0
 fi
 
-# Check Python version
-if ! check_python_version; then
+# Check that Python version suports venv
+if ! python -c "import venv" &>/dev/null; then
     echo "\033[1;33mWARNING: Python version must be > 3.3 to create a virtual environment.\033[0m"
     touch "$STATE_FILE"
     exit 1
@@ -66,27 +31,24 @@ fi
 # Check if the directory exists
 if [ -d "$VENV_DIR" ]; then
     if is_valid_venv "$VENV_DIR"; then
-        if ! is_devbox_python "$VENV_DIR"; then
+        if ! is_devbox_venv "$VENV_DIR"; then
             echo "\033[1;33mWARNING: Virtual environment at $VENV_DIR doesn't use Devbox Python.\033[0m"
-            echo "Virtual environment: $VENV_DIR"
             read -p "Do you want to overwrite it? (y/n) " -n 1 -r
             echo
             if [[ $REPLY =~ ^[Yy]$ ]]; then
                 echo "Overwriting existing virtual environment..."
-                rm -rf "$VENV_DIR"
-                python3 -m venv "$VENV_DIR"
+                create_venv
             else
-                echo "Using existing virtual environment. We recommend changing \$VENV_DIR"
+                echo "Using your existing virtual environment. We recommend changing \$VENV_DIR to a different location"
                 touch "$STATE_FILE"
                 exit 1
             fi
         fi
     else
-        echo "Directory exists but is not a valid virtual environment. Creating new one..."
-        rm -rf "$VENV_DIR"
-        python -m venv "$VENV_DIR"
+        echo "Directory exists but is not a valid virtual environment. Creating a new one..."
+        create_venv
     fi
 else
     echo "Virtual environment directory doesn't exist. Creating new one..."
-    python -m venv "$VENV_DIR"
+    create_venv
 fi

--- a/plugins/pip/venvShellHook.sh
+++ b/plugins/pip/venvShellHook.sh
@@ -1,3 +1,4 @@
+set -eu
 STATE_FILE="$DEVBOX_PROJECT_ROOT/.devbox/venv_check_completed"
 echo $STATE_FILE
 
@@ -16,7 +17,6 @@ is_devbox_python() {
 
     while true; do
         if [ ! -L "$python_path" ]; then
-            echo $python_path
             # Not a symlink, we're done
             break
         fi
@@ -36,6 +36,8 @@ is_devbox_python() {
             break
         fi
     done
+
+    [[ $python_path == $DEVBOX_PACKAGES_DIR/* ]]
 }
 
 # Function to check Python version
@@ -50,14 +52,13 @@ check_python_version() {
 
 # Check if we've already run this script
 if [ -f "$STATE_FILE" ]; then
+    # "We've already run this script. Exiting..."
     exit 0
 fi
 
 # Check Python version
 if ! check_python_version; then
-    echo "\n\033[1;33m========================================\033[0m"
     echo "\033[1;33mWARNING: Python version must be > 3.3 to create a virtual environment.\033[0m"
-    echo "\033[1;33m========================================\033[0m"
     touch "$STATE_FILE"
     exit 1
 fi
@@ -66,9 +67,7 @@ fi
 if [ -d "$VENV_DIR" ]; then
     if is_valid_venv "$VENV_DIR"; then
         if ! is_devbox_python "$VENV_DIR"; then
-            echo "\n\033[1;33m========================================\033[0m"
-            echo "\033[1;33mWARNING: Existing virtual environment doesn't use Devbox Python.\033[0m"
-            echo "\033[1;33m========================================\033[0m"
+            echo "\033[1;33mWARNING: Virtual environment at $VENV_DIR doesn't use Devbox Python.\033[0m"
             echo "Virtual environment: $VENV_DIR"
             read -p "Do you want to overwrite it? (y/n) " -n 1 -r
             echo
@@ -77,7 +76,7 @@ if [ -d "$VENV_DIR" ]; then
                 rm -rf "$VENV_DIR"
                 python3 -m venv "$VENV_DIR"
             else
-                echo "Operation cancelled."
+                echo "Using existing virtual environment. We recommend changing \$VENV_DIR"
                 touch "$STATE_FILE"
                 exit 1
             fi

--- a/plugins/pip/venvShellHook.sh
+++ b/plugins/pip/venvShellHook.sh
@@ -21,7 +21,7 @@ if [ -f "$STATE_FILE" ]; then
     exit 0
 fi
 
-# Check that Python version suports venv
+# Check that Python version supports venv
 if ! python -c "import venv" &>/dev/null; then
     echo "\033[1;33mWARNING: Python version must be > 3.3 to create a virtual environment.\033[0m"
     touch "$STATE_FILE"

--- a/plugins/python.json
+++ b/plugins/python.json
@@ -1,20 +1,14 @@
 {
   "name": "python",
-  "version": "0.0.3",
-  "description": "Python in Devbox works best when used with a virtual environment (vent, virtualenv, etc.). Devbox will automatically create a virtual environment using `venv` for python3 projects, so you can install packages with pip as normal.\nTo activate the environment, run `. $VENV_DIR/bin/activate` or add it to the init_hook of your devbox.json\nTo change where your virtual environment is created, modify the $VENV_DIR environment variable in your init_hook",
+  "version": "0.0.4",
+  "description": "Python in Devbox works best when used with a virtual environment (venv, virtualenv, etc.). Devbox will automatically create a virtual environment using `venv` for python3 projects, so you can install packages with pip as normal.\nTo activate the environment, run `. $VENV_DIR/bin/activate` or add it to the init_hook of your devbox.json\nTo change where your virtual environment is created, modify the $VENV_DIR environment variable in your init_hook",
   "env": {
-      /*
-        This is a block comment
-      */
-      "VENV_DIR": "{{ .Virtenv }}/.venv"
+    "VENV_DIR": "{{ .DevboxProjectDir }}/.venv"
   },
   "create_files": {
-      "{{ .Virtenv }}/bin/venvShellHook.sh": "pip/venvShellHook.sh"
+    "{{ .Virtenv }}/bin/venvShellHook.sh": "pip/venvShellHook.sh"
   },
-  // this is a line comment above shell
   "shell": {
-      "init_hook": [
-          "{{ .Virtenv }}/bin/venvShellHook.sh"
-      ]
+    "init_hook": ["{{ .Virtenv }}/bin/venvShellHook.sh"]
   }
 }


### PR DESCRIPTION
## Summary

Moves `.venv` to the Devbox Project Root, and adds some checks to ensure we warn the user if we are going to squash a user created venv. Moving `.venv` to the project root makes it more likely that Python Extensions and IDEs will pick up the devbox managed python, instead of a system python

Fixes DEV-105

## How was it tested?
