### PR TITLE
[Python] Venv tweaks based on testing in Sandboxes

### DIFF
--- a/plugins/pip.json
+++ b/plugins/pip.json
@@ -3,7 +3,8 @@
     "version": "0.0.2",
     "description": "This plugin adds a script for automatically creating a virtual environment using `venv` for python3 projects, so you can install packages with pip as normal.\nTo activate the environment, run `. $VENV_DIR/bin/activate` or add it to the init_hook of your devbox.json\nTo change where your virtual environment is created, modify the $VENV_DIR environment variable in your init_hook",
     "env": {
-        "VENV_DIR": "{{ .Virtenv }}/.venv"
+        "VENV_DIR": "{{ .Virtenv }}/.venv",
+        "UV_PYTHON": "{{ .DevboxProjectRoot }}/.devbox/nix/profile/default/bin/python"
     },
     "create_files": {
         "{{ .Virtenv }}/bin/venvShellHook.sh": "pip/venvShellHook.sh"

--- a/plugins/pip/venvShellHook.sh
+++ b/plugins/pip/venvShellHook.sh
@@ -15,12 +15,6 @@ create_venv() {
     echo "*\n.*" >> "$VENV_DIR/.gitignore"
 }
 
-# Check if we've already run this script
-if [ -f "$STATE_FILE" ]; then
-    # "We've already run this script. Exiting..."
-    exit 0
-fi
-
 # Check that Python version supports venv
 if ! python -c 'import venv' 1> /dev/null 2> /dev/null; then
     echo "\033[1;33mWARNING: Python version must be > 3.3 to create a virtual environment.\033[0m"
@@ -31,6 +25,11 @@ fi
 # Check if the directory exists
 if [ -d "$VENV_DIR" ]; then
     if is_valid_venv "$VENV_DIR"; then
+        # Check if we've already run this script
+        if [ -f "$STATE_FILE" ]; then
+            # "We've already run this script. Exiting..."
+            exit 0
+        fi
         if ! is_devbox_venv "$VENV_DIR"; then
             echo "\033[1;33mWARNING: Virtual environment at $VENV_DIR doesn't use Devbox Python.\033[0m"
             read -p "Do you want to overwrite it? (y/n) " -n 1 -r


### PR DESCRIPTION
## Summary

A few small tweaks after testing in Sandboxes

1. Move the `STATE_CHECK` to after we verify that a VENV exists and that it's properly formatted. This ensures that we can fix scenarios where the venv was deleted or broken, without excessively prompting the user
2. Add a `UV_PYTHON` environment variable to ensure that users who install `uv` don't accidentally overwrite the Python version in their `devbox.json`

## How was it tested?
1. Open the `python-flask` Jetify Example in Sandboxes
2. Test `.venv` is setup correctly with `devbox shell`
3. Delete the `.venv` dir, verify that re-running `devbox shell` creates it
4. Install `uv` (`devbox add uv`)
5. Verify that `uv sync` and other commands don't override Devbox Python