### PR TITLE
[Services] Keep Process Compose alive in background, add `attach` command

### DIFF
--- a/internal/boxcli/services.go
+++ b/internal/boxcli/services.go
@@ -69,6 +69,15 @@ func servicesCmd(persistentPreRunE ...cobraFunc) *cobra.Command {
 		},
 	}
 
+	attachCommand := &cobra.Command{
+		Use:   "attach",
+		Short: "Attach to a running process-compose for the current project",
+		Args:  cobra.ExactArgs(0),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return attachServices(cmd, flags)
+		},
+	}
+
 	lsCommand := &cobra.Command{
 		Use:   "ls",
 		Short: "List available services",
@@ -123,12 +132,27 @@ func servicesCmd(persistentPreRunE ...cobraFunc) *cobra.Command {
 	servicesCommand.Flag("run-in-current-shell").Hidden = true
 	serviceUpFlags.register(upCommand)
 	serviceStopFlags.register(stopCommand)
+	servicesCommand.AddCommand(attachCommand)
 	servicesCommand.AddCommand(lsCommand)
 	servicesCommand.AddCommand(upCommand)
 	servicesCommand.AddCommand(restartCommand)
 	servicesCommand.AddCommand(startCommand)
 	servicesCommand.AddCommand(stopCommand)
 	return servicesCommand
+}
+
+func attachServices(cmd *cobra.Command, flags servicesCmdFlags) error {
+
+	box, err := devbox.Open(&devopt.Opts{
+		Dir:         flags.config.path,
+		Environment: flags.config.environment,
+		Stderr:      cmd.ErrOrStderr(),
+	})
+	if err != nil {
+		return errors.WithStack(err)
+	}
+
+	return box.AttachToProcessManager(cmd.Context())
 }
 
 func listServices(cmd *cobra.Command, flags servicesCmdFlags) error {

--- a/internal/boxcli/services.go
+++ b/internal/boxcli/services.go
@@ -142,7 +142,6 @@ func servicesCmd(persistentPreRunE ...cobraFunc) *cobra.Command {
 }
 
 func attachServices(cmd *cobra.Command, flags servicesCmdFlags) error {
-
 	box, err := devbox.Open(&devopt.Opts{
 		Dir:         flags.config.path,
 		Environment: flags.config.environment,

--- a/internal/devbox/services.go
+++ b/internal/devbox/services.go
@@ -193,7 +193,6 @@ func (d *Devbox) AttachToProcessManager(ctx context.Context) error {
 			BinPath: processComposeBinPath,
 		},
 	)
-
 }
 
 func (d *Devbox) StartProcessManager(

--- a/internal/devbox/services.go
+++ b/internal/devbox/services.go
@@ -170,6 +170,32 @@ func (d *Devbox) RestartServices(
 	return nil
 }
 
+func (d *Devbox) AttachToProcessManager(ctx context.Context) error {
+	if !services.ProcessManagerIsRunning(d.projectDir) {
+		return usererr.New("Process manager is not running. Run `devbox services up` to start it.")
+	}
+
+	err := initDevboxUtilityProject(ctx, d.stderr)
+	if err != nil {
+		return err
+	}
+
+	processComposeBinPath, err := utilityLookPath("process-compose")
+	if err != nil {
+		return err
+	}
+
+	return services.AttachToProcessManager(
+		ctx,
+		d.stderr,
+		d.projectDir,
+		services.ProcessComposeOpts{
+			BinPath: processComposeBinPath,
+		},
+	)
+
+}
+
 func (d *Devbox) StartProcessManager(
 	ctx context.Context,
 	runInCurrentShell bool,

--- a/internal/services/manager.go
+++ b/internal/services/manager.go
@@ -227,7 +227,7 @@ func runProcessManagerInBackground(cmd *exec.Cmd, config *globalProcessComposeCo
 		return fmt.Errorf("failed to start process-compose: %w", err)
 	}
 
-	fmt.Fprintf(w, "Process-compose is now running on port %d\n",port)
+	fmt.Fprintf(w, "Process-compose is now running on port %d\n", port)
 	fmt.Fprintf(w, "To stop your services, run `devbox services stop`\n")
 
 	projectConfig := instance{

--- a/internal/services/manager.go
+++ b/internal/services/manager.go
@@ -159,7 +159,7 @@ func StartProcessManager(
 	if processComposeConfig.Background {
 		flags = append(flags, "-t=false")
 		cmd := exec.Command(processComposeConfig.BinPath, flags...)
-		return runProcessManagerInBackground(cmd, config, port, projectDir)
+		return runProcessManagerInBackground(cmd, config, port, projectDir, w)
 	}
 
 	cmd := exec.Command(processComposeConfig.BinPath, flags...)
@@ -206,7 +206,7 @@ func runProcessManagerInForeground(cmd *exec.Cmd, config *globalProcessComposeCo
 	return writeGlobalProcessComposeJSON(config, configFile)
 }
 
-func runProcessManagerInBackground(cmd *exec.Cmd, config *globalProcessComposeConfig, port int, projectDir string) error {
+func runProcessManagerInBackground(cmd *exec.Cmd, config *globalProcessComposeConfig, port int, projectDir string, w io.Writer) error {
 	logdir := filepath.Join(projectDir, processComposeLogfile)
 	logfile, err := os.OpenFile(logdir, os.O_CREATE|os.O_WRONLY|os.O_APPEND|os.O_TRUNC, 0o664)
 	if err != nil {
@@ -216,6 +216,8 @@ func runProcessManagerInBackground(cmd *exec.Cmd, config *globalProcessComposeCo
 	cmd.Stdout = logfile
 	cmd.Stderr = logfile
 
+	// These attributes set the process group ID to the process ID of process-compose
+	// Starting in it's own process group means it won't be terminated if the shell crashes
 	cmd.SysProcAttr = &syscall.SysProcAttr{
 		Setpgid: true,
 		Pgid:    0,
@@ -224,6 +226,9 @@ func runProcessManagerInBackground(cmd *exec.Cmd, config *globalProcessComposeCo
 	if err := cmd.Start(); err != nil {
 		return fmt.Errorf("failed to start process-compose: %w", err)
 	}
+
+	fmt.Fprintf(w, "Process-compose is now running on port %d\n",port)
+	fmt.Fprintf(w, "To stop your services, run `devbox services stop`\n")
 
 	projectConfig := instance{
 		Pid:  cmd.Process.Pid,
@@ -309,7 +314,7 @@ func AttachToProcessManager(ctx context.Context, w io.Writer, projectDir string,
 
 	project, ok := config.Instances[projectDir]
 	if !ok {
-		return fmt.Errorf("Process-compose is not running for this project. To start it, run `devbox services up`")
+		return fmt.Errorf("process-compose is not running for this project. To start it, run `devbox services up`")
 	}
 
 	flags := []string{"attach", "-p", strconv.Itoa(project.Port)}

--- a/internal/services/manager.go
+++ b/internal/services/manager.go
@@ -216,6 +216,11 @@ func runProcessManagerInBackground(cmd *exec.Cmd, config *globalProcessComposeCo
 	cmd.Stdout = logfile
 	cmd.Stderr = logfile
 
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		Setpgid: true,
+		Pgid:    0,
+	}
+
 	if err := cmd.Start(); err != nil {
 		return fmt.Errorf("failed to start process-compose: %w", err)
 	}


### PR DESCRIPTION
## Summary

This fixes two previously reported issues: 

1. If process-compose is not terminated gracefully (e.g., it's parent shell crashes, or is closed on accident), then process-compose may terminate without also terminating it's services. 
2. If process-compose is started in the background, a user can now run the `attach` command to re-attach the TUI to the backgrounded process compose

A few current limitations: 

1. This only applies to `devbox services up -b`, but could be extended to `devbox services up` as well by starting process-compose in the background, and then attaching the TUI
2. You will now need to explicitly run `devbox services stop` to stop process-compose for your project

Todos: 

1. Should we apply the backgrounding to `devbox services up` as well?
2. Should we allow users to specify a port or specific process-compose instance to attach to?
3. If so, should we list the process-compose instances somewhere? 

## How was it tested?

Tested on the Apache example:

Attach: 
1. Run `devbox services up -b` in the apache folder
2. Run `devbox services attach` in the apache folder, verify that it launches the TUI
3. Hit Ctrl-C to exit the TUI

Backgrounding:
4. Run `devbox services list`, verify that process-compose is still running
5. Terminate your shell or editor
6. Launch a new shell or editor, navigate to the apache example
7. Run `devbox services list` to verify that process-compose is still running.
