### PR TITLE
patchpkg: patch libstdc++

### DIFF
--- a/internal/boxcli/patch.go
+++ b/internal/boxcli/patch.go
@@ -17,6 +17,7 @@ func patchCmd() *cobra.Command {
 		},
 	}
 	cmd.Flags().StringVar(&builder.Glibc, "glibc", "", "patch binaries to use a different glibc")
+	cmd.Flags().StringVar(&builder.Gcc, "gcc", "", "patch binaries to use a different gcc")
 	cmd.Flags().BoolVar(&builder.RestoreRefs, "restore-refs", false, "restore references to removed store paths")
 	return cmd
 }

--- a/internal/shellgen/tmpl/glibc-patch.nix.tmpl
+++ b/internal/shellgen/tmpl/glibc-patch.nix.tmpl
@@ -77,6 +77,7 @@
 
         isLinux = (builtins.match ".*linux.*" system) != null;
         glibc = if isLinux then nixpkgs-glibc.legacyPackages."${system}".glibc else null;
+        gcc = if isLinux then nixpkgs-glibc.legacyPackages."${system}".stdenv.cc.cc.lib else null;
 
         # Create a package that puts the local devbox binary in the conventional
         # bin subdirectory. This also ensures that the executable is named
@@ -97,6 +98,7 @@
         builder = "${devbox}/bin/devbox";
         args = [ "patch" "--restore-refs" ] ++
           (if glibc != null then [ "--glibc" "${glibc}" ] else [ ]) ++
+          (if gcc != null then [ "--gcc" "${gcc}" ] else [ ]) ++
           [ pkg ];
       };
     in


### PR DESCRIPTION
This fixes an issue with TensorFlow not being able to find libstdc++.so at runtime.