### PR TITLE
devpkg: fix empty patch mode

### DIFF
--- a/internal/devpkg/narinfo_cache.go
+++ b/internal/devpkg/narinfo_cache.go
@@ -219,8 +219,8 @@ func (p *Package) outputsForOutputName(output string) ([]lock.Output, error) {
 // the package to query it from the binary cache.
 func (p *Package) isEligibleForBinaryCache() (bool, error) {
 	defer debug.FunctionTimer().End()
-	// Patched glibc packages are not in the binary cache.
-	if p.PatchGlibc() {
+	// Patched packages are not in the binary cache.
+	if p.Patch {
 		return false, nil
 	}
 	sysInfo, err := p.sysInfoIfExists()

--- a/internal/shellgen/flake_input.go
+++ b/internal/shellgen/flake_input.go
@@ -84,7 +84,7 @@ func (f *flakeInput) BuildInputsForSymlinkJoin() ([]*SymlinkJoin, error) {
 			return nil, err
 		}
 
-		if pkg.PatchGlibc() {
+		if pkg.Patch {
 			return nil, errors.New("patch_glibc is not yet supported for packages with non-default outputs")
 		}
 
@@ -125,7 +125,7 @@ func (f *flakeInput) BuildInputs() ([]string, error) {
 		if attributePathErr != nil {
 			err = attributePathErr
 		}
-		if pkg.PatchGlibc() {
+		if pkg.Patch {
 			// When the package comes from the glibc flake, the
 			// "legacyPackages" portion of the attribute path
 			// becomes just "packages" (matching the standard flake
@@ -179,7 +179,7 @@ func flakeInputs(ctx context.Context, packages []*devpkg.Package) []flakeInput {
 		// Packages that need a glibc patch are assigned to the special
 		// glibc-patched flake input. This input refers to the
 		// glibc-patch.nix flake.
-		if pkg.PatchGlibc() {
+		if pkg.Patch {
 			nixpkgsGlibc := flakeInputs.getOrAppend(glibcPatchFlakeRef)
 			nixpkgsGlibc.Name = "glibc-patch"
 			nixpkgsGlibc.URL = glibcPatchFlakeRef

--- a/internal/shellgen/flake_plan.go
+++ b/internal/shellgen/flake_plan.go
@@ -106,7 +106,7 @@ func newGlibcPatchFlake(nixpkgsGlibcRev string, packages []*devpkg.Package) (gli
 		NixpkgsGlibcFlakeRef: "flake:nixpkgs/" + nixpkgsGlibcRev,
 	}
 	for _, pkg := range packages {
-		if !pkg.PatchGlibc() {
+		if !pkg.Patch {
 			continue
 		}
 


### PR DESCRIPTION
Fix a case where an empty patch mode wouldn't default to "auto". This was causing Devbox to skip patching when it should not have.

Got rid of the sync.OnceValue function for determining if a package needs to be patched. This was originally done to avoid a call to nix.System(), but that call doesn't happen anymore.