### PR TITLE
Aadd `--impure` flag when calling print-dev-env

### DIFF
--- a/internal/boxcli/featureflag/impure_print_dev_env.go
+++ b/internal/boxcli/featureflag/impure_print_dev_env.go
@@ -1,0 +1,12 @@
+// Copyright 2024 Jetify Inc. and contributors. All rights reserved.
+// Use of this source code is governed by the license in the LICENSE file.
+
+package featureflag
+
+// ImpurePrintDevEnv controls whether the `devbox print-dev-env` command
+// will be called with the `--impure` flag.
+// Using the `--impure` flag will have two consequences:
+//  1. All environment variables will be passed to nix, this will enable
+//     the usage of flakes that rely on environment variables.
+//  2. It will disable nix caching, making the command slower.
+var ImpurePrintDevEnv = disable("IMPURE_PRINT_DEV_ENV")

--- a/internal/nix/nix.go
+++ b/internal/nix/nix.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+	"go.jetpack.io/devbox/internal/boxcli/featureflag"
 	"go.jetpack.io/devbox/internal/boxcli/usererr"
 	"go.jetpack.io/devbox/internal/redact"
 	"golang.org/x/mod/semver"
@@ -74,7 +75,11 @@ func (*Nix) PrintDevEnv(ctx context.Context, args *PrintDevEnvArgs) (*PrintDevEn
 	}
 
 	if len(data) == 0 {
-		cmd := command("print-dev-env", "--json", "--impure",
+		optionalImpureFlag := ""
+		if featureflag.ImpurePrintDevEnv.Enabled() {
+			optionalImpureFlag = "--impure"
+		}
+		cmd := command("print-dev-env", "--json", optionalImpureFlag,
 			"path:"+flakeDirResolved,
 		)
 		slog.Debug("running print-dev-env cmd", "cmd", cmd)

--- a/internal/nix/nix.go
+++ b/internal/nix/nix.go
@@ -75,13 +75,11 @@ func (*Nix) PrintDevEnv(ctx context.Context, args *PrintDevEnvArgs) (*PrintDevEn
 	}
 
 	if len(data) == 0 {
-		optionalImpureFlag := ""
+		cmd := command("print-dev-env", "--json")
 		if featureflag.ImpurePrintDevEnv.Enabled() {
-			optionalImpureFlag = "--impure"
+			cmd.Args = append(cmd.Args, "--impure")
 		}
-		cmd := command("print-dev-env", "--json", optionalImpureFlag,
-			"path:"+flakeDirResolved,
-		)
+		cmd.Args = append(cmd.Args, "path:"+flakeDirResolved)
 		slog.Debug("running print-dev-env cmd", "cmd", cmd)
 		data, err = cmd.Output(ctx)
 		if insecure, insecureErr := IsExitErrorInsecurePackage(err, "" /*pkgName*/, "" /*installable*/); insecure {

--- a/internal/nix/nix.go
+++ b/internal/nix/nix.go
@@ -74,7 +74,7 @@ func (*Nix) PrintDevEnv(ctx context.Context, args *PrintDevEnvArgs) (*PrintDevEn
 	}
 
 	if len(data) == 0 {
-		cmd := command("print-dev-env", "--json",
+		cmd := command("print-dev-env", "--json", "--impure",
 			"path:"+flakeDirResolved,
 		)
 		slog.Debug("running print-dev-env cmd", "cmd", cmd)


### PR DESCRIPTION
## Summary

Add `--impure` to the `print-dev-env` command, allowing flakes to access environment variables also in this step. Without this change, a flake that needs an env var to work will correctly build but then a shell could not be created.

This also solves #2196, signifying that other people encountered a similar problem.

## How was it tested?

Both by
```
devbox run test
```

and manually, building the tool and locally checking that a flake would pick up variables (with `builtins.getEnv`) when activating a shell.