### PR TITLE
[search] Fix bad error when installing "rust"

### DIFF
--- a/internal/nix/search.go
+++ b/internal/nix/search.go
@@ -109,7 +109,11 @@ func searchSystem(url, system string) (map[string]*Info, error) {
 		// return ErrPackageNotFound only for that case.
 		return nil, fmt.Errorf("error searching for pkg %s: %w", url, err)
 	}
-	return parseSearchResults(out), nil
+	parsed := parseSearchResults(out)
+	if len(parsed) == 0 {
+		return nil, fmt.Errorf("package not found: %s", url)
+	}
+	return parsed, nil
 }
 
 // allowableQuery specifies the regex that queries for SearchNixpkgsAttribute must match.

--- a/internal/nix/search_test.go
+++ b/internal/nix/search_test.go
@@ -1,6 +1,7 @@
 package nix
 
 import (
+	"reflect"
 	"testing"
 )
 
@@ -56,6 +57,55 @@ func TestAllowableQuery(t *testing.T) {
 			out := allowableQuery.MatchString(testCase.in)
 			if out != testCase.expected {
 				t.Errorf("got %t, want %t", out, testCase.expected)
+			}
+		})
+	}
+}
+
+func TestParseSearchResults(t *testing.T) {
+	testCases := []struct {
+		name           string
+		input          []byte
+		expectedResult map[string]*Info
+	}{
+		{
+			name: "Valid JSON input",
+			input: []byte(`{
+				"go": {
+					"pname": "go",
+					"version": "1.20.4"
+				},
+				"python3": {
+					"pname": "python3",
+					"version": "3.9.16"
+				}
+			}`),
+			expectedResult: map[string]*Info{
+				"go": {
+					AttributeKey: "go",
+					PName:        "go",
+					Version:      "1.20.4",
+				},
+				"python3": {
+					AttributeKey: "python3",
+					PName:        "python3",
+					Version:      "3.9.16",
+				},
+			},
+		},
+		{
+			name:           "Empty JSON input",
+			input:          []byte(`{}`),
+			expectedResult: map[string]*Info{},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := parseSearchResults(tc.input)
+
+			if !reflect.DeepEqual(result, tc.expectedResult) {
+				t.Errorf("Expected result %v, got %v", tc.expectedResult, result)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

nix search would return `{}` which and we would not return an error. Now we return error.

## How was it tested?

`devbox add rust`