### PR TITLE
internal/devbox: handle whitespace in paths

### DIFF
--- a/internal/devbox/shellrc.tmpl
+++ b/internal/devbox/shellrc.tmpl
@@ -56,7 +56,7 @@ working_dir="$(pwd)"
 cd "{{ .ProjectDir }}" || exit
 
 # Source the hooks file, which contains the project's init hooks and plugin hooks.
-. {{ .HooksFilePath }}
+. "{{ .HooksFilePath }}"
 
 cd "$working_dir" || exit
 

--- a/internal/devbox/shellrc_fish.tmpl
+++ b/internal/devbox/shellrc_fish.tmpl
@@ -59,7 +59,7 @@ set workingDir (pwd)
 cd "{{ .ProjectDir }}" || exit
 
 # Source the hooks file, which contains the project's init hooks and plugin hooks.
-source {{ .HooksFilePath }}
+source "{{ .HooksFilePath }}"
 
 cd "$workingDir" || exit
 

--- a/internal/devbox/testdata/shellrc/basic/shellrc.golden
+++ b/internal/devbox/testdata/shellrc/basic/shellrc.golden
@@ -21,7 +21,7 @@ working_dir="$(pwd)"
 cd "/path/to/projectDir" || exit
 
 # Source the hooks file, which contains the project's init hooks and plugin hooks.
-. /path/to/projectDir/.devbox/gen/scripts/.hooks.sh
+. "/path/to/projectDir/.devbox/gen/scripts/.hooks.sh"
 
 cd "$working_dir" || exit
 

--- a/internal/devbox/testdata/shellrc/noshellrc/shellrc.golden
+++ b/internal/devbox/testdata/shellrc/noshellrc/shellrc.golden
@@ -15,7 +15,7 @@ working_dir="$(pwd)"
 cd "/path/to/projectDir" || exit
 
 # Source the hooks file, which contains the project's init hooks and plugin hooks.
-. /path/to/projectDir/.devbox/gen/scripts/.hooks.sh
+. "/path/to/projectDir/.devbox/gen/scripts/.hooks.sh"
 
 cd "$working_dir" || exit
 

--- a/internal/nix/nix.go
+++ b/internal/nix/nix.go
@@ -23,6 +23,7 @@ import (
 	"go.jetpack.io/devbox/internal/boxcli/featureflag"
 	"go.jetpack.io/devbox/internal/boxcli/usererr"
 	"go.jetpack.io/devbox/internal/redact"
+	"go.jetpack.io/devbox/nix/flake"
 	"golang.org/x/mod/semver"
 
 	"go.jetpack.io/devbox/internal/debug"
@@ -73,13 +74,14 @@ func (*Nix) PrintDevEnv(ctx context.Context, args *PrintDevEnvArgs) (*PrintDevEn
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
+	ref := flake.Ref{Type: flake.TypePath, Path: flakeDirResolved}
 
 	if len(data) == 0 {
 		cmd := command("print-dev-env", "--json")
 		if featureflag.ImpurePrintDevEnv.Enabled() {
 			cmd.Args = append(cmd.Args, "--impure")
 		}
-		cmd.Args = append(cmd.Args, "path:"+flakeDirResolved)
+		cmd.Args = append(cmd.Args, ref)
 		slog.Debug("running print-dev-env cmd", "cmd", cmd)
 		data, err = cmd.Output(ctx)
 		if insecure, insecureErr := IsExitErrorInsecurePackage(err, "" /*pkgName*/, "" /*installable*/); insecure {

--- a/internal/shellgen/tmpl/script-wrapper.tmpl
+++ b/internal/shellgen/tmpl/script-wrapper.tmpl
@@ -1,5 +1,5 @@
-{{/* 
-    This wraps user scripts in devbox.json. The idea is to only run the init 
+{{/*
+    This wraps user scripts in devbox.json. The idea is to only run the init
     hooks once, even if the init hook calls devbox run again. This will also
     protect against using devbox service in the init hook.
 
@@ -8,7 +8,7 @@
 */ -}}
 
 if [ -z "${{ .SkipInitHookHash }}" ]; then
-    . {{ .InitHookPath }}
+    . "{{ .InitHookPath }}"
 fi
 
 {{ .Body }}

--- a/testscripts/basic/path_whitespace.test.txt
+++ b/testscripts/basic/path_whitespace.test.txt
@@ -1,0 +1,23 @@
+# Test that Devbox handles whitespace in project paths.
+
+mkdir 'my project'
+cd 'my project'
+
+exec devbox run -- hello
+stdout 'Hello, world!'
+
+exec devbox run -- touch 'file1 with spaces'
+exists 'file1 with spaces'
+
+exec devbox run test
+exists 'file2 with spaces'
+
+-- my project/devbox.json --
+{
+  "packages": ["hello@latest"],
+  "shell": {
+    "scripts": {
+      "test": "touch 'file2 with spaces'"
+    }
+  }
+}


### PR DESCRIPTION
Make sure the flake ref is URL-encoded and quote the rcfile in the shellrc template.

Fixes #2290.