### PR TITLE
[services] Let users set the port for process-compose

### DIFF
--- a/internal/boxcli/services.go
+++ b/internal/boxcli/services.go
@@ -20,6 +20,7 @@ type serviceUpFlags struct {
 	background          bool
 	processComposeFile  string
 	processComposeFlags []string
+	pcport              int
 }
 
 type serviceStopFlags struct {
@@ -38,6 +39,8 @@ func (flags *serviceUpFlags) register(cmd *cobra.Command) {
 		&flags.background, "background", "b", false, "run service in background")
 	cmd.Flags().StringArrayVar(
 		&flags.processComposeFlags, "pcflags", []string{}, "pass flags directly to process compose")
+	cmd.Flags().IntVarP(
+		&flags.pcport, "pcport", "p", 0, "specify the port for process-compose to use. You can also set the pcport by exporting PC_PORT_NUM")
 }
 
 func (flags *serviceStopFlags) register(cmd *cobra.Command) {
@@ -245,6 +248,10 @@ func startProcessManager(
 		return err
 	}
 
+	if flags.pcport < 0 {
+		return errors.Errorf("invalid pcport %d: ports cannot be less than 0", flags.pcport)
+	}
+
 	box, err := devbox.Open(&devopt.Opts{
 		Dir:                      servicesFlags.config.path,
 		Env:                      env,
@@ -263,6 +270,7 @@ func startProcessManager(
 		devopt.ProcessComposeOpts{
 			Background: flags.background,
 			ExtraFlags: flags.processComposeFlags,
+			PCPort:     flags.pcport,
 		},
 	)
 }

--- a/internal/boxcli/services.go
+++ b/internal/boxcli/services.go
@@ -40,7 +40,7 @@ func (flags *serviceUpFlags) register(cmd *cobra.Command) {
 	cmd.Flags().StringArrayVar(
 		&flags.processComposeFlags, "pcflags", []string{}, "pass flags directly to process compose")
 	cmd.Flags().IntVarP(
-		&flags.pcport, "pcport", "p", 0, "specify the port for process-compose to use. You can also set the pcport by exporting PC_PORT_NUM")
+		&flags.pcport, "pcport", "p", 0, "specify the port for process-compose to use. You can also set the pcport by exporting DEVBOX_PC_PORT_NUM")
 }
 
 func (flags *serviceStopFlags) register(cmd *cobra.Command) {
@@ -268,9 +268,9 @@ func startProcessManager(
 		servicesFlags.runInCurrentShell,
 		args,
 		devopt.ProcessComposeOpts{
-			Background: flags.background,
-			ExtraFlags: flags.processComposeFlags,
-			PCPort:     flags.pcport,
+			Background:         flags.background,
+			ExtraFlags:         flags.processComposeFlags,
+			ProcessComposePort: flags.pcport,
 		},
 	)
 }

--- a/internal/devbox/devopt/devboxopts.go
+++ b/internal/devbox/devopt/devboxopts.go
@@ -18,9 +18,9 @@ type Opts struct {
 }
 
 type ProcessComposeOpts struct {
-	ExtraFlags []string
-	Background bool
-	PCPort     int
+	ExtraFlags         []string
+	Background         bool
+	ProcessComposePort int
 }
 
 type GenerateOpts struct {

--- a/internal/devbox/devopt/devboxopts.go
+++ b/internal/devbox/devopt/devboxopts.go
@@ -20,6 +20,7 @@ type Opts struct {
 type ProcessComposeOpts struct {
 	ExtraFlags []string
 	Background bool
+	PCPort     int
 }
 
 type GenerateOpts struct {

--- a/internal/devbox/services.go
+++ b/internal/devbox/services.go
@@ -218,8 +218,8 @@ func (d *Devbox) StartProcessManager(
 		for _, flag := range processComposeOpts.ExtraFlags {
 			args = append(args, "--pcflags", flag)
 		}
-		if processComposeOpts.PCPort != 0 {
-			args = append(args, "--pcport", strconv.Itoa(processComposeOpts.PCPort))
+		if processComposeOpts.ProcessComposePort != 0 {
+			args = append(args, "--pcport", strconv.Itoa(processComposeOpts.ProcessComposePort))
 		}
 
 		return d.runDevboxServicesScript(ctx, args)
@@ -258,10 +258,10 @@ func (d *Devbox) StartProcessManager(
 		svcs,
 		d.projectDir,
 		services.ProcessComposeOpts{
-			BinPath:    processComposeBinPath,
-			Background: processComposeOpts.Background,
-			ExtraFlags: processComposeOpts.ExtraFlags,
-			PCPort:     processComposeOpts.PCPort,
+			BinPath:            processComposeBinPath,
+			Background:         processComposeOpts.Background,
+			ExtraFlags:         processComposeOpts.ExtraFlags,
+			ProcessComposePort: processComposeOpts.ProcessComposePort,
 		},
 	)
 }

--- a/internal/devbox/services.go
+++ b/internal/devbox/services.go
@@ -3,6 +3,7 @@ package devbox
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"text/tabwriter"
 
 	"go.jetpack.io/devbox/internal/boxcli/usererr"
@@ -217,6 +218,9 @@ func (d *Devbox) StartProcessManager(
 		for _, flag := range processComposeOpts.ExtraFlags {
 			args = append(args, "--pcflags", flag)
 		}
+		if processComposeOpts.PCPort != 0 {
+			args = append(args, "--pcport", strconv.Itoa(processComposeOpts.PCPort))
+		}
 
 		return d.runDevboxServicesScript(ctx, args)
 	}
@@ -257,6 +261,7 @@ func (d *Devbox) StartProcessManager(
 			BinPath:    processComposeBinPath,
 			Background: processComposeOpts.Background,
 			ExtraFlags: processComposeOpts.ExtraFlags,
+			PCPort:     processComposeOpts.PCPort,
 		},
 	)
 }

--- a/internal/services/manager.go
+++ b/internal/services/manager.go
@@ -44,6 +44,7 @@ type ProcessComposeOpts struct {
 	BinPath    string
 	ExtraFlags []string
 	Background bool
+	PCPort     int
 }
 
 func newGlobalProcessComposeConfig() *globalProcessComposeConfig {
@@ -128,10 +129,13 @@ func StartProcessManager(
 	config := readGlobalProcessComposeJSON(configFile)
 	config.File = configFile
 
-	// Get the port to use for this project
-	port, err := getAvailablePort()
+	port, err := selectPort(processComposeConfig.PCPort)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to select port: %v", err)
+	}
+
+	if !isPortAvailable(port) {
+		return fmt.Errorf("port %d is already in use", port)
 	}
 
 	// Start building the process-compose command

--- a/internal/services/manager.go
+++ b/internal/services/manager.go
@@ -41,10 +41,10 @@ type globalProcessComposeConfig struct {
 }
 
 type ProcessComposeOpts struct {
-	BinPath    string
-	ExtraFlags []string
-	Background bool
-	PCPort     int
+	BinPath            string
+	ExtraFlags         []string
+	Background         bool
+	ProcessComposePort int
 }
 
 func newGlobalProcessComposeConfig() *globalProcessComposeConfig {
@@ -129,13 +129,9 @@ func StartProcessManager(
 	config := readGlobalProcessComposeJSON(configFile)
 	config.File = configFile
 
-	port, err := selectPort(processComposeConfig.PCPort)
+	port, err := selectPort(processComposeConfig.ProcessComposePort)
 	if err != nil {
 		return fmt.Errorf("failed to select port: %v", err)
-	}
-
-	if !isPortAvailable(port) {
-		return fmt.Errorf("port %d is already in use", port)
 	}
 
 	// Start building the process-compose command


### PR DESCRIPTION
## Summary

Users can set the port that process-compose runs on when they use `devbox services`. If they do not specify a port, we default to randomly picking an open port with low risk of conflict

Users can specify their process-compose port by:

1. Passing the `--pcport, -p` flag when running `devbox services up`. 
2. Setting the `PC_PORT_NUM` environment variable. This variable can be set in the projects `devbox.json` if you want to always use the same port for process-compose. This is overridden by the `--pcport` flag.

## How was it tested?

In the MySQL example: 

1. When I run `devbox services up -b -p 8080`, or
2. When I run `PC_PORT_NUM devbox services up -b`,

I can verify that process-compose is running on my 8080 with `curl localhost:8080/processes` and seeing the list of expected processes.