### PR TITLE
bump installed nix version to latest, and update test-nix-versions

### DIFF
--- a/.github/workflows/cli-tests.yaml
+++ b/.github/workflows/cli-tests.yaml
@@ -208,13 +208,13 @@ jobs:
         run: devbox rm go
 
   # Run a sanity test to make sure Devbox can install and remove packages with
-  # the last 3 Nix releases.
+  # the last few Nix releases.
   test-nix-versions:
     needs: build-devbox
     strategy:
       matrix:
         os: [ubuntu-latest, macos-13]
-        nix-version: [2.15.1, 2.16.1, 2.17.0, 2.18.0, 2.19.2]
+        nix-version: [2.15.1, 2.16.1, 2.17.0, 2.18.0, 2.19.2, 2.24.7]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4

--- a/internal/nix/install.go
+++ b/internal/nix/install.go
@@ -38,7 +38,7 @@ func Install(writer io.Writer, daemon *bool) error {
 	}
 	defer r.Close()
 
-	installScript := "curl -L https://releases.nixos.org/nix/nix-2.18.1/install | sh -s"
+	installScript := "curl -L https://releases.nixos.org/nix/nix-2.24.7/install | sh -s"
 	if daemon != nil {
 		if *daemon {
 			installScript += " -- --daemon"


### PR DESCRIPTION
## Summary

Bumping to 2.24.7 which seems latest tag on https://github.com/NixOS/nix/tags 

Our current hardcoded one is fairly old (we should more periodically update this),
and is leading to issues with MacOS Sequoia (see https://github.com/NixOS/nix/issues/11543)

Also add this to the test-nix-versions. I am keeping the older nix versions
around because some of them exercise older nix profile (and other similar issues
that i am failing to recall atm) formats that some users may still be reliant on.

At some point, we should consider bumping up our minimum nix version as well
so we can deprecate legacy nix support (and keep the code base neater).

## How was it tested?

@lagoja is testing this manually

will ensure cicd pass as a sanity test
