### PR TITLE
[nix] Add DetSys installer behind feature flag

### DIFF
--- a/.github/workflows/cli-tests.yaml
+++ b/.github/workflows/cli-tests.yaml
@@ -183,6 +183,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-13]
+        use-detsys: [true, false]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -197,6 +198,7 @@ jobs:
       - name: Install nix and devbox packages
         run: |
           export NIX_INSTALLER_NO_CHANNEL_ADD=1
+          export DEVBOX_FEATURE_DETSYS_INSTALLER=${{ matrix.use-detsys }}
 
           # Setup github authentication to ensure Github's rate limits are not hit.
           # If this works, we can consider refactoring this into a reusable github action helper.

--- a/internal/boxcli/featureflag/detsys.go
+++ b/internal/boxcli/featureflag/detsys.go
@@ -1,0 +1,3 @@
+package featureflag
+
+var UseDetSysInstaller = cicdOnly("DETSYS_INSTALLER")

--- a/internal/boxcli/featureflag/detsys.go
+++ b/internal/boxcli/featureflag/detsys.go
@@ -1,3 +1,3 @@
 package featureflag
 
-var UseDetSysInstaller = cicdOnly("DETSYS_INSTALLER")
+var UseDetSysInstaller = disable("DETSYS_INSTALLER")

--- a/internal/boxcli/featureflag/feature.go
+++ b/internal/boxcli/featureflag/feature.go
@@ -43,13 +43,6 @@ func enable(name string) *feature {
 	return features[name]
 }
 
-func cicdOnly(name string) *feature {
-	if os.Getenv("CI") != "" || os.Getenv("CIRCLECI") != "" || os.Getenv("GITHUB_ACTIONS") != "" {
-		enable(name)
-	}
-	return disable(name)
-}
-
 var logMap = map[string]bool{}
 
 func (f *feature) Enabled() bool {

--- a/internal/boxcli/featureflag/feature.go
+++ b/internal/boxcli/featureflag/feature.go
@@ -43,6 +43,13 @@ func enable(name string) *feature {
 	return features[name]
 }
 
+func cicdOnly(name string) *feature {
+	if os.Getenv("CI") != "" || os.Getenv("CIRCLECI") != "" || os.Getenv("GITHUB_ACTIONS") != "" {
+		enable(name)
+	}
+	return disable(name)
+}
+
 var logMap = map[string]bool{}
 
 func (f *feature) Enabled() bool {

--- a/internal/boxcli/setup.go
+++ b/internal/boxcli/setup.go
@@ -49,7 +49,7 @@ func runInstallNixCmd(cmd *cobra.Command) error {
 		)
 		return nil
 	}
-	return nix.Install(cmd.ErrOrStderr(), nixDaemonFlagVal(cmd)())
+	return nix.Install(cmd.ErrOrStderr(), nixDaemonFlagVal(cmd))
 }
 
 // ensureNixInstalled verifies that nix is installed and that it is of a supported version

--- a/internal/boxcli/setup.go
+++ b/internal/boxcli/setup.go
@@ -29,13 +29,19 @@ func setupCmd() *cobra.Command {
 		},
 	}
 
-	installNixCommand.Flags().Bool(nixDaemonFlag, false, "Install Nix in multi-user mode.")
+	installNixCommand.Flags().Bool(
+		nixDaemonFlag,
+		false,
+		"Install Nix in multi-user mode. This flag is not supported if you are using DetSys installer",
+	)
 	setupCommand.AddCommand(installNixCommand)
 	return setupCommand
 }
 
 func runInstallNixCmd(cmd *cobra.Command) error {
 	if nix.BinaryInstalled() {
+		// TODO: If existing installation is not detsys, but new installation is detsys can we detect
+		// that and replace it?
 		ux.Finfof(
 			cmd.ErrOrStderr(),
 			"Nix is already installed. If this is incorrect "+

--- a/internal/nix/install.go
+++ b/internal/nix/install.go
@@ -47,13 +47,11 @@ func Install(writer io.Writer, daemon *bool) error {
 			installScript += " linux --init none"
 		}
 		installScript += " --no-confirm"
-	} else {
-		if daemon != nil {
-			if *daemon {
-				installScript += " -- --daemon"
-			} else {
-				installScript += " -- --no-daemon"
-			}
+	} else if daemon != nil {
+		if *daemon {
+			installScript += " -- --daemon"
+		} else {
+			installScript += " -- --no-daemon"
 		}
 	}
 

--- a/internal/nix/install.go
+++ b/internal/nix/install.go
@@ -29,7 +29,7 @@ const rootError = "warning: installing Nix as root is not supported by this scri
 
 // Install runs the install script for Nix. daemon has 3 states
 // nil is unset. false is --no-daemon. true is --daemon.
-func Install(writer io.Writer, daemon func() *bool) error {
+func Install(writer io.Writer, daemonFn func() *bool) error {
 	if isRoot() && build.OS() == build.OSWSL {
 		return usererr.New("Nix cannot be installed as root on WSL. Please run as a normal user with sudo access.")
 	}
@@ -51,8 +51,8 @@ func Install(writer io.Writer, daemon func() *bool) error {
 			installScript += " linux --init none"
 		}
 		installScript += " --no-confirm"
-	} else if daemon != nil {
-		if *daemon() {
+	} else if daemon := daemonFn(); daemon != nil {
+		if *daemon {
 			installScript += " -- --daemon"
 		} else {
 			installScript += " -- --no-daemon"


### PR DESCRIPTION
## Summary

* Adds detsys installer.
* Puts it behind disabled flag. Add CICD matrix to test.
* Special casing: Handles missing systemd by just skipping it.

## How was it tested?

* Tested `devbox setup nix` in linux docker container.
* Will test in CICD
* Much more testing needed before removing feature flag