### PR TITLE
[telemetry] Don't log user errors

### DIFF
--- a/internal/boxcli/midcobra/telemetry.go
+++ b/internal/boxcli/midcobra/telemetry.go
@@ -43,7 +43,7 @@ func (m *telemetryMiddleware) postRun(cmd *cobra.Command, args []string, runErr 
 	defer telemetry.Stop()
 
 	var userExecErr *usererr.ExitError
-	if errors.As(runErr, &userExecErr) {
+	if errors.As(runErr, &userExecErr) || !usererr.ShouldLogError(runErr) {
 		return
 	}
 


### PR DESCRIPTION
## Summary

We're running out of Sentry events and it looks like the culprit is devbox overlogging, including a lot of user errors that should not be logged.

This PR https://github.com/jetify-com/devbox/pull/844 removed code that avoided logging user errors. I think this was a bug? If programmer wants a user error to be logged, they should use `WithLoggedUserMessage` instead.

## How was it tested?

Untested
