### PR TITLE
Fix flake rev issue

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -18,7 +18,7 @@
           (x: "${lastTag}")
           (x: if (self ? shortRev)
               then "${x}-${self.shortRev}"
-              else "${x}-${if self ? dirtyShortRev then self.dirtyShortRev else "dirty"}")
+              else "${x}-${self.dirtyShortRev or "dirty"}")
         ];
 
         # Run `devbox run update-flake` to update the vendorHash

--- a/flake.nix
+++ b/flake.nix
@@ -1,5 +1,5 @@
 {
-  description = "Instant, easy, predictable shells and containers";
+  description = "Instant, easy, predictable dev environments";
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
@@ -16,9 +16,9 @@
         # Add the commit to the version string, in case someone builds from main
         getVersion = pkgs.lib.trivial.pipe self [
           (x: "${lastTag}")
-          (x: if (self ? revCount)
+          (x: if (self ? shortRev)
               then "${x}-${self.shortRev}"
-              else "${x}-${self.dirtyShortRev}")
+              else "${x}-${if self ? dirtyShortRev then self.dirtyShortRev else "dirty"}")
         ];
 
         # Run `devbox run update-flake` to update the vendorHash


### PR DESCRIPTION
## Summary

Nix flake fails to build with:

```nix
       error: attribute 'dirtyShortRev' missing
       at /nix/store/m5mqwkz0ss2cav2c9663mx8vwsmvcas3-source/flake.nix:21:28:
           20|               then "${x}-${self.shortRev}"
           21|               else "${x}-${self.dirtyShortRev}")
             |                            ^
           22|         ];
```

This fixes the issue

## How was it tested?

```
nix build github:jetify-com/devbox/jl/fix-flake-rev
```
