### PR TITLE
changed trigger to release to dockerhub to run on published releases

### DIFF
--- a/.github/workflows/docker-image-release.yml
+++ b/.github/workflows/docker-image-release.yml
@@ -1,9 +1,9 @@
 name: docker-image-release
 
 on:
-  push:
-    tags:
-      - '[0-9]+.[0-9]+.[0-9]+'
+  release:
+    types:
+      - published
   workflow_dispatch:
     inputs:
       tag:


### PR DESCRIPTION
## Summary
Previously we ran docker image build and publish to dockerhub when a new tag was created, but this introduced a bug when a tag was created as a draft it would trigger this run but the assets from the tag weren't publicly available yet.
This change makes sure that the tag is marked as a release and is published to run so that the assets it needs (mainly compiled devbox binary) it publicly available before building and pushing a container image to dockerhub.

## How was it tested?
need to wait for the next release to truly test.