### PR TITLE
[lockfile] Fix tidy for non-versioned packages

### DIFF
--- a/internal/devbox/devbox.go
+++ b/internal/devbox/devbox.go
@@ -853,8 +853,8 @@ func (d *Devbox) flakeDir() string {
 // flakes  (lockfile vs devbox list)
 func (d *Devbox) AllPackageNamesIncludingRemovedTriggerPackages() []string {
 	result := []string{}
-	for _, p := range d.AllPackagesIncludingRemovedTriggerPackages() {
-		result = append(result, p.Versioned())
+	for _, p := range d.cfg.Packages(true /*includeRemovedTriggerPackages*/) {
+		result = append(result, p.VersionedName())
 	}
 	return result
 }


### PR DESCRIPTION
## Summary

Fixes issue introduced in https://github.com/jetify-com/devbox/pull/2277

This comment explains it pretty well: https://github.com/jetify-com/devbox/pull/2277/files#r1767085866

except:

> I think this doesn't matter in practice, because we always append @latest during devbox add <name>.

This is not 100% true. In the very small number of packages that are not in nixhub but are valid attribute paths, (e.g. `stdenv.cc.cc.lib`) we store the key in the lockfile without `@latest`  :(. The key missmatch caused lockfile.Tidy to remove entries.

My bad for making the suggestion that lead to this, this was really subtle difference.

## How was it tested?

Added `stdenv.cc.cc.lib` on devbox.json linux only, installed on linux and copied over lockfile to macos. Did `devbox install` and ensured lockfile was not modified.


