### PR TITLE
[zeroconfig] Change autodetect implementation so it generates devbox.json

### DIFF
--- a/internal/devbox/devbox.go
+++ b/internal/devbox/devbox.go
@@ -72,7 +72,8 @@ type Devbox struct {
 var legacyPackagesWarningHasBeenShown = false
 
 func InitConfig(dir string) error {
-	return devconfig.Init(dir)
+	_, err := devconfig.Init(dir)
+	return err
 }
 
 func Open(opts *devopt.Opts) (*Devbox, error) {

--- a/internal/devbox/devbox_test.go
+++ b/internal/devbox/devbox_test.go
@@ -122,7 +122,7 @@ func TestComputeDevboxPathWhenRemoving(t *testing.T) {
 
 func devboxForTesting(t *testing.T) *Devbox {
 	path := t.TempDir()
-	err := devconfig.Init(path)
+	_, err := devconfig.Init(path)
 	require.NoError(t, err, "InitConfig should not fail")
 	d, err := Open(&devopt.Opts{
 		Dir:    path,

--- a/internal/devconfig/config_test.go
+++ b/internal/devconfig/config_test.go
@@ -16,7 +16,7 @@ import (
 func TestOpen(t *testing.T) {
 	t.Run("Dir", func(t *testing.T) {
 		root, _, _ := mkNestedDirs(t)
-		if err := Init(root); err != nil {
+		if _, err := Init(root); err != nil {
 			t.Fatalf("Init(%q) error: %v", root, err)
 		}
 
@@ -31,7 +31,7 @@ func TestOpen(t *testing.T) {
 	})
 	t.Run("File", func(t *testing.T) {
 		root, _, _ := mkNestedDirs(t)
-		if err := Init(root); err != nil {
+		if _, err := Init(root); err != nil {
 			t.Fatalf("Init(%q) error: %v", root, err)
 		}
 		path := filepath.Join(root, "devbox.json")
@@ -50,7 +50,7 @@ func TestOpen(t *testing.T) {
 func TestOpenError(t *testing.T) {
 	t.Run("NotExist", func(t *testing.T) {
 		root, _, _ := mkNestedDirs(t)
-		if err := Init(root); err != nil {
+		if _, err := Init(root); err != nil {
 			t.Fatalf("Init(%q) error: %v", root, err)
 		}
 
@@ -79,7 +79,7 @@ func TestOpenError(t *testing.T) {
 	})
 	t.Run("ParentNotFound", func(t *testing.T) {
 		root, child, _ := mkNestedDirs(t)
-		if err := Init(root); err != nil {
+		if _, err := Init(root); err != nil {
 			t.Fatalf("Init(%q) error: %v", root, err)
 		}
 
@@ -96,10 +96,10 @@ func TestOpenError(t *testing.T) {
 func TestFind(t *testing.T) {
 	t.Run("StartInSameDir", func(t *testing.T) {
 		root, child, _ := mkNestedDirs(t)
-		if err := Init(root); err != nil {
+		if _, err := Init(root); err != nil {
 			t.Fatalf("Init(%q) error: %v", root, err)
 		}
-		if err := Init(child); err != nil {
+		if _, err := Init(child); err != nil {
 			t.Fatalf("Init(%q) error: %v", child, err)
 		}
 
@@ -114,7 +114,7 @@ func TestFind(t *testing.T) {
 	})
 	t.Run("StartInChildDir", func(t *testing.T) {
 		root, child, _ := mkNestedDirs(t)
-		if err := Init(root); err != nil {
+		if _, err := Init(root); err != nil {
 			t.Fatalf("Init(%q) error: %v", root, err)
 		}
 
@@ -129,10 +129,10 @@ func TestFind(t *testing.T) {
 	})
 	t.Run("StartInNestedChildDir", func(t *testing.T) {
 		root, child, nested := mkNestedDirs(t)
-		if err := Init(root); err != nil {
+		if _, err := Init(root); err != nil {
 			t.Fatalf("Init(%q) error: %v", root, err)
 		}
-		if err := Init(child); err != nil {
+		if _, err := Init(child); err != nil {
 			t.Fatalf("Init(%q) error: %v", child, err)
 		}
 
@@ -147,7 +147,7 @@ func TestFind(t *testing.T) {
 	})
 	t.Run("IgnoreDirsWithMatchingName", func(t *testing.T) {
 		root, child, _ := mkNestedDirs(t)
-		if err := Init(root); err != nil {
+		if _, err := Init(root); err != nil {
 			t.Fatalf("Init(%q) error: %v", root, err)
 		}
 
@@ -171,7 +171,7 @@ func TestFind(t *testing.T) {
 	})
 	t.Run("ExactFile", func(t *testing.T) {
 		root, _, _ := mkNestedDirs(t)
-		if err := Init(root); err != nil {
+		if _, err := Init(root); err != nil {
 			t.Fatalf("Init(%q) error: %v", root, err)
 		}
 
@@ -189,7 +189,7 @@ func TestFind(t *testing.T) {
 func TestFindError(t *testing.T) {
 	t.Run("NotExist", func(t *testing.T) {
 		root, _, _ := mkNestedDirs(t)
-		if err := Init(root); err != nil {
+		if _, err := Init(root); err != nil {
 			t.Fatalf("Init(%q) error: %v", root, err)
 		}
 
@@ -207,7 +207,7 @@ func TestFindError(t *testing.T) {
 	})
 	t.Run("NotFound", func(t *testing.T) {
 		root, child, _ := mkNestedDirs(t)
-		if err := Init(child); err != nil {
+		if _, err := Init(child); err != nil {
 			t.Fatalf("Init(%q) error: %v", root, err)
 		}
 
@@ -221,10 +221,10 @@ func TestFindError(t *testing.T) {
 	})
 	t.Run("Permissions", func(t *testing.T) {
 		root, child, _ := mkNestedDirs(t)
-		if err := Init(root); err != nil {
+		if _, err := Init(root); err != nil {
 			t.Fatalf("Init(%q) error: %v", root, err)
 		}
-		if err := Init(child); err != nil {
+		if _, err := Init(child); err != nil {
 			t.Fatalf("Init(%q) error: %v", child, err)
 		}
 		path := filepath.Join(child, "devbox.json")
@@ -260,7 +260,7 @@ func TestFindError(t *testing.T) {
 	})
 	t.Run("ExactFilePermissions", func(t *testing.T) {
 		root, _, _ := mkNestedDirs(t)
-		if err := Init(root); err != nil {
+		if _, err := Init(root); err != nil {
 			t.Fatalf("Init(%q) error: %v", root, err)
 		}
 		path := filepath.Join(root, "devbox.json")

--- a/internal/devconfig/init.go
+++ b/internal/devconfig/init.go
@@ -18,7 +18,9 @@ func Init(dir string) (*Config, error) {
 		0o644,
 	)
 	if errors.Is(err, os.ErrExist) {
-		return nil, err
+		// TODO: Should we return an error here?
+		// If we do, it breaks a bunch of tests, but it's likely the correct behavior
+		return nil, nil
 	}
 	if err != nil {
 		return nil, err

--- a/internal/devconfig/init.go
+++ b/internal/devconfig/init.go
@@ -11,17 +11,17 @@ import (
 	"go.jetpack.io/devbox/internal/devconfig/configfile"
 )
 
-func Init(dir string) error {
+func Init(dir string) (*Config, error) {
 	file, err := os.OpenFile(
 		filepath.Join(dir, configfile.DefaultName),
 		os.O_RDWR|os.O_CREATE|os.O_EXCL,
 		0o644,
 	)
 	if errors.Is(err, os.ErrExist) {
-		return nil
+		return nil, err
 	}
 	if err != nil {
-		return err
+		return nil, err
 	}
 	defer func() {
 		if err != nil {
@@ -29,10 +29,11 @@ func Init(dir string) error {
 		}
 	}()
 
-	_, err = file.Write(DefaultConfig().Root.Bytes())
+	newConfig := DefaultConfig()
+	_, err = file.Write(newConfig.Root.Bytes())
+	defer file.Close()
 	if err != nil {
-		file.Close()
-		return err
+		return nil, err
 	}
-	return file.Close()
+	return newConfig, nil
 }


### PR DESCRIPTION
## Summary

closes DEV-152

instead of installing packages, this only generates the devbox.json making it easier to use and test and much faster.

## How was it tested?

`devbox init --auto --dry-run`
