### PR TITLE
Bump process-compose to 1.34.0

### DIFF
--- a/internal/devbox/util.go
+++ b/internal/devbox/util.go
@@ -16,7 +16,7 @@ import (
 	"go.jetpack.io/devbox/internal/xdg"
 )
 
-const processComposeVersion = "1.24.2"
+const processComposeVersion = "1.34.0"
 
 var utilProjectConfigPath string
 


### PR DESCRIPTION
## Summary

Bump process-compose to 1.34.0. This includes Greg's fix for the CultureAmp reported issue.

## How was it tested?