### PR TITLE
Bump version to 0.13.4

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -36,6 +36,8 @@
 
           src = ./.;
 
+          subpackage = [./cmd/devbox];
+
           ldflags = [
             "-s"
             "-w"

--- a/flake.nix
+++ b/flake.nix
@@ -11,7 +11,7 @@
       let
         pkgs = nixpkgs.legacyPackages.${system};
 
-        lastTag = "0.13.3";
+        lastTag = "0.13.4";
 
         revision = if (self ? shortRev)
                    then "${self.shortRev}"
@@ -50,7 +50,7 @@
 
           nativeBuildInputs = [ pkgs.installShellFiles ];
 
-          postInstall = ''
+          postInstall = pkgs.lib.optionalString (pkgs.stdenv.buildPlatform.canExecute pkgs.stdenv.hostPlatform) ''
             installShellCompletion --cmd devbox \
               --bash <($out/bin/devbox completion bash) \
               --fish <($out/bin/devbox completion fish) \


### PR DESCRIPTION
## Summary

* Bumps Devbox version to 0.13.4. Will tag this commit once merged
* Adds `subpackage` to only build the Devbox binary. Otherwise we also build the Testrunner/updater binary which is not relevant for users
* Support cross-compilation by skipping post-install scripts if Devbox is built for a different system than the host

## How was it tested?

`nix build .` ++ `devbox run tidy`