### PR TITLE
boxcli: add clean command

### DIFF
--- a/internal/boxcli/clean.go
+++ b/internal/boxcli/clean.go
@@ -1,0 +1,34 @@
+// Copyright 2024 Jetify Inc. and contributors. All rights reserved.
+// Use of this source code is governed by the license in the LICENSE file.
+
+package boxcli
+
+import (
+	"github.com/spf13/cobra"
+
+	"go.jetpack.io/devbox/internal/devbox"
+)
+
+type cleanFlags struct{}
+
+func cleanCmd() *cobra.Command {
+	flags := &cleanFlags{}
+	command := &cobra.Command{
+		Use:   "clean",
+		Short: "Cleans up an existing devbox directory.",
+		Long: "Cleans up an existing devbox directory." +
+			"This will delete all devbox files and directories." +
+			"This includes .devbox, devbox.json, devbox.lock.",
+		Args: cobra.MaximumNArgs(0),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runCleanCmd(cmd, args, flags)
+		},
+	}
+
+	return command
+}
+
+func runCleanCmd(_ *cobra.Command, args []string, _ *cleanFlags) error {
+	path := pathArg(args)
+	return devbox.Clean(path)
+}

--- a/internal/boxcli/clean.go
+++ b/internal/boxcli/clean.go
@@ -16,9 +16,9 @@ func cleanCmd() *cobra.Command {
 	command := &cobra.Command{
 		Use:   "clean",
 		Short: "Cleans up an existing devbox directory.",
-		Long: "Cleans up an existing devbox directory." +
-			"This will delete all devbox files and directories." +
-			"This includes .devbox, devbox.json, devbox.lock.",
+		Long: "Cleans up an existing devbox directory.\n" +
+			"This will delete all devbox files and directories.\n" +
+			"This includes .devbox, devbox.json, devbox.lock.\n",
 		Args: cobra.MaximumNArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runCleanCmd(cmd, args, flags)

--- a/internal/boxcli/root.go
+++ b/internal/boxcli/root.go
@@ -66,6 +66,7 @@ func RootCmd() *cobra.Command {
 	command.AddCommand(globalCmd())
 	command.AddCommand(infoCmd())
 	command.AddCommand(initCmd())
+	command.AddCommand(cleanCmd())
 	command.AddCommand(installCmd())
 	command.AddCommand(integrateCmd())
 	command.AddCommand(listCmd())

--- a/internal/devbox/devbox.go
+++ b/internal/devbox/devbox.go
@@ -76,6 +76,11 @@ func InitConfig(dir string) error {
 	return err
 }
 
+func Clean(dir string) error {
+	err := devconfig.Clean(dir)
+	return err
+}
+
 func Open(opts *devopt.Opts) (*Devbox, error) {
 	var cfg *devconfig.Config
 	var err error

--- a/internal/devconfig/clean.go
+++ b/internal/devconfig/clean.go
@@ -10,10 +10,17 @@ import (
 )
 
 func Clean(dir string) error {
-	filesToDelete := []string{configfile.DefaultName, "devbox.lock", ".devbox"}
+	filesToDelete := []string{
+		configfile.DefaultName,
+		"devbox.lock",
+		".devbox",
+	}
 	for _, f := range filesToDelete {
 		// TODO: what should we do here? print an error?
-		_ = os.Remove(f)
+		_ = os.RemoveAll(dir + f)
 	}
+
+	// TODO: should the devbox shell be killed here?
+
 	return nil
 }

--- a/internal/devconfig/clean.go
+++ b/internal/devconfig/clean.go
@@ -1,0 +1,19 @@
+// Copyright 2024 Jetify Inc. and contributors. All rights reserved.
+// Use of this source code is governed by the license in the LICENSE file.
+
+package devconfig
+
+import (
+	"os"
+
+	"go.jetpack.io/devbox/internal/devconfig/configfile"
+)
+
+func Clean(dir string) error {
+	filesToDelete := []string{configfile.DefaultName, "devbox.lock", ".devbox"}
+	for _, f := range filesToDelete {
+		// TODO: what should we do here? print an error?
+		_ = os.Remove(f)
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary
This if a first draft for #2335, I am not sure about the behaviour or features of the command yet so I only added basic functionality.
The issue also mentioned deleting files like .envrc, I didn't include this yet since these files might be generated by a user instead of the devbox, maybe this should be added by an optional parameter? or are generated files tracked?
I also wasn't sure if the clean command should exit the devbox shell or not. In case it should, is the pid of the devbox saved anywhere so it can be killed, or is there a better way to do so?

## How was it tested?
- devbox init
- devbox add go
- devbox shell
- devbox clean

=> expected result: .devbox, devbox.json, devbox.lock are deleted and the user remains in the shell.
