### PR TITLE
[auth | dev] use new dev auth url

### DIFF
--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -83,7 +83,7 @@ func JetpackAPIHost() string {
 
 func SuccessRedirect() string {
 	if IsDev {
-		return "https://auth.jetpack.dev/account/login/success"
+		return "https://auth.dev-jetify.com/account/login/success"
 	}
 	return "https://auth.jetify.com/account/login/success"
 }


### PR DESCRIPTION
## Summary

## How was it tested?

`devbox auth login` with compiled devbox worked without ending up at error page
