### PR TITLE
[autodetect] Fix autodetect

### DIFF
--- a/internal/devconfig/configfile/file.go
+++ b/internal/devconfig/configfile/file.go
@@ -115,6 +115,11 @@ func (c *ConfigFile) SaveTo(path string) error {
 	return os.WriteFile(filepath.Join(path, DefaultName), c.Bytes(), 0o644)
 }
 
+// TODO: Can we remove SaveTo and just use Save()?
+func (c *ConfigFile) Save() error {
+	return c.SaveTo(c.AbsRootPath)
+}
+
 // Get returns the package with the given versionedName
 func (c *ConfigFile) GetPackage(versionedName string) (*Package, bool) {
 	name, version := parseVersionedName(versionedName)

--- a/pkg/autodetect/autodetect.go
+++ b/pkg/autodetect/autodetect.go
@@ -13,7 +13,11 @@ func InitConfig(ctx context.Context, path string) error {
 		return err
 	}
 
-	return populateConfig(ctx, path, config)
+	if err = populateConfig(ctx, path, config); err != nil {
+		return err
+	}
+
+	return config.Root.Save()
 }
 
 func DryRun(ctx context.Context, path string) ([]byte, error) {


### PR DESCRIPTION
## Summary

Previously config was not getting properly saved after packages were added. This fixes it.

## How was it tested?

`devbox init --auto`