### PR TITLE
[env] Fixed env_from bug when it is called from a subdirectory

### DIFF
--- a/internal/devconfig/configfile/env.go
+++ b/internal/devconfig/configfile/env.go
@@ -26,7 +26,12 @@ func (c *ConfigFile) ParseEnvsFromDotEnv() (map[string]string, error) {
 	if !c.IsdotEnvEnabled() {
 		return nil, fmt.Errorf("env file does not have a .env extension")
 	}
-	envFileAbsPath := path.Join(filepath.Dir(c.AbsRootPath), c.EnvFrom)
+	envFileAbsPath := filepath.Dir(c.AbsRootPath)
+	if filepath.IsAbs(c.EnvFrom) {
+		envFileAbsPath = path.Join(envFileAbsPath, path.Base(c.EnvFrom))
+	} else {
+		envFileAbsPath = path.Join(envFileAbsPath, c.EnvFrom)
+	}
 	file, err := os.Open(envFileAbsPath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open file: %s", envFileAbsPath)

--- a/internal/devconfig/configfile/env.go
+++ b/internal/devconfig/configfile/env.go
@@ -3,7 +3,6 @@ package configfile
 import (
 	"fmt"
 	"os"
-	"path"
 	"path/filepath"
 
 	"github.com/hashicorp/go-envparse"
@@ -26,11 +25,10 @@ func (c *ConfigFile) ParseEnvsFromDotEnv() (map[string]string, error) {
 	if !c.IsdotEnvEnabled() {
 		return nil, fmt.Errorf("env file does not have a .env extension")
 	}
-	// We don't allow absolute path for env_from as it breaks reproducibility
-	if filepath.IsAbs(c.EnvFrom) {
-		return nil, fmt.Errorf("`env_from` field can't take an absolute path")
+	envFileAbsPath := c.EnvFrom
+	if !filepath.IsAbs(c.EnvFrom) {
+		envFileAbsPath = filepath.Join(filepath.Dir(c.AbsRootPath), c.EnvFrom)
 	}
-	envFileAbsPath := path.Join(filepath.Dir(c.AbsRootPath), c.EnvFrom)
 	file, err := os.Open(envFileAbsPath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open file: %s", envFileAbsPath)

--- a/internal/devconfig/configfile/env.go
+++ b/internal/devconfig/configfile/env.go
@@ -27,8 +27,9 @@ func (c *ConfigFile) ParseEnvsFromDotEnv() (map[string]string, error) {
 		return nil, fmt.Errorf("env file does not have a .env extension")
 	}
 	envFileAbsPath := filepath.Dir(c.AbsRootPath)
+	// We don't allow absolute path for env_from as it breaks reproducibility
 	if filepath.IsAbs(c.EnvFrom) {
-		envFileAbsPath = path.Join(envFileAbsPath, path.Base(c.EnvFrom))
+		return nil, fmt.Errorf("`env_from` field can't take an absolute path")
 	} else {
 		envFileAbsPath = path.Join(envFileAbsPath, c.EnvFrom)
 	}

--- a/internal/devconfig/configfile/env.go
+++ b/internal/devconfig/configfile/env.go
@@ -3,6 +3,7 @@ package configfile
 import (
 	"fmt"
 	"os"
+	"path"
 	"path/filepath"
 
 	"github.com/hashicorp/go-envparse"
@@ -25,10 +26,10 @@ func (c *ConfigFile) ParseEnvsFromDotEnv() (map[string]string, error) {
 	if !c.IsdotEnvEnabled() {
 		return nil, fmt.Errorf("env file does not have a .env extension")
 	}
-
-	file, err := os.Open(c.EnvFrom)
+	envFileAbsPath := path.Join(filepath.Dir(c.AbsRootPath), c.EnvFrom)
+	file, err := os.Open(envFileAbsPath)
 	if err != nil {
-		return nil, fmt.Errorf("failed to open file: %s", c.EnvFrom)
+		return nil, fmt.Errorf("failed to open file: %s", envFileAbsPath)
 	}
 	defer file.Close()
 

--- a/internal/devconfig/configfile/env.go
+++ b/internal/devconfig/configfile/env.go
@@ -26,13 +26,11 @@ func (c *ConfigFile) ParseEnvsFromDotEnv() (map[string]string, error) {
 	if !c.IsdotEnvEnabled() {
 		return nil, fmt.Errorf("env file does not have a .env extension")
 	}
-	envFileAbsPath := filepath.Dir(c.AbsRootPath)
 	// We don't allow absolute path for env_from as it breaks reproducibility
 	if filepath.IsAbs(c.EnvFrom) {
 		return nil, fmt.Errorf("`env_from` field can't take an absolute path")
-	} else {
-		envFileAbsPath = path.Join(envFileAbsPath, c.EnvFrom)
 	}
+	envFileAbsPath := path.Join(filepath.Dir(c.AbsRootPath), c.EnvFrom)
 	file, err := os.Open(envFileAbsPath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open file: %s", envFileAbsPath)


### PR DESCRIPTION
## Summary
Fixes this bug:
https://github.com/jetify-com/devbox/pull/2174/files#r1659165116

## How was it tested?
- use compiled devbox
- put `export FOO = 'BBBAR'` in .env file
- put the following in a devbox.json file
```json
  {
    "packages": [],
    "shell": {
      "init_hook": [
        "echo 'Welcome to devbox!' > /dev/null"
      ],
      "scripts": {
        "test": [
          "echo $FOO"
        ]
      }
    },
    "env_from": ".env"
  }
```
- create a subdirectory besides devbox.json called `test`
- cd test && devbox run test
