### PR TITLE
Revert process-compose to 1.24.2

### DIFF
--- a/internal/devbox/util.go
+++ b/internal/devbox/util.go
@@ -16,7 +16,7 @@ import (
 	"go.jetpack.io/devbox/internal/xdg"
 )
 
-const processComposeVersion = "1.34.0"
+const processComposeVersion = "1.24.2"
 
 var utilProjectConfigPath string
 


### PR DESCRIPTION
## Summary

Process-compose 1.34 introduces a bug that causes postgresql and other daemon-based processes to hang indefinitely. 

See #2354 for more details.

## How was it tested?

Tested postgresql plugin using 1.34, 1.27 -- verified that the issue still existed
Tested postgresql plugin with 1.24.2 -- verified the issue was resolved