### PR TITLE
bump version to 0.13.5

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1727122398,
-        "narHash": "sha256-o8VBeCWHBxGd4kVMceIayf5GApqTavJbTa44Xcg5Rrk=",
+        "lastModified": 1728888510,
+        "narHash": "sha256-nsNdSldaAyu6PE3YUA+YQLqUDJh+gRbBooMMekZJwvI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "30439d93eb8b19861ccbe3e581abf97bdc91b093",
+        "rev": "a3c0b3b21515f74fd2665903d4ce6bc4dc81c77c",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -11,7 +11,7 @@
       let
         pkgs = nixpkgs.legacyPackages.${system};
 
-        lastTag = "0.13.4";
+        lastTag = "0.13.5";
 
         revision = if (self ? shortRev)
                    then "${self.shortRev}"
@@ -36,7 +36,7 @@
 
           src = ./.;
 
-          subpackage = [./cmd/devbox];
+          subpackage = [ ./cmd/devbox ];
 
           ldflags = [
             "-s"


### PR DESCRIPTION
## Summary

Updating the version to fix a process-compose bug with postgresql

* Bump version to 0.13.5
* Upgrade the nixpkgs commit we use to build

## How was it tested?

nix build .

Tested `devbox init` on an existing project to validate warning
Tested `devbox services up` on postgres to validate process-compose change
