### PR TITLE
fix: json syntax error in plugin example

### DIFF
--- a/docs/app/docs/guides/creating_plugins.md
+++ b/docs/app/docs/guides/creating_plugins.md
@@ -219,7 +219,7 @@ The plugin.json below installs MongoDB + the Mongo shell, and sets the environme
   "version": "0.0.1",
   "description": "Plugin for the [`mongodb`](https://www.nixhub.io/packages/mongodb) package. This plugin configures MonogoDB to use a local config file and data directory for this project, and configures a mongodb service.",
   "packages": [
-    "mongodb@latest"
+    "mongodb@latest",
     "mongosh@latest"
   ],
   "env": {


### PR DESCRIPTION
Fixes the syntax error in the plugin creation example docs.
