### PR TITLE
Add --recompute flag for commands: shell and run

### DIFF
--- a/internal/boxcli/run.go
+++ b/internal/boxcli/run.go
@@ -123,18 +123,18 @@ func runScriptCmd(cmd *cobra.Command, args []string, flags runCmdFlags) error {
 		return redact.Errorf("error reading devbox.json: %w", err)
 	}
 
-	onStaleState := func() {
-		ux.FHidableWarning(
-			ctx,
-			cmd.ErrOrStderr(),
-			devbox.StateOutOfDateMessage,
-			"with --recompute=true",
-		)
-	}
-
 	envOpts := devopt.EnvOptions{
-		Hooks: devopt.EnvLifecycleHooks{
-			OnStaleStateWithSkipRecompute: onStaleState,
+		Hooks: devopt.LifecycleHooks{
+			OnStaleState: func() {
+				if !flags.recomputeEnv {
+					ux.FHidableWarning(
+						ctx,
+						cmd.ErrOrStderr(),
+						devbox.StateOutOfDateMessage,
+						"with --recompute=true",
+					)
+				}
+			},
 		},
 		OmitNixEnv:    flags.omitNixEnv,
 		Pure:          flags.pure,

--- a/internal/boxcli/shell.go
+++ b/internal/boxcli/shell.go
@@ -96,18 +96,18 @@ func runShellCmd(cmd *cobra.Command, flags shellCmdFlags) error {
 		return shellInceptionErrorMsg("devbox shell")
 	}
 
-	onStaleState := func() {
-		ux.FHidableWarning(
-			ctx,
-			cmd.ErrOrStderr(),
-			devbox.StateOutOfDateMessage,
-			"with --recompute=true",
-		)
-	}
-
 	return box.Shell(ctx, devopt.EnvOptions{
-		Hooks: devopt.EnvLifecycleHooks{
-			OnStaleStateWithSkipRecompute: onStaleState,
+		Hooks: devopt.LifecycleHooks{
+			OnStaleState: func() {
+				if !flags.recomputeEnv {
+					ux.FHidableWarning(
+						ctx,
+						cmd.ErrOrStderr(),
+						devbox.StateOutOfDateMessage,
+						"with --recompute=true",
+					)
+				}
+			},
 		},
 		OmitNixEnv:    flags.omitNixEnv,
 		Pure:          flags.pure,

--- a/internal/boxcli/shellenv.go
+++ b/internal/boxcli/shellenv.go
@@ -115,19 +115,19 @@ func shellEnvFunc(
 		}
 	}
 
-	onStaleState := func() {
-		ux.FHidableWarning(
-			ctx,
-			cmd.ErrOrStderr(),
-			devbox.StateOutOfDateMessage,
-			box.RefreshAliasOrCommand(),
-		)
-	}
-
 	envStr, err := box.EnvExports(ctx, devopt.EnvExportsOpts{
 		EnvOptions: devopt.EnvOptions{
-			Hooks: devopt.EnvLifecycleHooks{
-				OnStaleStateWithSkipRecompute: onStaleState,
+			Hooks: devopt.LifecycleHooks{
+				OnStaleState: func() {
+					if !flags.recomputeEnv {
+						ux.FHidableWarning(
+							ctx,
+							cmd.ErrOrStderr(),
+							devbox.StateOutOfDateMessage,
+							box.RefreshAliasOrCommand(),
+						)
+					}
+				},
 			},
 			OmitNixEnv:        flags.omitNixEnv,
 			PreservePathStack: flags.preservePathStack,

--- a/internal/boxcli/shellenv.go
+++ b/internal/boxcli/shellenv.go
@@ -115,15 +115,24 @@ func shellEnvFunc(
 		}
 	}
 
+	onStaleState := func() {
+		ux.FHidableWarning(
+			ctx,
+			cmd.ErrOrStderr(),
+			devbox.StateOutOfDateMessage,
+			box.RefreshAliasOrCommand(),
+		)
+	}
+
 	envStr, err := box.EnvExports(ctx, devopt.EnvExportsOpts{
 		EnvOptions: devopt.EnvOptions{
+			Hooks: devopt.EnvLifecycleHooks{
+				OnStaleStateWithSkipRecompute: onStaleState,
+			},
 			OmitNixEnv:        flags.omitNixEnv,
 			PreservePathStack: flags.preservePathStack,
 			Pure:              flags.pure,
-			RecomputeEnv: &devopt.RecomputeEnvOpts{
-				Disabled:              !flags.recomputeEnv,
-				StateOutOfDateMessage: fmt.Sprintf(devbox.StateOutOfDateMessage, box.RefreshAliasOrCommand()),
-			},
+			SkipRecompute:     !flags.recomputeEnv,
 		},
 		NoRefreshAlias: flags.noRefreshAlias,
 		RunHooks:       flags.runInitHook,

--- a/internal/boxcli/shellenv.go
+++ b/internal/boxcli/shellenv.go
@@ -116,11 +116,14 @@ func shellEnvFunc(
 	}
 
 	envStr, err := box.EnvExports(ctx, devopt.EnvExportsOpts{
-		DontRecomputeEnvironment: !flags.recomputeEnv,
 		EnvOptions: devopt.EnvOptions{
 			OmitNixEnv:        flags.omitNixEnv,
 			PreservePathStack: flags.preservePathStack,
 			Pure:              flags.pure,
+			RecomputeEnv: &devopt.RecomputeEnvOpts{
+				Disabled:              !flags.recomputeEnv,
+				StateOutOfDateMessage: fmt.Sprintf(devbox.StateOutOfDateMessage, box.RefreshAliasOrCommand()),
+			},
 		},
 		NoRefreshAlias: flags.noRefreshAlias,
 		RunHooks:       flags.runInitHook,

--- a/internal/devbox/devbox.go
+++ b/internal/devbox/devbox.go
@@ -351,22 +351,7 @@ func (d *Devbox) EnvExports(ctx context.Context, opts devopt.EnvExportsOpts) (st
 	var envs map[string]string
 	var err error
 
-	if opts.DontRecomputeEnvironment {
-		upToDate, _ := d.lockfile.IsUpToDateAndInstalled(isFishShell())
-		if !upToDate {
-			ux.FHidableWarning(
-				ctx,
-				d.stderr,
-				StateOutOfDateMessage,
-				d.refreshAliasOrCommand(),
-			)
-		}
-
-		envs, err = d.computeEnv(ctx, true /*usePrintDevEnvCache*/, opts.EnvOptions)
-	} else {
-		envs, err = d.ensureStateIsUpToDateAndComputeEnv(ctx, opts.EnvOptions)
-	}
-
+	envs, err = d.ensureStateIsUpToDateAndComputeEnv(ctx, opts.EnvOptions)
 	if err != nil {
 		return "", err
 	}
@@ -819,23 +804,34 @@ func (d *Devbox) ensureStateIsUpToDateAndComputeEnv(
 ) (map[string]string, error) {
 	defer debug.FunctionTimer().End()
 
-	// When ensureStateIsUpToDate is called with ensure=true, it always
-	// returns early if the lockfile is up to date. So we don't need to check here
-	if err := d.ensureStateIsUpToDate(ctx, ensure); isConnectionError(err) {
-		if !fileutil.Exists(d.nixPrintDevEnvCachePath()) {
-			ux.Ferrorf(
+	if envOpts.RecomputeEnv.Disabled {
+		upToDate, _ := d.lockfile.IsUpToDateAndInstalled(isFishShell())
+		if !upToDate {
+			ux.FHidableWarning(
+				ctx,
 				d.stderr,
-				"Error connecting to the internet and no cached environment found. Aborting.\n",
+				envOpts.RecomputeEnv.StateOutOfDateMessage, //nolint:govet
 			)
+		}
+	} else {
+		// When ensureStateIsUpToDate is called with ensure=true, it always
+		// returns early if the lockfile is up to date. So we don't need to check here
+		if err := d.ensureStateIsUpToDate(ctx, ensure); isConnectionError(err) {
+			if !fileutil.Exists(d.nixPrintDevEnvCachePath()) {
+				ux.Ferrorf(
+					d.stderr,
+					"Error connecting to the internet and no cached environment found. Aborting.\n",
+				)
+				return nil, err
+			}
+			ux.Fwarningf(
+				d.stderr,
+				"Error connecting to the internet. Will attempt to use cached environment.\n",
+			)
+		} else if err != nil {
+			// Some other non connection error, just return it.
 			return nil, err
 		}
-		ux.Fwarningf(
-			d.stderr,
-			"Error connecting to the internet. Will attempt to use cached environment.\n",
-		)
-	} else if err != nil {
-		// Some other non connection error, just return it.
-		return nil, err
 	}
 
 	// Since ensureStateIsUpToDate calls computeEnv when not up do date,

--- a/internal/devbox/devbox.go
+++ b/internal/devbox/devbox.go
@@ -804,14 +804,17 @@ func (d *Devbox) ensureStateIsUpToDateAndComputeEnv(
 ) (map[string]string, error) {
 	defer debug.FunctionTimer().End()
 
-	if envOpts.SkipRecompute {
-		upToDate, _ := d.lockfile.IsUpToDateAndInstalled(isFishShell())
-		if !upToDate {
-			if envOpts.Hooks.OnStaleStateWithSkipRecompute != nil {
-				envOpts.Hooks.OnStaleStateWithSkipRecompute()
-			}
+	upToDate, err := d.lockfile.IsUpToDateAndInstalled(isFishShell())
+	if err != nil {
+		return nil, err
+	}
+	if !upToDate {
+		if envOpts.Hooks.OnStaleState != nil {
+			envOpts.Hooks.OnStaleState()
 		}
-	} else {
+	}
+
+	if !envOpts.SkipRecompute {
 		// When ensureStateIsUpToDate is called with ensure=true, it always
 		// returns early if the lockfile is up to date. So we don't need to check here
 		if err := d.ensureStateIsUpToDate(ctx, ensure); isConnectionError(err) {

--- a/internal/devbox/devbox.go
+++ b/internal/devbox/devbox.go
@@ -804,14 +804,12 @@ func (d *Devbox) ensureStateIsUpToDateAndComputeEnv(
 ) (map[string]string, error) {
 	defer debug.FunctionTimer().End()
 
-	if envOpts.RecomputeEnv.Disabled {
+	if envOpts.SkipRecompute {
 		upToDate, _ := d.lockfile.IsUpToDateAndInstalled(isFishShell())
 		if !upToDate {
-			ux.FHidableWarning(
-				ctx,
-				d.stderr,
-				envOpts.RecomputeEnv.StateOutOfDateMessage, //nolint:govet
-			)
+			if envOpts.Hooks.OnStaleStateWithSkipRecompute != nil {
+				envOpts.Hooks.OnStaleStateWithSkipRecompute()
+			}
 		}
 	} else {
 		// When ensureStateIsUpToDate is called with ensure=true, it always

--- a/internal/devbox/devopt/devboxopts.go
+++ b/internal/devbox/devopt/devboxopts.go
@@ -62,10 +62,9 @@ type UpdateOpts struct {
 }
 
 type EnvExportsOpts struct {
-	DontRecomputeEnvironment bool
-	EnvOptions               EnvOptions
-	NoRefreshAlias           bool
-	RunHooks                 bool
+	EnvOptions     EnvOptions
+	NoRefreshAlias bool
+	RunHooks       bool
 }
 
 // EnvOptions configure the Devbox Environment in the `computeEnv` function.
@@ -76,4 +75,10 @@ type EnvOptions struct {
 	OmitNixEnv        bool
 	PreservePathStack bool
 	Pure              bool
+	RecomputeEnv      *RecomputeEnvOpts
+}
+
+type RecomputeEnvOpts struct {
+	Disabled              bool // Disabled instead of Enabled, because zero-value is false
+	StateOutOfDateMessage string
 }

--- a/internal/devbox/devopt/devboxopts.go
+++ b/internal/devbox/devopt/devboxopts.go
@@ -72,13 +72,14 @@ type EnvExportsOpts struct {
 // like `shellenv`, `shell` and `run`.
 // - The struct is designed for the "common case" to be zero-initialized as `EnvOptions{}`.
 type EnvOptions struct {
+	Hooks             EnvLifecycleHooks
 	OmitNixEnv        bool
 	PreservePathStack bool
 	Pure              bool
-	RecomputeEnv      *RecomputeEnvOpts
+	SkipRecompute     bool
 }
 
-type RecomputeEnvOpts struct {
-	Disabled              bool // Disabled instead of Enabled, because zero-value is false
-	StateOutOfDateMessage string
+type EnvLifecycleHooks struct {
+	// OnStaleStateWithSkipRecompute is called when the Devbox state is out of date, AND it is not being recomputed.
+	OnStaleStateWithSkipRecompute func()
 }

--- a/internal/devbox/devopt/devboxopts.go
+++ b/internal/devbox/devopt/devboxopts.go
@@ -72,14 +72,14 @@ type EnvExportsOpts struct {
 // like `shellenv`, `shell` and `run`.
 // - The struct is designed for the "common case" to be zero-initialized as `EnvOptions{}`.
 type EnvOptions struct {
-	Hooks             EnvLifecycleHooks
+	Hooks             LifecycleHooks
 	OmitNixEnv        bool
 	PreservePathStack bool
 	Pure              bool
 	SkipRecompute     bool
 }
 
-type EnvLifecycleHooks struct {
-	// OnStaleStateWithSkipRecompute is called when the Devbox state is out of date, AND it is not being recomputed.
-	OnStaleStateWithSkipRecompute func()
+type LifecycleHooks struct {
+	// OnStaleState is called when the Devbox state is out of date, AND it is not being recomputed.
+	OnStaleState func()
 }

--- a/internal/devbox/packages.go
+++ b/internal/devbox/packages.go
@@ -303,7 +303,7 @@ func (d *Devbox) ensureStateIsUpToDate(ctx context.Context, mode installMode) er
 			ctx,
 			d.stderr,
 			StateOutOfDateMessage,
-			d.refreshAliasOrCommand(),
+			d.RefreshAliasOrCommand(),
 		)
 	}
 

--- a/internal/devbox/refresh.go
+++ b/internal/devbox/refresh.go
@@ -26,7 +26,7 @@ func (d *Devbox) isGlobal() bool {
 // In some cases (e.g. 2 non-global projects somehow active at the same time),
 // refresh might not match. This is a tiny edge case, so no need to make UX
 // great, we just print out the entire command.
-func (d *Devbox) refreshAliasOrCommand() string {
+func (d *Devbox) RefreshAliasOrCommand() string {
 	if !d.isRefreshAliasSet() {
 		// even if alias is not set, it might still be set by the end of this process
 		return fmt.Sprintf("`%s` or `%s`", d.refreshAliasName(), d.refreshCmd())


### PR DESCRIPTION
## Summary

This PR continues the work from #2013 to also add the `--recompute` flag option for `devbox run` and `devbox shell`.
For some users on bad networks, this can save them annoyance and time for when they _know_ their devbox environment is up-to-date.

Fixes #2315

## How was it tested?
This PR affects 3 commands: `run`, `shell` and `shellenv`.

1. For `run`:
Added `"hello": "latest",` to devbox.json of this project.

```
devbox run --recompute=false -- echo "hello world"
Warning: Your devbox environment may be out of date. Run with --recompute=true to update it.
hello world
```

then
```
devbox run -- echo "hello world"
Info: Ensuring packages are installed.
✓ Computed the Devbox environment.
hello world
```

2. For `shell`. Ran similar commands as above.

3. For `shellenv`. Followed test plan of #1963.

Changed the `.envrc` to be:
```
.envrc
@@ -1,7 +1,13 @@
 # Automatically sets up your devbox environment whenever you cd into this
 # directory via our direnv integration:

-eval "$(devbox generate direnv --print-envrc)"
+#eval "$(devbox generate direnv --print-envrc)"

+ # output of `devbox generate direnv --print-envrc` to modify it
+use_devbox() {
+    watch_file devbox.json devbox.lock
+    # eval "$(devbox shellenv --init-hook --install --no-refresh-alias)"
+    eval "$(devbox shellenv --init-hook --no-refresh-alias --recompute=false)"
+}
+use devbox
 # check out https://www.jetify.com/devbox/docs/ide_configuration/direnv/
 # for more details
```

Then modified devbox.json and saw the warning get printed.