### PR TITLE
[whitespace] sourcing init hooks: wrap project dir path in quotes

### DIFF
--- a/internal/devbox/devbox.go
+++ b/internal/devbox/devbox.go
@@ -374,7 +374,7 @@ func (d *Devbox) EnvExports(ctx context.Context, opts devopt.EnvExportsOpts) (st
 	envStr := exportify(envs)
 
 	if opts.RunHooks {
-		hooksStr := ". " + shellgen.ScriptPath(d.ProjectDir(), shellgen.HooksFilename)
+		hooksStr := ". \"" + shellgen.ScriptPath(d.ProjectDir(), shellgen.HooksFilename) + "\""
 		envStr = fmt.Sprintf("%s\n%s;\n", envStr, hooksStr)
 	}
 


### PR DESCRIPTION
## Summary

Fixes #2374

## How was it tested?

Should add an automated test but trying to squeeze this out.

in `/Users/savil/code/jetpack/devbox-projects/project with spaces`:

```
% cat devbox.json
{
  "packages": [],
  "shell": {
    "init_hook": [
      "echo 'Welcome to devbox!' > /dev/null"
    ],
    "scripts": {
      "test": [
        "echo \"Error: no test specified\" && exit 1"
      ]
    }
  }
}
```

did `devbox generate direnv`

BEFORE: when cd-ing:
```
Success: generated .envrc file
Success: ran `direnv allow`
direnv: loading ~/code/jetpack/devbox-projects/project with spaces/.envrc
direnv: using devbox
/bin/bash:131: /Users/savil/code/jetpack/devbox-projects/project: No such file or directory
direnv: export +AR +AS +CC +CONFIG_SHELL +CXX +DEVBOX_NIX_ENV_PATH_b34d1ddb08645bdcc5635ad815352419d9e4c170665ecc20e5abdb7503e1fe80 +HOST_PATH +IN_NIX_SHELL +LD +LD_DYLD_PATH +MACOSX_DEPLOYMENT_TARGET +NIX_BINTOOLS +NIX_BINTOOLS_WRAPPER_TARGET_HOST_x86_64_apple_darwin +NIX_BUILD_CORES +NIX_CC +NIX_CC_WRAPPER_TARGET_HOST_x86_64_apple_darwin +NIX_CFLAGS_COMPILE +NIX_COREFOUNDATION_RPATH +NIX_DONT_SET_RPATH +NIX_DONT_SET_RPATH_FOR_BUILD +NIX_ENFORCE_NO_NATIVE +NIX_HARDENING_ENABLE +NIX_IGNORE_LD_THROUGH_GCC +NIX_LDFLAGS +NIX_NO_SELF_RPATH +NIX_STORE +NM +PATH_LOCALE +RANLIB +SIZE +SOURCE_DATE_EPOCH +STRINGS +STRIP +__DEVBOX_SHELLENV_HASH_b34d1ddb08645bdcc5635ad815352419d9e4c170665ecc20e5abdb7503e1fe80 +__darwinAllowLocalNetworking +__impureHostDeps +__propagatedImpureHostDeps +__propagatedSandboxProfile +__sandboxProfile +__structuredAttrs +buildInputs +buildPhase +builder +cmakeFlags +configureFlags +depsBuildBuild +depsBuildBuildPropagated +depsBuildTarget +depsBuildTargetPropagated +depsHostHost +depsHostHostPropagated +depsTargetTarget +depsTargetTargetPropagated +doCheck +doInstallCheck +dontAddDisableDepTrack +mesonFlags +name +nativeBuildInputs +out +outputs +patches +phases +preferLocalBuild +propagatedBuildInputs +propagatedNativeBuildInputs +shell +shellHook +stdenv +strictDeps +system ~DEVBOX_CONFIG_DIR ~DEVBOX_PACKAGES_DIR ~DEVBOX_PATH_STACK ~DEVBOX_PROJECT_ROOT ~DEVBOX_WD ~PATH
```

AFTER:
```
% cd 'project with spaces'
direnv: loading ~/code/jetpack/devbox-projects/project with spaces/.envrc
direnv: using devbox
direnv: export +AR +AS +CC +CONFIG_SHELL +CXX +DEVBOX_NIX_ENV_PATH_b34d1ddb08645bdcc5635ad815352419d9e4c170665ecc20e5abdb7503e1fe80 +HOST_PATH +IN_NIX_SHELL +LD +LD_DYLD_PATH +MACOSX_DEPLOYMENT_TARGET +NIX_BINTOOLS +NIX_BINTOOLS_WRAPPER_TARGET_HOST_x86_64_apple_darwin +NIX_BUILD_CORES +NIX_CC +NIX_CC_WRAPPER_TARGET_HOST_x86_64_apple_darwin +NIX_CFLAGS_COMPILE +NIX_COREFOUNDATION_RPATH +NIX_DONT_SET_RPATH +NIX_DONT_SET_RPATH_FOR_BUILD +NIX_ENFORCE_NO_NATIVE +NIX_HARDENING_ENABLE +NIX_IGNORE_LD_THROUGH_GCC +NIX_LDFLAGS +NIX_NO_SELF_RPATH +NIX_STORE +NM +PATH_LOCALE +RANLIB +SIZE +SOURCE_DATE_EPOCH +STRINGS +STRIP +__DEVBOX_SHELLENV_HASH_b34d1ddb08645bdcc5635ad815352419d9e4c170665ecc20e5abdb7503e1fe80 +__darwinAllowLocalNetworking +__impureHostDeps +__propagatedImpureHostDeps +__propagatedSandboxProfile +__sandboxProfile +__structuredAttrs +buildInputs +buildPhase +builder +cmakeFlags +configureFlags +depsBuildBuild +depsBuildBuildPropagated +depsBuildTarget +depsBuildTargetPropagated +depsHostHost +depsHostHostPropagated +depsTargetTarget +depsTargetTargetPropagated +doCheck +doInstallCheck +dontAddDisableDepTrack +mesonFlags +name +nativeBuildInputs +out +outputs +patches +phases +preferLocalBuild +propagatedBuildInputs +propagatedNativeBuildInputs +shell +shellHook +stdenv +strictDeps +system ~DEVBOX_CONFIG_DIR ~DEVBOX_PACKAGES_DIR ~DEVBOX_PATH_STACK ~DEVBOX_PROJECT_ROOT ~DEVBOX_WD ~PATH
```
