### PR TITLE
[zeroconfig] Default nodejs to corepack enabled

### DIFF
--- a/internal/devconfig/configfile/ast.go
+++ b/internal/devconfig/configfile/ast.go
@@ -425,3 +425,25 @@ func (c *configAST) beforeComment(path ...any) []byte {
 		}),
 	)
 }
+
+func (c *configAST) setEnv(env map[string]string) {
+	members := make([]hujson.ObjectMember, 0, len(env))
+	for k, v := range env {
+		members = append(members, hujson.ObjectMember{
+			Name:  hujson.Value{Value: hujson.String(k)},
+			Value: hujson.Value{Value: hujson.String(v)},
+		})
+	}
+	i := c.memberIndex(c.root.Value.(*hujson.Object), "env")
+	if i == -1 {
+		c.root.Value.(*hujson.Object).Members = append(c.root.Value.(*hujson.Object).Members, hujson.ObjectMember{
+			Name:  hujson.Value{Value: hujson.String("env")},
+			Value: hujson.Value{Value: &hujson.Object{Members: members}},
+		})
+	} else {
+		c.root.Value.(*hujson.Object).Members[i].Value.Value = &hujson.Object{
+			Members: members,
+		}
+	}
+	c.root.Format()
+}

--- a/internal/devconfig/configfile/ast_test.go
+++ b/internal/devconfig/configfile/ast_test.go
@@ -1,0 +1,69 @@
+package configfile
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/tailscale/hujson"
+)
+
+func TestSetEnv(t *testing.T) {
+	tests := []struct {
+		name     string
+		initial  string
+		env      map[string]string
+		expected string
+	}{
+		{
+			name:    "add env to empty config",
+			initial: "{}",
+			env: map[string]string{
+				"FOO": "bar",
+				"BAZ": "qux",
+			},
+			expected: `{"env": {"FOO": "bar", "BAZ": "qux"}}
+`,
+		},
+		{
+			name: "update existing env",
+			initial: `{
+	"env": {
+		"EXISTING": "value"
+	}
+}`,
+			env: map[string]string{
+				"FOO": "bar",
+			},
+			expected: `{
+	"env": {"FOO": "bar"}
+}
+`,
+		},
+		{
+			name: "clear env with empty map",
+			initial: `{
+	"env": {
+		"EXISTING": "value"
+	}
+}`,
+			env: map[string]string{},
+			expected: `{
+	"env": {}
+}
+`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			val, err := hujson.Parse([]byte(tt.initial))
+			assert.NoError(t, err)
+
+			ast := &configAST{root: val}
+			ast.setEnv(tt.env)
+
+			actual := string(ast.root.Pack())
+			assert.Equal(t, tt.expected, actual)
+		})
+	}
+}

--- a/internal/devconfig/configfile/env.go
+++ b/internal/devconfig/configfile/env.go
@@ -44,3 +44,8 @@ func (c *ConfigFile) ParseEnvsFromDotEnv() (map[string]string, error) {
 
 	return envMap, nil
 }
+
+func (c *ConfigFile) SetEnv(env map[string]string) {
+	c.Env = env
+	c.ast.setEnv(env)
+}

--- a/pkg/autodetect/autodetect.go
+++ b/pkg/autodetect/autodetect.go
@@ -36,6 +36,11 @@ func populateConfig(ctx context.Context, path string, config *devconfig.Config) 
 	for _, pkg := range pkgs {
 		config.PackageMutator().Add(pkg)
 	}
+	env, err := env(ctx, path)
+	if err != nil {
+		return err
+	}
+	config.Root.SetEnv(env)
 	return nil
 }
 
@@ -55,6 +60,14 @@ func packages(ctx context.Context, path string) ([]string, error) {
 		return nil, err
 	}
 	return mostRelevantDetector.Packages(ctx)
+}
+
+func env(ctx context.Context, path string) (map[string]string, error) {
+	mostRelevantDetector, err := relevantDetector(path)
+	if err != nil || mostRelevantDetector == nil {
+		return nil, err
+	}
+	return mostRelevantDetector.Env(ctx)
 }
 
 // relevantDetector returns the most relevant detector for the given path.

--- a/pkg/autodetect/detector/detector.go
+++ b/pkg/autodetect/detector/detector.go
@@ -5,4 +5,5 @@ import "context"
 type Detector interface {
 	Relevance(path string) (float64, error)
 	Packages(ctx context.Context) ([]string, error)
+	Env(ctx context.Context) (map[string]string, error)
 }

--- a/pkg/autodetect/detector/go.go
+++ b/pkg/autodetect/detector/go.go
@@ -38,6 +38,10 @@ func (d *GoDetector) Packages(ctx context.Context) ([]string, error) {
 	return []string{"go@" + goVersion}, nil
 }
 
+func (d *GoDetector) Env(ctx context.Context) (map[string]string, error) {
+	return map[string]string{}, nil
+}
+
 func parseGoVersion(goModContent string) string {
 	// Use a regular expression to find the Go version directive
 	re := regexp.MustCompile(`(?m)^go\s+(\d+\.\d+(\.\d+)?)`)

--- a/pkg/autodetect/detector/nodejs.go
+++ b/pkg/autodetect/detector/nodejs.go
@@ -41,6 +41,10 @@ func (d *NodeJSDetector) Packages(ctx context.Context) ([]string, error) {
 	return []string{"nodejs@" + d.nodeVersion(ctx)}, nil
 }
 
+func (d *NodeJSDetector) Env(ctx context.Context) (map[string]string, error) {
+	return map[string]string{"DEVBOX_COREPACK_ENABLED": "1"}, nil
+}
+
 func (d *NodeJSDetector) nodeVersion(ctx context.Context) string {
 	if d.packageJSON == nil || d.packageJSON.Engines.Node == "" {
 		return "latest" // Default to latest if not specified

--- a/pkg/autodetect/detector/php.go
+++ b/pkg/autodetect/detector/php.go
@@ -49,6 +49,10 @@ func (d *PHPDetector) Packages(ctx context.Context) ([]string, error) {
 	return packages, nil
 }
 
+func (d *PHPDetector) Env(ctx context.Context) (map[string]string, error) {
+	return map[string]string{}, nil
+}
+
 func (d *PHPDetector) phpVersion(ctx context.Context) string {
 	require := d.composerJSON.Require
 

--- a/pkg/autodetect/detector/poetry.go
+++ b/pkg/autodetect/detector/poetry.go
@@ -58,6 +58,10 @@ func (d *PoetryDetector) Packages(ctx context.Context) ([]string, error) {
 	return []string{"python@" + pythonVersion, "poetry@" + poetryVersion}, nil
 }
 
+func (d *PoetryDetector) Env(ctx context.Context) (map[string]string, error) {
+	return d.PythonDetector.Env(ctx)
+}
+
 func determineBestVersion(ctx context.Context, pkg, version string) string {
 	if version == "" {
 		return "latest"

--- a/pkg/autodetect/detector/python.go
+++ b/pkg/autodetect/detector/python.go
@@ -28,6 +28,10 @@ func (d *PythonDetector) Packages(ctx context.Context) ([]string, error) {
 	return []string{"python@latest"}, nil
 }
 
+func (d *PythonDetector) Env(ctx context.Context) (map[string]string, error) {
+	return map[string]string{}, nil
+}
+
 func (d *PythonDetector) maxRelevance() float64 {
 	return 1.0
 }


### PR DESCRIPTION
## Summary

* Adds `DEVBOX_COREPACK_ENABLED: "1"` to nodejs detector.
* Adds ability to set env programmatically on config. (This probably doesn't work with interspaced comments)

## How was it tested?

* Unit tests
* Manually created project with package.json and then did `devbox init --auto` 
