### PR TITLE
[PROPOSAL] postgresql process-compose is faulty when $PGHOST contains blank space

### DIFF
--- a/plugins/postgresql/process-compose.yaml
+++ b/plugins/postgresql/process-compose.yaml
@@ -2,7 +2,7 @@ version: "0.5"
 
 processes:
   postgresql:
-    command: "pg_ctl start -o \"-k $PGHOST\""
+    command: "pg_ctl start -o \"-k '$PGHOST'\""
     is_daemon: true
     shutdown: 
       command: "pg_ctl stop -m fast"


### PR DESCRIPTION
Hello,

Please view this PR as a bug report and proposal for a fix, and not a finished feature implementation. 

When we were working with devbox we realised we had errors on some of our machines. After some debugging we found that `devbox services start postgresql` did not work properly on machines, where the absolute path to the project contained a blank space. This change in the process-compose was what fixed the issue for us.

I did not perform any due dilligence in checking or testing if this proposed change does not introduce a breaking change for other consumers. I am merely proposing a change that has worked for us personally.


## Summary

The postgresql process compose is faulty, as it does not properly escape the PGHOST variable. When a blank space is anywhere in the absolute path of the  project, pg_ctl will interpret the blank space as a new argument, instead of being part of the path argument.

## How was it tested?
WIP, the change was tested locally in an extra process-compose.yml that was not part of the plugin. This PR merely suggests that the change may be applied to the plugin. However I have not done any testing and this PR **SHOULD NOT BE MERGED AS IS**. 
As the change is only trivial I used the PR to notify of the issue, since this makes it much clearer what the problem was.

