### PR TITLE
[bug] plugin env PATH fix

### DIFF
--- a/internal/devbox/devbox.go
+++ b/internal/devbox/devbox.go
@@ -726,8 +726,6 @@ func (d *Devbox) computeEnv(
 	if err != nil {
 		return nil, err
 	}
-	// fmt.Println("PATH before configEnv: ", env["PATH"])
-	// fmt.Println("PATH after configEnv: ", configEnv["PATH"])
 
 	addEnvIfNotPreviouslySetByDevbox(env, configEnv)
 

--- a/internal/devbox/devbox.go
+++ b/internal/devbox/devbox.go
@@ -726,6 +726,9 @@ func (d *Devbox) computeEnv(
 	if err != nil {
 		return nil, err
 	}
+	// fmt.Println("PATH before configEnv: ", env["PATH"])
+	// fmt.Println("PATH after configEnv: ", configEnv["PATH"])
+
 	addEnvIfNotPreviouslySetByDevbox(env, configEnv)
 
 	markEnvsAsSetByDevbox(configEnv)

--- a/internal/devbox/devbox.go
+++ b/internal/devbox/devbox.go
@@ -726,7 +726,6 @@ func (d *Devbox) computeEnv(
 	if err != nil {
 		return nil, err
 	}
-
 	addEnvIfNotPreviouslySetByDevbox(env, configEnv)
 
 	markEnvsAsSetByDevbox(configEnv)

--- a/internal/devconfig/config.go
+++ b/internal/devconfig/config.go
@@ -424,7 +424,7 @@ func createIncludableFromPluginConfig(pluginConfig *plugin.Config) *Config {
 //	/config/env/bin/:/plugin2/bin/:/plugin1/bin/:$PATH
 //
 // because config env should take priority over plugins
-func mergePATHsFromTwoEnvs(currentEnv map[string]string, newEnv map[string]string) map[string]string {
+func mergePATHsFromTwoEnvs(currentEnv, newEnv map[string]string) map[string]string {
 	if currentEnv["PATH"] != "" {
 		slog.Debug("A Plugin or Config wants to modify PATH. Processing the merge", "AddedPATH", newEnv["PATH"])
 		newEnv["PATH"] = strings.Replace(newEnv["PATH"], "$PATH", currentEnv["PATH"], 1)

--- a/internal/devconfig/config.go
+++ b/internal/devconfig/config.go
@@ -425,7 +425,7 @@ func createIncludableFromPluginConfig(pluginConfig *plugin.Config) *Config {
 //
 // because config env should take priority over plugins
 func mergePATHsFromTwoEnvs(currentEnv, newEnv map[string]string) map[string]string {
-	if currentEnv["PATH"] != "" {
+	if currentEnv["PATH"] != "" && newEnv["PATH"] != "" {
 		slog.Debug("A Plugin or Config wants to modify PATH. Processing the merge", "AddedPATH", newEnv["PATH"])
 		newEnv["PATH"] = strings.Replace(newEnv["PATH"], "$PATH", currentEnv["PATH"], 1)
 	}


### PR DESCRIPTION
## Summary
When a plugin modifies PATH and also config in devbox.json modifies PATH via `env:{}`, the env overwrites the plugin and so PATH modification from the plugin is lost. This is because we do `maps.Copy()` to merge the env from plugin to the one from config. 
The copy is fine for all other env variables but for PATH we need to handle merging the two rather than overwriting.
Fixes #2138 

## How was it tested?
bug recreate:
- devbox init
- devbox add ruby (ruby plugin modifies PATH)
- devbox shell (see PATH is prepended with ruby plugin)
- modify devbox.json and add `"env": {"PATH": "/my/config/bin:$PATH"}`
- re-enter devbox shell and see PATH prepend from ruby plugin is lost, only `"/my/config/bin"` is prepended.
fix recreate:
- follow same steps, but in last step both PATH prepends from devbox.json and from plugin are present.