### PR TITLE
Nix Installer have an official documentation, now

### DIFF
--- a/docs/app/docs/installing_devbox.mdx
+++ b/docs/app/docs/installing_devbox.mdx
@@ -20,7 +20,7 @@ curl -fsSL https://get.jetify.com/devbox | bash
 
 Devbox requires the [Nix Package Manager](https://nixos.org/download.html). If Nix is not detected when running a command, Devbox will install it for you in single-user mode for Linux. Don't worry: You can use Devbox without needing to learn the Nix Language.
 
-If you would like to install Nix yourself, we recommend the [Determinate Nix Installer](https://determinate.systems/posts/determinate-nix-installer/).
+If you would like to install Nix yourself, we recommend the [Determinate Nix Installer](https://determinate.systems/nix-installer/).
 
 </TabItem>
 <TabItem value="macos" label="MacOS">


### PR DESCRIPTION
## Summary

Change the URL of Nix Installer, they have a proper documentation, now ; which is better than the announcement blog post

## How was it tested?

Just with markdown preview instead GitHub