### PR TITLE
Exclude testscripts from Flake build

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -47,6 +47,9 @@
             "-X go.jetpack.io/devbox/internal/build.Commit=${revision}"
           ];
 
+          # Don't generate test binaries (as we'd include them as a bin)
+          excludedPackages = [ "testscripts" ];
+
           # Disable tests if they require network access or are integration tests
           doCheck = false;
 


### PR DESCRIPTION
This stops including a potentially-colliding 'updater' binary in the derivation.

## Summary

When I tried to install Zen browser on my NixOS system via a flake (`zen-browser.url = "github:MarceColl/zen-browser-flake";`), I got a build error saying that zen-browser included a file that collides with a devbox file:

```
error: builder for '/nix/store/8fy82p10qwd7z5aj4sraq9k88c62nz55-home-manager-path.drv' failed with exit code 25;
       last 1 log lines:
       > error: collision between `/nix/store/915ll44ksnhy369wyqlm8ys7ylxzmi89-devbox-0.13.6-0bc66cb/bin/updater' and `/nix/store/s2bz22csj1a8yjh3n3i1h67s5zhrh1g2-zen-browser-1.0.1-a.6/bin/updater'
```

My guess is that the zen-browser flake is also at fault (also errantly including a binary named `updater`) but this is where I looked (and figured out how to fix) first.

## How was it tested?

Re-ran the build via `nix build .` and verified that `./result/bin/` now contains only `devbox`. (It used to also contain a 1.7MB file called `updater`.)
