### PR TITLE
[cli-test] Added /usr/bin to PATH so that haskell can to verify pkg downloads

### DIFF
--- a/examples/development/haskell/devbox.json
+++ b/examples/development/haskell/devbox.json
@@ -7,6 +7,9 @@
     "zlib@latest",
     "hpack@latest"
   ],
+  "env": {
+    "PATH": "$PATH:/usr/bin"
+  },
   "shell": {
     "init_hook": null,
     "scripts": {


### PR DESCRIPTION
## Summary
CICD jobs for [`cli-test`](https://github.com/jetify-com/devbox/actions/workflows/cli-tests.yaml?query=branch%3Amain) has been failing on Haskell example because the PATH (only) in test environment for macos doesn't have access to `/usr/bin/security` so it fails to verify TLS handshake on haskell package downloads. 
This small change ensures haskell has access to security binary. 

Broader fix would be to add `/usr/bin` to [`setupPATH`](https://github.com/jetify-com/devbox/blob/0fdfc6764a0a16fbbff504410053b13dee075e5f/testscripts/testrunner/setupenv.go#L39) function that sets up test environments before being run in CICD. But this PR keeps the scope to only the failing test.

related to https://github.com/commercialhaskell/stack/issues/4558

## How was it tested?
tested in this CI job:
https://github.com/jetify-com/devbox/actions/runs/12147321911