### PR TITLE
feat(cli): improve search result view for large version lists

### DIFF
--- a/internal/boxcli/search.go
+++ b/internal/boxcli/search.go
@@ -104,7 +104,11 @@ func printSearchResults(
 		versionString := ""
 		if len(nonEmptyVersions) > 0 {
 			ellipses := lo.Ternary(resultsAreTrimmed && pkg.NumVersions > trimmedVersionsLength, " ...", "")
-			versionString = fmt.Sprintf(" (%s%s)", strings.Join(nonEmptyVersions, ", "), ellipses)
+			if showAll {
+				versionString = fmt.Sprintf("\n > %s \n", strings.Join(nonEmptyVersions, "\n > "))
+			} else {
+				versionString = fmt.Sprintf(" (%s%s)", strings.Join(nonEmptyVersions, ", "), ellipses)
+			}
 		}
 		fmt.Fprintf(w, "* %s %s\n", pkg.Name, versionString)
 	}


### PR DESCRIPTION
## Summary
This is a cool package, i was looking for something like this and just found it. 
As we know when searching for a package the results will be like this
![image](https://github.com/user-attachments/assets/7dbfdbe3-156e-41e2-898a-43a6bc2840b3)

but the results will be a bit difficult to read when there are many versions are available like this.
![image](https://github.com/user-attachments/assets/1e6ed34b-4816-48d8-a5c5-37c10bec4385)

I suggest it would be easier to read the available versions if it were like this
![image](https://github.com/user-attachments/assets/3803a0c1-5132-40a8-8630-5a3b40df8297)

or if you have a more readable option I'm open to that. Thanks for making such a cool package.