### PR TITLE
Bump version to 0.13.7

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -11,7 +11,7 @@
       let
         pkgs = nixpkgs.legacyPackages.${system};
 
-        lastTag = "0.13.6";
+        lastTag = "0.13.7";
 
         revision =
           if (self ? shortRev)


### PR DESCRIPTION
## Summary

Bump flake version to 0.13.7

## How was it tested?

nix build .
