### PR TITLE
devbox: export API for devbox install

### DIFF
--- a/devbox.go
+++ b/devbox.go
@@ -1,0 +1,32 @@
+// Package devbox creates and configures Devbox development environments.
+package devbox
+
+import (
+	"context"
+	"io"
+
+	"go.jetpack.io/devbox/internal/devbox"
+	"go.jetpack.io/devbox/internal/devbox/devopt"
+)
+
+// Devbox is a Devbox development environment.
+type Devbox struct {
+	dx *devbox.Devbox
+}
+
+// Open loads a Devbox environment from a config file or directory.
+func Open(path string) (*Devbox, error) {
+	dx, err := devbox.Open(&devopt.Opts{
+		Dir:    path,
+		Stderr: io.Discard,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &Devbox{dx: dx}, nil
+}
+
+// Install downloads and installs missing packages.
+func (d *Devbox) Install(ctx context.Context) error {
+	return d.dx.Install(ctx)
+}


### PR DESCRIPTION
Add a top-level package that makes a subset of the `internal/devbox` functionality (currently just install) public.

There are some places where we want to run devbox commands (such as in the prefetcher) which requires us to run the CLI externally. Exporting a package means we can run the command implementation directly and don't need to install the CLI (similar to what we're doing with autodetect).