### PR TITLE
move glibcLocales to plugins

### DIFF
--- a/examples/databases/postgres/devbox.json
+++ b/examples/databases/postgres/devbox.json
@@ -1,10 +1,6 @@
 {
   "packages": {
-    "postgresql": "latest",
-    "glibcLocales": {
-      "version":   "latest",
-      "platforms": ["x86_64-linux", "aarch64-linux"]
-    }
+    "postgresql": "latest"
   },
   "shell": {
     "init_hook": null

--- a/plugins/mariadb.json
+++ b/plugins/mariadb.json
@@ -15,9 +15,13 @@
     "{{ .Virtenv }}/setup_db.sh": "mariadb/setup_db.sh",
     "{{ .Virtenv }}/process-compose.yaml": "mariadb/process-compose.yaml"
   },
-  "packages": [
-    "path:{{ .Virtenv }}/flake"
-  ],
+  "packages": {
+    "path:{{ .Virtenv }}/flake": {},
+    "glibcLocales": {
+      "version": "latest",
+      "platforms": ["x86_64-linux", "aarch64-linux"]
+    }
+  },
   "__remove_trigger_package": true,
   "shell": {
     "init_hook": [

--- a/plugins/mysql.json
+++ b/plugins/mysql.json
@@ -15,9 +15,13 @@
       "{{ .Virtenv }}/setup_db.sh": "mysql/setup_db.sh",
       "{{ .Virtenv }}/process-compose.yaml": "mysql/process-compose.yaml"
     },
-    "packages": [
-      "path:{{ .Virtenv }}/flake"
-    ],
+    "packages": {
+      "path:{{ .Virtenv }}/flake": {},
+      "glibcLocales": {
+        "version": "latest",
+        "platforms": ["x86_64-linux", "aarch64-linux"]
+      }
+    },
     "__remove_trigger_package": true,
     "shell": {
       "init_hook": [

--- a/plugins/postgresql.json
+++ b/plugins/postgresql.json
@@ -2,6 +2,12 @@
     "name": "postgresql",
     "version": "0.0.2",
     "description": "To initialize the database run `initdb`.",
+    "packages": {
+        "glibcLocales": {
+            "version": "latest",
+            "platforms": ["x86_64-linux", "aarch64-linux"]
+        }
+    },
     "env": {
         "PGDATA": "{{ .Virtenv }}/data",
         "PGHOST": "{{ .Virtenv }}"


### PR DESCRIPTION
## Summary

Add `glibcLocales` to the Plugins for PostgreSQL, MySQL, and MariaDB so users don't have to add it on Linux

## How was it tested?

Run e2e tests, test in Devspaces
