### PR TITLE
devbox: clean up profile history after sync

### DIFF
--- a/testscripts/rm/multi.test.txt
+++ b/testscripts/rm/multi.test.txt
@@ -10,6 +10,10 @@ exec devbox rm vim hello
 
 json.superset devbox.json expected.json
 
+# Check that profile history was cleaned up. There should only be
+# default and default-N-link.
+glob -count=2 .devbox/nix/profile/*
+
 -- expected.json --
 {
   "packages": []


### PR DESCRIPTION
After syncing the flake packages to the profile, remove all old generations of the Nix profile. This allows the Nix garbage collector to eventually remove any old packages.

Opted for a Go implementation instead of calling `nix profile wipe-history` because deleting the history is pretty simple and this is faster.