### PR TITLE
lock: add support for locking stdenv + flakerefs

### DIFF
--- a/internal/devbox/devbox.go
+++ b/internal/devbox/devbox.go
@@ -46,6 +46,7 @@ import (
 	"go.jetpack.io/devbox/internal/shellgen"
 	"go.jetpack.io/devbox/internal/telemetry"
 	"go.jetpack.io/devbox/internal/ux"
+	"go.jetpack.io/devbox/nix/flake"
 )
 
 const (
@@ -202,8 +203,14 @@ func (d *Devbox) ConfigHash() (string, error) {
 	return cachehash.Bytes(buf.Bytes()), nil
 }
 
-func (d *Devbox) NixPkgsCommitHash() string {
-	return d.cfg.NixPkgsCommitHash()
+func (d *Devbox) Stdenv() flake.Ref {
+	return flake.Ref{
+		Type:  flake.TypeGitHub,
+		Owner: "NixOS",
+		Repo:  "nixpkgs",
+		Ref:   "nixpkgs-unstable",
+		Rev:   d.cfg.NixPkgsCommitHash(),
+	}
 }
 
 func (d *Devbox) Generate(ctx context.Context) error {

--- a/internal/devbox/update.go
+++ b/internal/devbox/update.go
@@ -65,6 +65,9 @@ func (d *Devbox) Update(ctx context.Context, opts devopt.UpdateOpts) error {
 		}
 	}
 
+	if err := d.updateStdenv(); err != nil {
+		return err
+	}
 	if err := d.ensureStateIsUpToDate(ctx, update); err != nil {
 		return err
 	}
@@ -101,6 +104,15 @@ func (d *Devbox) inputsToUpdate(
 		pkgsToUpdate = append(pkgsToUpdate, found)
 	}
 	return pkgsToUpdate, nil
+}
+
+func (d *Devbox) updateStdenv() error {
+	err := d.lockfile.Remove(d.Stdenv().String())
+	if err != nil {
+		return err
+	}
+	d.lockfile.Stdenv() // will re-resolve the stdenv flake
+	return nil
 }
 
 func (d *Devbox) updateDevboxPackage(pkg *devpkg.Package) error {

--- a/internal/devconfig/configfile/file.go
+++ b/internal/devconfig/configfile/file.go
@@ -94,11 +94,8 @@ func (c *ConfigFile) Equals(other *ConfigFile) bool {
 }
 
 func (c *ConfigFile) NixPkgsCommitHash() string {
-	// The commit hash for nixpkgs-unstable on 2023-10-25 from status.nixos.org
-	const DefaultNixpkgsCommit = "75a52265bda7fd25e06e3a67dee3f0354e73243c"
-
-	if c == nil || c.Nixpkgs == nil || c.Nixpkgs.Commit == "" {
-		return DefaultNixpkgsCommit
+	if c == nil || c.Nixpkgs == nil {
+		return ""
 	}
 	return c.Nixpkgs.Commit
 }

--- a/internal/lock/interfaces.go
+++ b/internal/lock/interfaces.go
@@ -3,16 +3,18 @@
 
 package lock
 
+import "go.jetpack.io/devbox/nix/flake"
+
 type devboxProject interface {
 	ConfigHash() (string, error)
-	NixPkgsCommitHash() string
+	Stdenv() flake.Ref
 	AllPackageNamesIncludingRemovedTriggerPackages() []string
 	ProjectDir() string
 }
 
 type Locker interface {
 	Get(string) *Package
-	LegacyNixpkgsPath(string) string
+	Stdenv() flake.Ref
 	ProjectDir() string
 	Resolve(string) (*Package, error)
 }

--- a/internal/nix/build.go
+++ b/internal/nix/build.go
@@ -20,6 +20,9 @@ type BuildArgs struct {
 
 func Build(ctx context.Context, args *BuildArgs, installables ...string) error {
 	defer debug.FunctionTimer().End()
+
+	FixInstallableArgs(installables)
+
 	// --impure is required for allowUnfreeEnv/allowInsecureEnv to work.
 	cmd := command("build", "--impure")
 	cmd.Args = appendArgs(cmd.Args, args.Flags)

--- a/internal/nix/flake.go
+++ b/internal/nix/flake.go
@@ -1,0 +1,30 @@
+package nix
+
+import (
+	"context"
+	"encoding/json"
+
+	"go.jetpack.io/devbox/nix/flake"
+)
+
+type FlakeMetadata struct {
+	Description string    `json:"description"`
+	Original    flake.Ref `json:"original"`
+	Resolved    flake.Ref `json:"resolved"`
+	Locked      flake.Ref `json:"locked"`
+	Path        string    `json:"path"`
+}
+
+func ResolveFlake(ctx context.Context, ref flake.Ref) (FlakeMetadata, error) {
+	cmd := command("flake", "metadata", "--json", ref)
+	out, err := cmd.Output(ctx)
+	if err != nil {
+		return FlakeMetadata{}, err
+	}
+	meta := FlakeMetadata{}
+	err = json.Unmarshal(out, &meta)
+	if err != nil {
+		return FlakeMetadata{}, err
+	}
+	return meta, nil
+}

--- a/internal/nix/profiles.go
+++ b/internal/nix/profiles.go
@@ -52,6 +52,7 @@ func ProfileInstall(ctx context.Context, args *ProfileInstallArgs) error {
 		"--priority", nextPriority(args.ProfilePath),
 	)
 
+	FixInstallableArgs(args.Installables)
 	cmd.Args = appendArgs(cmd.Args, args.Installables)
 	cmd.Env = allowUnfreeEnv(os.Environ())
 
@@ -75,6 +76,8 @@ func ProfileRemove(profilePath string, packageNames ...string) error {
 		"--profile", profilePath,
 		"--impure", // for NIXPKGS_ALLOW_UNFREE
 	)
+
+	FixInstallableArgs(packageNames)
 	cmd.Args = appendArgs(cmd.Args, packageNames)
 	cmd.Env = allowUnfreeEnv(allowInsecureEnv(os.Environ()))
 	return cmd.Run(context.TODO())

--- a/internal/nix/store.go
+++ b/internal/nix/store.go
@@ -13,7 +13,6 @@ import (
 	"go.jetpack.io/devbox/internal/debug"
 	"go.jetpack.io/devbox/internal/redact"
 	"go.jetpack.io/devbox/nix"
-	"go.jetpack.io/devbox/nix/flake"
 	"golang.org/x/exp/maps"
 )
 
@@ -29,20 +28,8 @@ func StorePathFromHashPart(ctx context.Context, hash, storeAddr string) (string,
 func StorePathsFromInstallable(ctx context.Context, installable string, allowInsecure bool) ([]string, error) {
 	defer debug.FunctionTimer().End()
 
-	// Some older versions of Nix have a bug where specifying a narHash
-	// without a lastModifiedDate query parameter results in an error. I'm
-	// not sure when it was fixed, but I know it works in 2.25+.
-	if !nix.AtLeast(nix.Version2_25) {
-		parsed, err := flake.ParseInstallable(installable)
-		if err == nil {
-			parsed.Ref.NARHash = ""
-			parsed.Ref.LastModified = 0
-			installable = parsed.String()
-		}
-	}
-
 	// --impure for NIXPKGS_ALLOW_UNFREE
-	cmd := command("path-info", installable, "--json", "--impure")
+	cmd := command("path-info", FixInstallableArg(installable), "--json", "--impure")
 	cmd.Env = allowUnfreeEnv(os.Environ())
 
 	if allowInsecure {

--- a/internal/shellgen/flake_input.go
+++ b/internal/shellgen/flake_input.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/samber/lo"
 	"go.jetpack.io/devbox/internal/devpkg"
+	"go.jetpack.io/devbox/internal/nix"
 	"go.jetpack.io/devbox/nix/flake"
 )
 
@@ -43,7 +44,7 @@ func (f *flakeInput) HashFromNixPkgsURL() string {
 
 func (f *flakeInput) URLWithCaching() string {
 	if !f.IsNixpkgs() {
-		return f.Ref.String()
+		return nix.FixInstallableArg(f.Ref.String())
 	}
 	return getNixpkgsInfo(f.Ref.Rev).URL
 }

--- a/internal/shellgen/flake_plan.go
+++ b/internal/shellgen/flake_plan.go
@@ -20,7 +20,7 @@ import (
 // flakePlan contains the data to populate the top level flake.nix file
 // that builds the devbox environment
 type flakePlan struct {
-	NixpkgsInfo *NixpkgsInfo
+	Stdenv      flake.Ref
 	Packages    []*devpkg.Package
 	FlakeInputs []flakeInput
 	System      string
@@ -44,21 +44,9 @@ func newFlakePlan(ctx context.Context, devbox devboxer) (*flakePlan, error) {
 		return nil, err
 	}
 
-	flakeInputs := flakeInputs(ctx, packages)
-	nixpkgsInfo := getNixpkgsInfo(devbox.Config().NixPkgsCommitHash())
-
-	// This is an optimization. Try to reuse the nixpkgs info from the flake
-	// inputs to avoid introducing a new one.
-	for _, input := range flakeInputs {
-		if input.IsNixpkgs() {
-			nixpkgsInfo = getNixpkgsInfo(input.HashFromNixPkgsURL())
-			break
-		}
-	}
-
 	return &flakePlan{
-		FlakeInputs: flakeInputs,
-		NixpkgsInfo: nixpkgsInfo,
+		FlakeInputs: flakeInputs(ctx, packages),
+		Stdenv:      devbox.Lockfile().Stdenv(),
 		Packages:    packages,
 		System:      nix.System(),
 	}, nil
@@ -66,7 +54,7 @@ func newFlakePlan(ctx context.Context, devbox devboxer) (*flakePlan, error) {
 
 func (f *flakePlan) needsGlibcPatch() bool {
 	for _, in := range f.FlakeInputs {
-		if in.URL == glibcPatchFlakeRef {
+		if in.Ref == glibcPatchFlakeRef {
 			return true
 		}
 	}

--- a/internal/shellgen/generate_test.go
+++ b/internal/shellgen/generate_test.go
@@ -14,6 +14,7 @@ import (
 	"go.jetpack.io/devbox/internal/devpkg"
 	"go.jetpack.io/devbox/internal/lock"
 	"go.jetpack.io/devbox/internal/searcher"
+	"go.jetpack.io/devbox/nix/flake"
 )
 
 // update overwrites golden files with the new test results.
@@ -41,10 +42,6 @@ func TestWriteFromTemplate(t *testing.T) {
 	})
 	t.Run("WriteModifiedSmaller", func(t *testing.T) {
 		emptyPlan := &flakePlan{
-			NixpkgsInfo: &NixpkgsInfo{
-				URL:    "",
-				TarURL: "",
-			},
 			Packages:    []*devpkg.Package{},
 			FlakeInputs: []flakeInput{},
 			System:      "x86_64-linux",
@@ -89,15 +86,11 @@ If the new file is correct, you can update the golden file with:
 var (
 	locker            = &lockmock{}
 	testFlakeTmplPlan = &flakePlan{
-		NixpkgsInfo: &NixpkgsInfo{
-			URL:    "https://github.com/nixos/nixpkgs/archive/b9c00c1d41ccd6385da243415299b39aa73357be.tar.gz",
-			TarURL: "", // TODO savil
-		},
 		Packages: []*devpkg.Package{}, // TODO savil
 		FlakeInputs: []flakeInput{
 			{
 				Name: "nixpkgs",
-				URL:  "github:NixOS/nixpkgs/b9c00c1d41ccd6385da243415299b39aa73357be",
+				Ref:  flake.Ref{Type: flake.TypeGitHub, Owner: "NixOS", Repo: "nixpkgs", Rev: "b9c00c1d41ccd6385da243415299b39aa73357be"},
 				Packages: []*devpkg.Package{
 					devpkg.PackageFromStringWithDefaults("php@latest", locker),
 					devpkg.PackageFromStringWithDefaults("php81Packages.composer@latest", locker),
@@ -137,14 +130,6 @@ func (*lockmock) Resolve(pkg string) (*lock.Package, error) {
 	}, nil
 }
 
-func (*lockmock) Get(pkg string) *lock.Package {
-	return nil
-}
-
-func (*lockmock) LegacyNixpkgsPath(pkg string) string {
-	return ""
-}
-
-func (*lockmock) ProjectDir() string {
-	return ""
-}
+func (*lockmock) Get(pkg string) *lock.Package { return nil }
+func (*lockmock) Stdenv() flake.Ref            { return flake.Ref{} }
+func (*lockmock) ProjectDir() string           { return "" }

--- a/internal/shellgen/testdata/flake.nix.golden
+++ b/internal/shellgen/testdata/flake.nix.golden
@@ -2,7 +2,7 @@
    description = "A devbox shell";
 
    inputs = {
-     nixpkgs.url = "https://github.com/nixos/nixpkgs/archive/b9c00c1d41ccd6385da243415299b39aa73357be.tar.gz";
+     nixpkgs.url = "";
      nixpkgs.url = "github:NixOS/nixpkgs/b9c00c1d41ccd6385da243415299b39aa73357be";
    };
 

--- a/internal/shellgen/tmpl/flake.nix.tmpl
+++ b/internal/shellgen/tmpl/flake.nix.tmpl
@@ -2,7 +2,7 @@
    description = "A devbox shell";
 
    inputs = {
-     nixpkgs.url = "{{ .NixpkgsInfo.URL }}";
+     nixpkgs.url = "{{ .Stdenv }}";
 
      {{- range .FlakeInputs }}
      {{.Name}}.url = "{{.URLWithCaching}}";
@@ -41,7 +41,7 @@
             {{- range $_, $output := $pkg.GetOutputsWithCache }}
             {{ if $output.CacheURI -}}
             (builtins.trace "downloading {{ $pkg.Versioned }}" (builtins.fetchClosure {
-              {{/*  
+              {{/*
                 HACK HACK HACK! fetchClosure only supports http(s) caches and not
                 s3 caches. Until we implement that, we put a fake store here.
                 Since we pre-build everything, fetchClosure will not actually

--- a/internal/shellgen/tmpl/shell.nix.tmpl
+++ b/internal/shellgen/tmpl/shell.nix.tmpl
@@ -1,7 +1,7 @@
 let
   pkgs = import
     (fetchTarball {
-      url = "{{ .NixpkgsInfo.TarURL }}";
+      url = "https://github.com/nixos/nixpkgs/archive/b9c00c1d41ccd6385da243415299b39aa73357be.tar.gz";
     })
     { };
 in


### PR DESCRIPTION
Depends on #2464.

---

Make the `stdenv` (and other flakerefs) lockable and updateable. This makes it possible to update the stdenv with a regular `devbox update` and simplifies the logic for how the stdenv commit is chosen:

1. If there's no stdenv flakeref in devbox.lock, resolve github:NixOS/nixpkgs/nixpkgs-unstable to a locked ref and store it in the lockfile.
2. Otherwise, use the ref in the lockfile.