### PR TITLE
nix/flake: fix Ref.String() for github flakes w/ rev and ref

### DIFF
--- a/nix/flake/flakeref.go
+++ b/nix/flake/flakeref.go
@@ -395,7 +395,7 @@ func (r Ref) String() string {
 		}
 		url := &url.URL{
 			Scheme: "github",
-			Opaque: buildEscapedPath(r.Owner, r.Repo, r.Rev, r.Ref),
+			Opaque: buildEscapedPath(r.Owner, r.Repo, cmp.Or(r.Rev, r.Ref)),
 			RawQuery: appendQueryString(nil,
 				"host", r.Host,
 				"dir", r.Dir,

--- a/nix/flake/flakeref_test.go
+++ b/nix/flake/flakeref_test.go
@@ -233,13 +233,14 @@ func TestFlakeRefString(t *testing.T) {
 		{Type: TypeIndirect, ID: "indirect", Ref: "ref", Rev: "5233fd2ba76a3accb5aaa999c00509a11fd0793c"}: "flake:indirect/ref/5233fd2ba76a3accb5aaa999c00509a11fd0793c",
 
 		// GitHub references.
-		{Type: TypeGitHub, Owner: "NixOS", Repo: "nix"}:                                                  "github:NixOS/nix",
-		{Type: TypeGitHub, Owner: "NixOS", Repo: "nix", Ref: "v1.2.3"}:                                   "github:NixOS/nix/v1.2.3",
-		{Type: TypeGitHub, Owner: "NixOS", Repo: "nix", Ref: "my/ref"}:                                   "github:NixOS/nix/my%2Fref",
-		{Type: TypeGitHub, Owner: "NixOS", Repo: "nix", Ref: "5233fd2ba76a3accb5aaa999c00509a11fd0793c"}: "github:NixOS/nix/5233fd2ba76a3accb5aaa999c00509a11fd0793c",
-		{Type: TypeGitHub, Owner: "NixOS", Repo: "nix", Ref: "5233fd2bb76a3accb5aaa999c00509a11fd0793z"}: "github:NixOS/nix/5233fd2bb76a3accb5aaa999c00509a11fd0793z",
-		{Type: TypeGitHub, Owner: "NixOS", Repo: "nix", Dir: "sub/dir"}:                                  "github:NixOS/nix?dir=sub%2Fdir",
-		{Type: TypeGitHub, Owner: "NixOS", Repo: "nix", Dir: "sub/dir", Host: "example.com"}:             "github:NixOS/nix?dir=sub%2Fdir&host=example.com",
+		{Type: TypeGitHub, Owner: "NixOS", Repo: "nix"}:                                                               "github:NixOS/nix",
+		{Type: TypeGitHub, Owner: "NixOS", Repo: "nix", Ref: "v1.2.3"}:                                                "github:NixOS/nix/v1.2.3",
+		{Type: TypeGitHub, Owner: "NixOS", Repo: "nix", Ref: "my/ref"}:                                                "github:NixOS/nix/my%2Fref",
+		{Type: TypeGitHub, Owner: "NixOS", Repo: "nix", Ref: "5233fd2ba76a3accb5aaa999c00509a11fd0793c"}:              "github:NixOS/nix/5233fd2ba76a3accb5aaa999c00509a11fd0793c",
+		{Type: TypeGitHub, Owner: "NixOS", Repo: "nix", Ref: "5233fd2bb76a3accb5aaa999c00509a11fd0793z"}:              "github:NixOS/nix/5233fd2bb76a3accb5aaa999c00509a11fd0793z",
+		{Type: TypeGitHub, Owner: "NixOS", Repo: "nix", Rev: "5233fd2ba76a3accb5aaa999c00509a11fd0793c", Ref: "main"}: "github:NixOS/nix/5233fd2ba76a3accb5aaa999c00509a11fd0793c",
+		{Type: TypeGitHub, Owner: "NixOS", Repo: "nix", Dir: "sub/dir"}:                                               "github:NixOS/nix?dir=sub%2Fdir",
+		{Type: TypeGitHub, Owner: "NixOS", Repo: "nix", Dir: "sub/dir", Host: "example.com"}:                          "github:NixOS/nix?dir=sub%2Fdir&host=example.com",
 
 		// Git references.
 		{Type: TypeGit, URL: "git://example.com/repo/flake"}:                                                                     "git://example.com/repo/flake",


### PR DESCRIPTION
The string form of GitHub flakeref can only have a rev or a ref, not both. For example:

- Good: `github:NixOS/nixpkgs/b321c8e818546d5491ee5611476500557b880856`
- Good: `github:NixOS/nixpkgs/nixpkgs-unstable`
- Bad: `github:NixOS/nixpkgs/nixpkgs-unstable/b321c8e818546d5491ee5611476500557b880856`

If both the Rev and Ref fields are set, use Rev.