### PR TITLE
fix: sort scripts list

### DIFF
--- a/internal/devbox/devbox.go
+++ b/internal/devbox/devbox.go
@@ -345,6 +345,9 @@ func (d *Devbox) ListScripts() []string {
 		keys[i] = k
 		i++
 	}
+
+	slices.Sort(keys)
+
 	return keys
 }
 


### PR DESCRIPTION
This allows to have a consistent output from `devbox run`.

Closes #1631 and #1991.

## Summary

## How was it tested?

I tested running multiple times `devbox run` in different project where I use it.