### PR TITLE
fix(python plugin): set UV_PYTHON to python in .venv

### DIFF
--- a/plugins/python.json
+++ b/plugins/python.json
@@ -4,7 +4,7 @@
   "description": "Python in Devbox works best when used with a virtual environment (venv, virtualenv, etc.). Devbox will automatically create a virtual environment using `venv` for python3 projects, so you can install packages with pip as normal.\nTo activate the environment, run `. $VENV_DIR/bin/activate` or add it to the init_hook of your devbox.json\nTo change where your virtual environment is created, modify the $VENV_DIR environment variable in your init_hook",
   "env": {
     "VENV_DIR": "{{ .DevboxProjectDir }}/.venv",
-    "UV_PYTHON": "{{ .DevboxProjectDir }}/.devbox/nix/profile/default/bin/python"
+    "UV_PYTHON": "{{ .DevboxProjectDir }}/.venv/bin/python"
   },
   "create_files": {
     "{{ .Virtenv }}/bin/venvShellHook.sh": "python/venvShellHook.sh"


### PR DESCRIPTION
Fixes #2411

## Summary
The UV_PYTHON env variables sets which python executable uv will use. 

The current plugin sets the UV_PYTHON value  to `.devbox/nix/profile/default/bin/python` which means `uv pip install ` commands will try to install and save libraries under the  `.devbox/nix/profile/default/lib/python3.x/site-packages` directory. 

This will cause an error as the directory doesn't have write permissions because it exists under a folder that is a symlinked to a folder under the `/nix/store` path.

This change makes sure UV_PYTHON points to the python executable under .venv. 
This will make `uv pip install` commands install libraries to the site-packages directory  under .venv just like normal `pip install ` would.

## How was it tested?

1. devbox create uvtest --template python-pip
2. cd uvtest
3. devbox add uv
4. uv pip install fastapi