### PR TITLE
fix: disable poetry plugin output

### DIFF
--- a/plugins/poetry/initHook.sh
+++ b/plugins/poetry/initHook.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-poetry env use $(command -v python) --directory="${DEVBOX_PYPROJECT_DIR:-$DEVBOX_DEFAULT_PYPROJECT_DIR}" --no-interaction >&2
+poetry env use $(command -v python) --directory="${DEVBOX_PYPROJECT_DIR:-$DEVBOX_DEFAULT_PYPROJECT_DIR}" --no-interaction --quiet >&2


### PR DESCRIPTION
## Summary

When using poetry, with the suggested `init_hook` from the docs:
```
{
    "packages": [
        "python3",
        "poetry@1.8" // notice I am using poetry 1.8, the poetry shell command is not part of poetry version 2.0
    ],
    "shell": {
        "init_hook": "poetry shell"
    }
}
```
and running `devbox shell`, while the poetry env is being loaded, it generates this log: 
`Using virtualenv: /home/fotiadis/src/work/trumo/services/tc_gateway_consumer/.venv`

This can be problematic to users instant prompt like the very famous zsh theme [powerlevel10k](https://github.com/romkatv/powerlevel10k)

By adding the `--quiet` flag this solves the problem

### What about poetry 2.0?

poetry 2.0 has removed the `poetry shell` (the functionality still exists if you download a plugin). The new way to achieve the same behavior according to [the docs](https://python-poetry.org/docs/managing-environments/#activating-the-environment) is: `eval $(poetry env activate)`

This change doesn't impact either major versions of poetry, and it will continue to work as normal

## How was it tested?

By disabling the current poetry plugin, and creating a new one that is the exact copy, just with the flag on
