### PR TITLE
Optimize Docker Image Size by Cleaning Nix Store

### DIFF
--- a/internal/devbox/generate/tmpl/dev.Dockerfile.tmpl
+++ b/internal/devbox/generate/tmpl/dev.Dockerfile.tmpl
@@ -21,7 +21,7 @@ COPY devbox.lock devbox.lock
 {{range $i, $element := .LocalFlakeDirs -}}
 COPY {{$element}} {{$element}}
 {{end}}
-RUN devbox run -- echo "Installed Packages."
+RUN devbox run -- echo "Installed Packages." && nix-store --gc && nix-store --optimise
 {{if .IsDevcontainer}}
 RUN devbox shellenv --init-hook >> ~/.profile
 {{- else}}


### PR DESCRIPTION
## Summary

This MR modifies the Dockerfile to reduce the final image size by optimizing the Nix store after installing packages. Added `nix-store --gc` and `nix-store --optimise` commands to clean up and optimize the Nix store after package installation.

## How was it tested?

Built the Docker image locally and verified the image size reduction. Confirmed that the application runs as expected after the changes.
