### PR TITLE
refactor(templates): use depth of 1 in clone command to limit history…

### DIFF
--- a/internal/templates/template.go
+++ b/internal/templates/template.go
@@ -45,6 +45,8 @@ func InitFromRepo(w io.Writer, repo, subdir, target string) error {
 		"git", "clone", parsedRepoURL,
 		// Clone and checkout a specific ref
 		"-b", lo.Ternary(build.IsDev, "main", build.Version),
+		// Create shallow clone with depth of 1
+		"--depth", "1",
 		tmp,
 	)
 	fmt.Fprintf(w, "%s\n", cmd)


### PR DESCRIPTION
addresses #2487 

## Summary
Creating a project using one of the templates will clone the entire history of the repo.
Only one commit is really needed in order to access the template files used to initialize a project.
This change creates a shallow clone with a depth of 1 to reduce the amount of history that is fetched which should increase speed  without sacrificing any functionality

## How was it tested?
1. `devbox run build`: build devbox
2. `time devbox create --template go test1`: time the devbox create command and confirm it clones faster and still creates the project 