### PR TITLE
fix: pass a ctx to client searcher `search`

### DIFF
--- a/internal/boxcli/search.go
+++ b/internal/boxcli/search.go
@@ -33,7 +33,7 @@ func searchCmd() *cobra.Command {
 			query := args[0]
 			name, version, isVersioned := searcher.ParseVersionedPackage(query)
 			if !isVersioned {
-				results, err := searcher.Client().Search(query)
+				results, err := searcher.Client().Search(cmd.Context(), query)
 				if err != nil {
 					return err
 				}

--- a/internal/searcher/client.go
+++ b/internal/searcher/client.go
@@ -32,7 +32,7 @@ func Client() *client {
 	}
 }
 
-func (c *client) Search(query string) (*SearchResults, error) {
+func (c *client) Search(ctx context.Context, query string) (*SearchResults, error) {
 	if query == "" {
 		return nil, fmt.Errorf("query should not be empty")
 	}
@@ -43,7 +43,7 @@ func (c *client) Search(query string) (*SearchResults, error) {
 	}
 	searchURL := endpoint + "?q=" + url.QueryEscape(query)
 
-	return execGet[SearchResults](context.TODO(), searchURL)
+	return execGet[SearchResults](ctx, searchURL)
 }
 
 // Resolve calls the /resolve endpoint of the search service. This returns


### PR DESCRIPTION
## Summary

This allows to cancel the search request.

## How was it tested?

Mostly manual testing