### PR TITLE
add --no-install flag to `devbox update`

### DIFF
--- a/internal/boxcli/update.go
+++ b/internal/boxcli/update.go
@@ -17,6 +17,7 @@ type updateCmdFlags struct {
 	config      configFlags
 	sync        bool
 	allProjects bool
+	noInstall   bool
 }
 
 func updateCmd() *cobra.Command {
@@ -49,6 +50,12 @@ func updateCmd() *cobra.Command {
 		false,
 		"update all projects in the working directory, recursively.",
 	)
+	command.Flags().BoolVar(
+		&flags.noInstall,
+		"no-install",
+		false,
+		"update lockfile but don't install anything",
+	)
 	return command
 }
 
@@ -75,7 +82,8 @@ func updateCmdFunc(cmd *cobra.Command, args []string, flags *updateCmdFlags) err
 	}
 
 	return box.Update(cmd.Context(), devopt.UpdateOpts{
-		Pkgs: args,
+		Pkgs:      args,
+		NoInstall: flags.noInstall,
 	})
 }
 

--- a/internal/devbox/devopt/devboxopts.go
+++ b/internal/devbox/devopt/devboxopts.go
@@ -58,6 +58,7 @@ type AddOpts struct {
 
 type UpdateOpts struct {
 	Pkgs                  []string
+	NoInstall             bool
 	IgnoreMissingPackages bool
 }
 

--- a/internal/devbox/packages.go
+++ b/internal/devbox/packages.go
@@ -275,8 +275,9 @@ const (
 	install   installMode = "install"
 	uninstall installMode = "uninstall"
 	// update is both install new package version and uninstall old package version
-	update installMode = "update"
-	ensure installMode = "ensure"
+	update    installMode = "update"
+	ensure    installMode = "ensure"
+	noInstall installMode = "noInstall"
 )
 
 // ensureStateIsUpToDate ensures the Devbox project state is up to date.

--- a/internal/devbox/update.go
+++ b/internal/devbox/update.go
@@ -68,7 +68,11 @@ func (d *Devbox) Update(ctx context.Context, opts devopt.UpdateOpts) error {
 	if err := d.updateStdenv(); err != nil {
 		return err
 	}
-	if err := d.ensureStateIsUpToDate(ctx, update); err != nil {
+	mode := update
+	if opts.NoInstall {
+		mode = noInstall
+	}
+	if err := d.ensureStateIsUpToDate(ctx, mode); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
## Summary

As part of getting devbox working in renovate, we need to run devbox in renovate's base image (added here https://github.com/containerbase/base/pull/3191). The problem is the way nix is installed (already in that image) it cannot actually install anything. This is because it's a quirky variant of a single user install where all the `/nix/*` paths are set to custom values.

We can work around this by just having devbox update the lockfile but not actually install anything (which is also a speed win) - but this functionality doesn't seem to available in the devbox cli currently.

This is a potential implementation adding what we need for renovate to upgrade devbox projects. Happy for you to do it another way. The approach we've taken seems like it's misusing the `mode` variable a little bit.

## How was it tested?

Manually tested only; run locally on a macbook, plus in the container linked above.
- add some packages that are older
- upgrade them by manually editing devbox.json
- run `devbox update --no-install` to update all packages in `devbox.lock` to latest within ranges `devbox.json`
- in the container this failed with `cmd.path=/usr/local/bin/nix cmd.stderr="cannot connect to socket at '/tmp/containerbase/cache/nix/state/daemon-socket/socket': No such file or directory"` but with this change it works
- run `devbox update nodejs --no-install` also works for a single package
- changes to lockfile seem to be the same as `devbox update` without the flag, so behaviour of this flag shouldn't surprise anyone