### PR TITLE
[ls] return unresolved packages as a warning instead of an error

### DIFF
--- a/internal/devbox/packages.go
+++ b/internal/devbox/packages.go
@@ -73,10 +73,8 @@ func (d *Devbox) Outdated(ctx context.Context) (map[string]UpdateVersion, error)
 		outdatedPackages[pkg.Versioned()] = UpdateVersion{Current: existingLockPackage.Version, Latest: lockPackage.Version}
 	}
 
-	if len(warnings) > 0 {
-		for _, warning := range warnings {
-			fmt.Fprintf(d.stderr, "%s\n", warning)
-		}
+	for _, warning := range warnings {
+		fmt.Fprintf(d.stderr, "%s\n", warning)
 	}
 
 	return outdatedPackages, nil


### PR DESCRIPTION
## Summary

Fixes #2510 

Previously, `devbox ls --outdated` would error on packages that it could not resolve, like `stdenv.cc.cc.lib` or `darwin.apple_sdk.frameworks.IOKit`. This prevented devbox from checking if the rest of the packages were outdated. 

This PR changes the error to a warning, so the rest of the version checks can proceed

## How was it tested?

1. Create a devbox.json
2. Add standard packages using `devbox add`
3. Add `stdenv.cc.cc.lib` or `darwin.apple_sdk.frameworks.IOKit` to the project
4. Verify that `devbox ls --outdated` shows a warning for the non-versioned packages instead of an error.
