### PR TITLE
[run] Add --all-projects flag

### DIFF
--- a/examples/development/elixir/elixir_hello/devbox.lock
+++ b/examples/development/elixir/elixir_hello/devbox.lock
@@ -1,54 +1,71 @@
 {
   "lockfile_version": "1",
   "packages": {
+    "darwin.apple_sdk.frameworks.CoreServices": {
+      "resolved": "github:NixOS/nixpkgs/3a05eebede89661660945da1f151959900903b6a?narHash=sha256-Ly2fBL1LscV%2BKyCqPRufUBuiw%2BzmWrlJzpWOWbahplg%3D#darwin.apple_sdk.frameworks.CoreServices",
+      "source": "nixpkg",
+      "systems": {
+        "aarch64-darwin": {
+          "outputs": [
+            {
+              "path": "/nix/store/mpq140x7nsx9gz73h4nfp9kpp297mshh-CoreServices-11.0",
+              "default": true
+            }
+          ]
+        }
+      }
+    },
     "elixir@latest": {
-      "last_modified": "2024-11-28T07:51:56Z",
+      "last_modified": "2024-12-27T03:08:00Z",
       "plugin_version": "0.0.1",
-      "resolved": "github:NixOS/nixpkgs/226216574ada4c3ecefcbbec41f39ce4655f78ef#elixir",
+      "resolved": "github:NixOS/nixpkgs/7cc0bff31a3a705d3ac4fdceb030a17239412210#elixir",
       "source": "devbox-search",
-      "version": "1.17.3",
+      "version": "1.18.1",
       "systems": {
         "aarch64-darwin": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/91w79z55qsjkhnbs3a21l3h27va98mf6-elixir-1.17.3",
+              "path": "/nix/store/hdd9x34p0gplcl1bramq80lqi76xrd87-elixir-1.18.1",
               "default": true
             }
           ],
-          "store_path": "/nix/store/91w79z55qsjkhnbs3a21l3h27va98mf6-elixir-1.17.3"
+          "store_path": "/nix/store/hdd9x34p0gplcl1bramq80lqi76xrd87-elixir-1.18.1"
         },
         "aarch64-linux": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/pz4hk0sp4zj76waaprlfdmvc4xdblz55-elixir-1.17.3",
+              "path": "/nix/store/a4g29icpil9b1hsniqspz5k110h4df8v-elixir-1.18.1",
               "default": true
             }
           ],
-          "store_path": "/nix/store/pz4hk0sp4zj76waaprlfdmvc4xdblz55-elixir-1.17.3"
+          "store_path": "/nix/store/a4g29icpil9b1hsniqspz5k110h4df8v-elixir-1.18.1"
         },
         "x86_64-darwin": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/gnjg57wv71svvqw7s3rxyjc6lkps2r95-elixir-1.17.3",
+              "path": "/nix/store/b3h6f36zd4gjivb76lvvs6a9bi1mq9q8-elixir-1.18.1",
               "default": true
             }
           ],
-          "store_path": "/nix/store/gnjg57wv71svvqw7s3rxyjc6lkps2r95-elixir-1.17.3"
+          "store_path": "/nix/store/b3h6f36zd4gjivb76lvvs6a9bi1mq9q8-elixir-1.18.1"
         },
         "x86_64-linux": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/rx7qr8bar4qldx6yg3njvm8hn84d3yyk-elixir-1.17.3",
+              "path": "/nix/store/3zd200bq28mv3pdbii7rijzmb0gmhhs3-elixir-1.18.1",
               "default": true
             }
           ],
-          "store_path": "/nix/store/rx7qr8bar4qldx6yg3njvm8hn84d3yyk-elixir-1.17.3"
+          "store_path": "/nix/store/3zd200bq28mv3pdbii7rijzmb0gmhhs3-elixir-1.18.1"
         }
       }
+    },
+    "github:NixOS/nixpkgs/nixpkgs-unstable": {
+      "resolved": "github:NixOS/nixpkgs/3a05eebede89661660945da1f151959900903b6a?lastModified=1740547748&narHash=sha256-Ly2fBL1LscV%2BKyCqPRufUBuiw%2BzmWrlJzpWOWbahplg%3D"
     }
   }
 }

--- a/internal/boxcli/run.go
+++ b/internal/boxcli/run.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log/slog"
 	"slices"
+	"sort"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -98,7 +99,8 @@ func listScripts(cmd *cobra.Command, flags runCmdFlags) []string {
 		for _, box := range boxes {
 			scripts = append(scripts, box.ListScripts()...)
 		}
-		return scripts
+		sort.Strings(scripts)
+		return lo.Uniq(scripts)
 	}
 	box, err := devbox.Open(devboxOpts)
 	if err != nil {

--- a/internal/devbox/devbox.go
+++ b/internal/devbox/devbox.go
@@ -165,8 +165,9 @@ func Open(opts *devopt.Opts) (*Devbox, error) {
 		}
 		ux.Fwarningf(
 			os.Stderr, // Always stderr. box.writer should probably always be err.
-			"Your devbox.json contains packages in legacy format. "+
+			"Your devbox.json at %s contains packages in legacy format. "+
 				"Please run `devbox %supdate` to update your devbox.json.\n",
+			box.projectDir,
 			lo.Ternary(box.projectDir == globalPath, "global ", ""),
 		)
 	}


### PR DESCRIPTION
## Summary

Allows running a script on all devbox projects nested in a directory. Useful for monorepos. Example:

`devbox run --all-projects lint`

Doing 

`devbox run --all-projects` without a script name shows all available scripts among all nested projects.

@savil I kinda regret changing `run` to remove the need for `--`. It means that this flag only works for defined scripts, not for arbitrary commands :( 

## How was it tested?

`devbox run --all-projects fmt`
