### PR TITLE
Disable PreRunE check for Nix when passing no-install flag on update cmd

### DIFF
--- a/internal/boxcli/update.go
+++ b/internal/boxcli/update.go
@@ -30,7 +30,12 @@ func updateCmd() *cobra.Command {
 			"If no packages are specified, all packages will be updated. " +
 			"Legacy non-versioned packages will be converted to @latest versioned " +
 			"packages resolved to their current version.",
-		PreRunE: ensureNixInstalled,
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			if flags.noInstall {
+				return nil
+			}
+			return ensureNixInstalled(cmd, args)
+		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return updateCmdFunc(cmd, args, flags)
 		},


### PR DESCRIPTION
## Summary

https://github.com/renovatebot/renovate/issues/27543#issuecomment-2705204833

Running into issues running the no-install command in renovate because the Nix install is not mounted.

This PR makes it so the PreRunE check to check if Nix is installed correctly won't run if the --no-install flag is passed to the update command.

## How was it tested?

I built devbox with a println in the ensureNixInstalled function and validated that it does not run when the --no-install flag is passed

## Community Contribution License

All community contributions in this pull request are licensed to the project
maintainers under the terms of the
[Apache 2 License](https://www.apache.org/licenses/LICENSE-2.0).

By creating this pull request, I represent that I have the right to license the
contributions to the project maintainers under the Apache 2 License as stated in
the
[Community Contribution License](https://github.com/jetify-com/opensource/blob/main/CONTRIBUTING.md#community-contribution-license).
