### PR TITLE
Feat/pin devbox version

### DIFF
--- a/devbox.json
+++ b/devbox.json
@@ -1,6 +1,7 @@
 {
   "name":        "devbox",
   "description": "Instant, easy, and predictable development environments",
+  "devbox_version": "0.0.0-dev",
   "packages": {
     "fd":  "latest",
     "git": "latest",

--- a/docs/app/docs/configuration.md
+++ b/docs/app/docs/configuration.md
@@ -7,6 +7,7 @@ Your devbox configuration is stored in a `devbox.json` file, located in your pro
 
 ```json
 {
+    "devbox_version": "",
     "packages": [] | {},
     "env": {},
     "shell": {
@@ -16,6 +17,10 @@ Your devbox configuration is stored in a `devbox.json` file, located in your pro
     "include": []
 }
 ```
+
+## Devbox Version
+
+The devbox_version field locks your project to a specific Devbox version, safeguarding against unexpected changes when collaborators update their environments.
 
 ### Packages
 
@@ -297,6 +302,7 @@ An example of a devbox configuration for a Rust project called `hello_world` mig
 
 ```json
 {
+    "devbox_version": "v1.0.0",
     "packages": [
         "rustup@latest",
         "libiconv@latest"

--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/google/go-cmp v0.7.0
 	github.com/google/uuid v1.6.0
 	github.com/hashicorp/go-envparse v0.1.0
+	github.com/hashicorp/go-version v1.7.0
 	github.com/joho/godotenv v1.5.1
 	github.com/mattn/go-isatty v0.0.20
 	github.com/mholt/archives v0.1.0
@@ -167,7 +168,6 @@ require (
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-immutable-radix/v2 v2.1.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
-	github.com/hashicorp/go-version v1.7.0 // indirect
 	github.com/hashicorp/golang-lru/v2 v2.0.7 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/hexops/gotextdiff v1.0.3 // indirect

--- a/internal/devconfig/config.go
+++ b/internal/devconfig/config.go
@@ -49,6 +49,7 @@ const defaultInitHook = "echo 'Welcome to devbox!' > /dev/null"
 func DefaultConfig() *Config {
 	cfg, err := loadBytes([]byte(fmt.Sprintf(`{
 		"$schema": "https://raw.githubusercontent.com/jetify-com/devbox/%s/.schema/devbox.schema.json",
+		"devbox_version": "%s",
 		"packages": [],
 		"shell": {
 			"init_hook": [

--- a/internal/devconfig/configfile/file.go
+++ b/internal/devconfig/configfile/file.go
@@ -110,6 +110,13 @@ func (c *ConfigFile) InitHook() *shellcmd.Commands {
 // SaveTo writes the config to a file.
 func (c *ConfigFile) SaveTo(path string) error {
 	return os.WriteFile(filepath.Join(path, DefaultName), c.Bytes(), 0o644)
+	finalPath := path
+  if filepath.Base(path) != DefaultName {
+      finalPath = filepath.Join(path, DefaultName)
+  }
+
+	//return os.WriteFile(filepath.Join(path, DefaultName), c.Bytes(), 0o644)
+	return os.WriteFile(filepath.Join(finalPath), c.Bytes(), 0o644)
 }
 
 // TODO: Can we remove SaveTo and just use Save()?


### PR DESCRIPTION
## Summary

Allowss users pin the devbox version so there are no issues with people running various devbox versions while working in team setting.

Implements #1371 

## How was it tested?

Running tests and using it locally.

## Community Contribution License

All community contributions in this pull request are licensed to the project
maintainers under the terms of the
[Apache 2 License](https://www.apache.org/licenses/LICENSE-2.0).

By creating this pull request, I represent that I have the right to license the
contributions to the project maintainers under the Apache 2 License as stated in
the
[Community Contribution License](https://github.com/jetify-com/opensource/blob/main/CONTRIBUTING.md#community-contribution-license).
