### PR TITLE
Fix misleading error message when using an expired GITHUB_TOKEN 

### DIFF
--- a/internal/plugin/github.go
+++ b/internal/plugin/github.go
@@ -105,10 +105,10 @@ func (p *githubPlugin) FileContent(subpath string) ([]byte, error) {
 			}
 			defer res.Body.Close()
 			if res.StatusCode != http.StatusOK {
-				authInfo := "No auth header was send with this request."
+				authInfo := "No auth header was sent with this request."
 				if req.Header.Get("Authorization") != "" {
 					authInfo = fmt.Sprintf(
-						"The auth header `%s` was send with this request.",
+						"The auth header `%s` was sent with this request.",
 						getRedactedAuthHeader(req),
 					)
 				}
@@ -181,7 +181,7 @@ func getRedactedAuthHeader(req *http.Request) string {
 
 	authType, token := parts[0], parts[1]
 	if len(token) < 10 {
-		// second word to short to reveal any, but show first word
+		// second word too short to reveal any, but show first word
 		return authType + " " + strings.Repeat("*", len(token))
 	}
 

--- a/internal/plugin/github.go
+++ b/internal/plugin/github.go
@@ -4,6 +4,7 @@ import (
 	"cmp"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"os"
@@ -104,12 +105,20 @@ func (p *githubPlugin) FileContent(subpath string) ([]byte, error) {
 			}
 			defer res.Body.Close()
 			if res.StatusCode != http.StatusOK {
+				authInfo := "No auth header was send with this request."
+				if req.Header.Get("Authorization") != "" {
+					authInfo = fmt.Sprintf(
+						"The auth header `%s` was send with this request.",
+						getRedactedAuthHeader(req),
+					)
+				}
 				return nil, 0, usererr.New(
-					"failed to get plugin %s @ %s (Status code %d). \nPlease make "+
+					"failed to get plugin %s @ %s (Status code %d).\n%s\nPlease make "+
 						"sure a plugin.json file exists in plugin directory.",
 					p.LockfileKey(),
 					req.URL.String(),
 					res.StatusCode,
+					authInfo,
 				)
 			}
 			body, err := io.ReadAll(res.Body)
@@ -147,6 +156,11 @@ func (p *githubPlugin) request(contentURL string) (*http.Request, error) {
 	if ghToken != "" {
 		authValue := fmt.Sprintf("token %s", ghToken)
 		req.Header.Add("Authorization", authValue)
+		slog.Debug(
+			"GITHUB_TOKEN env var found, adding to request's auth header",
+			"headerValue",
+			getRedactedAuthHeader(req),
+		)
 	}
 
 	return req, nil
@@ -154,4 +168,23 @@ func (p *githubPlugin) request(contentURL string) (*http.Request, error) {
 
 func (p *githubPlugin) LockfileKey() string {
 	return p.ref.String()
+}
+
+func getRedactedAuthHeader(req *http.Request) string {
+	authHeader := req.Header.Get("Authorization")
+	parts := strings.SplitN(authHeader, " ", 2)
+
+	if len(authHeader) < 10 || len(parts) < 2 {
+		// too short to safely reveal any part
+		return strings.Repeat("*", len(authHeader))
+	}
+
+	authType, token := parts[0], parts[1]
+	if len(token) < 10 {
+		// second word to short to reveal any, but show first word
+		return authType + " " + strings.Repeat("*", len(token))
+	}
+
+	// show first 4 chars of token to help with debugging (will often be "ghp_")
+	return authType + " " + token[:4] + strings.Repeat("*", len(token)-4)
 }


### PR DESCRIPTION
## Summary

Currently when if `GITHUB_TOKEN` is set to an expired or invalid token requests to github will fail with a 404. There is not messaging to the user (even with `DEVBOX_DEBUG=1`) to indicate the cause. This took a while to debug, opening this PR to make it easier for the next person this happens to.

## How was it tested?

- make a temp devbox project and add a plugin like https://github.com/jetify-com/devbox-plugins/tree/main/mongodb
- set `GITHUB_TOKEN` to a random string
- see the following error that doesn't indicate the cause of the error at all (also try running with `DEVBOX_DEBUG=1` and see no extra helpful info
```
❯ devbox install

Error: failed to get plugin github:jetpack-io/devbox-plugins?dir=mongodb @ https://raw.githubusercontent.com/jetpack-io/devbox-plugins/master/mongodb/plugin.json (Status code 404). 
Please make sure a plugin.json file exists in plugin directory.
```
- **now using code in this PR**
```
❯ ../dist/devbox install

Error: failed to get plugin github:jetpack-io/devbox-plugins?dir=mongodb @ https://raw.githubusercontent.com/jetpack-io/devbox-plugins/master/mongodb/plugin.json (Status code 404).
The auth header `token gh_1*********` was send with this request.
Please make sure a plugin.json file exists in plugin directory.
```

## Community Contribution License

All community contributions in this pull request are licensed to the project
maintainers under the terms of the
[Apache 2 License](https://www.apache.org/licenses/LICENSE-2.0).

By creating this pull request, I represent that I have the right to license the
contributions to the project maintainers under the Apache 2 License as stated in
the
[Community Contribution License](https://github.com/jetify-com/opensource/blob/main/CONTRIBUTING.md#community-contribution-license).
