### PR TITLE
[perf] Cache nixpkgs resolution

### DIFF
--- a/devbox.lock
+++ b/devbox.lock
@@ -2,8 +2,8 @@
   "lockfile_version": "1",
   "packages": {
     "fd@latest": {
-      "last_modified": "2025-02-07T11:26:36Z",
-      "resolved": "github:NixOS/nixpkgs/d98abf5cf5914e5e4e9d57205e3af55ca90ffc1d#fd",
+      "last_modified": "2025-03-11T17:52:14Z",
+      "resolved": "github:NixOS/nixpkgs/0d534853a55b5d02a4ababa1d71921ce8f0aee4c#fd",
       "source": "devbox-search",
       "version": "10.2.0",
       "systems": {
@@ -11,164 +11,165 @@
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/ad5m54pfn9k39v80lpyhrnsh336nqrp5-fd-10.2.0",
+              "path": "/nix/store/40pdazk980kp3h26py4hjyx9rys1g14n-fd-10.2.0",
               "default": true
             }
           ],
-          "store_path": "/nix/store/ad5m54pfn9k39v80lpyhrnsh336nqrp5-fd-10.2.0"
+          "store_path": "/nix/store/40pdazk980kp3h26py4hjyx9rys1g14n-fd-10.2.0"
         },
         "aarch64-linux": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/vn3mny38qmf3lm809rpcvahxqwhkqb7m-fd-10.2.0",
+              "path": "/nix/store/76zcwa1d33vciy4gyqvk6jl2n3g1542q-fd-10.2.0",
               "default": true
             }
           ],
-          "store_path": "/nix/store/vn3mny38qmf3lm809rpcvahxqwhkqb7m-fd-10.2.0"
+          "store_path": "/nix/store/76zcwa1d33vciy4gyqvk6jl2n3g1542q-fd-10.2.0"
         },
         "x86_64-darwin": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/6kdv4iy9j3svncq0vs47wxfvvn7flcr5-fd-10.2.0",
+              "path": "/nix/store/ys9qmljs0ag7j040radgg48l6pvjmv9l-fd-10.2.0",
               "default": true
             }
           ],
-          "store_path": "/nix/store/6kdv4iy9j3svncq0vs47wxfvvn7flcr5-fd-10.2.0"
+          "store_path": "/nix/store/ys9qmljs0ag7j040radgg48l6pvjmv9l-fd-10.2.0"
         },
         "x86_64-linux": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/x58pg72qw2xv1vvs4pbqw63zhkdkp331-fd-10.2.0",
+              "path": "/nix/store/rrdvpl7rym4ia0h7rfz1vmlcvvivj30j-fd-10.2.0",
               "default": true
             }
           ],
-          "store_path": "/nix/store/x58pg72qw2xv1vvs4pbqw63zhkdkp331-fd-10.2.0"
+          "store_path": "/nix/store/rrdvpl7rym4ia0h7rfz1vmlcvvivj30j-fd-10.2.0"
         }
       }
     },
     "git@latest": {
-      "last_modified": "2025-02-07T11:26:36Z",
-      "resolved": "github:NixOS/nixpkgs/d98abf5cf5914e5e4e9d57205e3af55ca90ffc1d#git",
+      "last_modified": "2025-03-11T17:52:14Z",
+      "resolved": "github:NixOS/nixpkgs/0d534853a55b5d02a4ababa1d71921ce8f0aee4c#git",
       "source": "devbox-search",
-      "version": "2.47.2",
+      "version": "2.48.1",
       "systems": {
         "aarch64-darwin": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/9z3jhc0rlj3zaw8nd1zka9vli6w0q11g-git-2.47.2",
+              "path": "/nix/store/b3sci30zzzlj3rzj1y89cijnd6zcwapk-git-2.48.1",
               "default": true
             },
             {
               "name": "doc",
-              "path": "/nix/store/rh151iwgy4h8yv8kxd5facw57cyj0bav-git-2.47.2-doc"
+              "path": "/nix/store/086knqdw7fjgzczp0i6nad95s2v6jbya-git-2.48.1-doc"
             }
           ],
-          "store_path": "/nix/store/9z3jhc0rlj3zaw8nd1zka9vli6w0q11g-git-2.47.2"
+          "store_path": "/nix/store/b3sci30zzzlj3rzj1y89cijnd6zcwapk-git-2.48.1"
         },
         "aarch64-linux": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/gx5y37qcfqdvn0h6swjd04dmqjjh3nk7-git-2.47.2",
+              "path": "/nix/store/pck1dr5jxrd5b8nmfasbn13z422jhcfm-git-2.48.1",
               "default": true
             },
             {
               "name": "debug",
-              "path": "/nix/store/8vfpmf3vjgzl2psip76p0f9h11sb6y3p-git-2.47.2-debug"
+              "path": "/nix/store/xqqsvzlilh843rm6knykyng81apapr33-git-2.48.1-debug"
             },
             {
               "name": "doc",
-              "path": "/nix/store/c25mq3q83dvw3k5pb0qr5333g3cycylq-git-2.47.2-doc"
+              "path": "/nix/store/485b32ys0s2dvjfisn7405ildmpqvfzk-git-2.48.1-doc"
             }
           ],
-          "store_path": "/nix/store/gx5y37qcfqdvn0h6swjd04dmqjjh3nk7-git-2.47.2"
+          "store_path": "/nix/store/pck1dr5jxrd5b8nmfasbn13z422jhcfm-git-2.48.1"
         },
         "x86_64-darwin": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/39xx5gx3hxigs1b5ldw5i2jr84vsn3rf-git-2.47.2",
+              "path": "/nix/store/9qjzgsf9mvdp6sfd7xyzhgrahl2qhhp6-git-2.48.1",
               "default": true
             },
             {
               "name": "doc",
-              "path": "/nix/store/xmh2djjrnbpiqqgpblrcbavnqh0nv4km-git-2.47.2-doc"
+              "path": "/nix/store/cgv7qa0ix059ma9a0qac0bywfvl3k7k2-git-2.48.1-doc"
             }
           ],
-          "store_path": "/nix/store/39xx5gx3hxigs1b5ldw5i2jr84vsn3rf-git-2.47.2"
+          "store_path": "/nix/store/9qjzgsf9mvdp6sfd7xyzhgrahl2qhhp6-git-2.48.1"
         },
         "x86_64-linux": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/33g65w5cc9n8fr0hxj84282xmv4l7hyl-git-2.47.2",
+              "path": "/nix/store/lqx2rv26sdndpa2vyy2vxsahj03km69z-git-2.48.1",
               "default": true
             },
             {
-              "name": "debug",
-              "path": "/nix/store/jyz4nvcd3bci4vg2sfsmvrq0fp9mzr5a-git-2.47.2-debug"
+              "name": "doc",
+              "path": "/nix/store/hjczhs1dm3hzij7mx5c91rkzqvkb89av-git-2.48.1-doc"
             },
             {
-              "name": "doc",
-              "path": "/nix/store/lb4nipdhlwrxdavz7gdkcik6lkz3cbdm-git-2.47.2-doc"
+              "name": "debug",
+              "path": "/nix/store/bk8xndavdnc2qgyvc6hcc8h29lk9jzqb-git-2.48.1-debug"
             }
           ],
-          "store_path": "/nix/store/33g65w5cc9n8fr0hxj84282xmv4l7hyl-git-2.47.2"
+          "store_path": "/nix/store/lqx2rv26sdndpa2vyy2vxsahj03km69z-git-2.48.1"
         }
       }
     },
     "github:NixOS/nixpkgs/nixpkgs-unstable": {
-      "resolved": "github:NixOS/nixpkgs/73cf49b8ad837ade2de76f87eb53fc85ed5d4680?lastModified=1739866667&narHash=sha256-EO1ygNKZlsAC9avfcwHkKGMsmipUk1Uc0TbrEZpkn64%3D"
+      "last_modified": "2025-04-07T13:23:10Z",
+      "resolved": "github:NixOS/nixpkgs/b0b4b5f8f621bfe213b8b21694bab52ecfcbf30b?lastModified=1744032190&narHash=sha256-KSlfrncSkcu1YE%2BuuJ%2FPTURsSlThoGkRqiGDVdbiE%2Fk%3D"
     },
     "go@latest": {
-      "last_modified": "2025-02-12T00:10:52Z",
-      "resolved": "github:NixOS/nixpkgs/83a2581c81ff5b06f7c1a4e7cc736a455dfcf7b4#go_1_24",
+      "last_modified": "2025-03-11T17:52:14Z",
+      "resolved": "github:NixOS/nixpkgs/0d534853a55b5d02a4ababa1d71921ce8f0aee4c#go",
       "source": "devbox-search",
-      "version": "1.24.0",
+      "version": "1.24.1",
       "systems": {
         "aarch64-darwin": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/qldcnifalkvyah0wnv7m4zb854yd9l88-go-1.24.0",
+              "path": "/nix/store/ja4jxx60lh1qfqfl4z4p2rff56ia1c3c-go-1.24.1",
               "default": true
             }
           ],
-          "store_path": "/nix/store/qldcnifalkvyah0wnv7m4zb854yd9l88-go-1.24.0"
+          "store_path": "/nix/store/ja4jxx60lh1qfqfl4z4p2rff56ia1c3c-go-1.24.1"
         },
         "aarch64-linux": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/rrxgml7w4pfmibjbspkdvrw8vd2vnarb-go-1.24.0",
+              "path": "/nix/store/8ply43gnxk1xwichr81mpgbjcd9a1y5w-go-1.24.1",
               "default": true
             }
           ],
-          "store_path": "/nix/store/rrxgml7w4pfmibjbspkdvrw8vd2vnarb-go-1.24.0"
+          "store_path": "/nix/store/8ply43gnxk1xwichr81mpgbjcd9a1y5w-go-1.24.1"
         },
         "x86_64-darwin": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/7imv22pl4qrjwvi6jzlfb305rc2min45-go-1.24.0",
+              "path": "/nix/store/87yxrfx5lh78bdz393i33cr5z23x06q4-go-1.24.1",
               "default": true
             }
           ],
-          "store_path": "/nix/store/7imv22pl4qrjwvi6jzlfb305rc2min45-go-1.24.0"
+          "store_path": "/nix/store/87yxrfx5lh78bdz393i33cr5z23x06q4-go-1.24.1"
         },
         "x86_64-linux": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/vh5d5bj1sljdhdypy80x1ydx2jx6rv2q-go-1.24.0",
+              "path": "/nix/store/cfjhl0kn7xc65466pha9fkrvigw3g72n-go-1.24.1",
               "default": true
             }
           ],
-          "store_path": "/nix/store/vh5d5bj1sljdhdypy80x1ydx2jx6rv2q-go-1.24.0"
+          "store_path": "/nix/store/cfjhl0kn7xc65466pha9fkrvigw3g72n-go-1.24.1"
         }
       }
     }

--- a/internal/lock/lockfile.go
+++ b/internal/lock/lockfile.go
@@ -141,6 +141,23 @@ func (f *File) Save() error {
 	return cuecfg.WriteFile(lockFilePath(f.devboxProject.ProjectDir()), f)
 }
 
+func (f *File) UpdateStdenv() error {
+	if err := nix.ClearFlakeCache(f.devboxProject.Stdenv()); err != nil {
+		return err
+	}
+	if err := f.Remove(f.devboxProject.Stdenv().String()); err != nil {
+		return err
+	}
+	return f.Add(f.devboxProject.Stdenv().String())
+}
+
+// TODO: We should improve a few issues with this function:
+// * It shared the same name as Devbox.Stdenv() which is confusing.
+// * Since File implements DevboxProject, IDEs really struggle to accurately find call sites.
+// (side note, we should remove DevboxProject interface)
+// * This function forces a resolution of the stdenv flake which is slow and doesn't give us a
+// chance to "prep" the user for some waiting.
+// * Should we rename to Nixpkgs() ? Stdenv feels a bit ambiguous.
 func (f *File) Stdenv() flake.Ref {
 	unlocked := f.devboxProject.Stdenv()
 	pkg, err := f.Resolve(unlocked.String())

--- a/internal/lock/resolve.go
+++ b/internal/lock/resolve.go
@@ -223,7 +223,7 @@ func lockFlake(ctx context.Context, ref flake.Ref) (flake.Ref, error) {
 
 	var meta nix.FlakeMetadata
 	var err error
-	// For nixpkgs, we cache resolutions (currently flakeCacheTTL=90 days) to avoid downloading
+	// For nixpkgs, we cache resolutions (currently flakeCacheTTL=30 days) to avoid downloading
 	// new nixpkgs too often which is really slow and rarely changes anything.
 	//
 	// Ideally we can do something similar for all packages (flake and otherwise)

--- a/internal/nix/flake.go
+++ b/internal/nix/flake.go
@@ -9,7 +9,7 @@ import (
 	"go.jetify.com/pkg/filecache"
 )
 
-const flakeCacheTTL = time.Hour * 24 * 90
+const flakeCacheTTL = time.Hour * 24 * 30
 
 var flakeFileCache = filecache.New[FlakeMetadata]("devbox/flakes")
 

--- a/internal/nix/flake.go
+++ b/internal/nix/flake.go
@@ -3,16 +3,23 @@ package nix
 import (
 	"context"
 	"encoding/json"
+	"time"
 
 	"go.jetify.com/devbox/nix/flake"
+	"go.jetify.com/pkg/filecache"
 )
 
+const flakeCacheTTL = time.Hour * 24 * 90
+
+var flakeFileCache = filecache.New[FlakeMetadata]("devbox/flakes")
+
 type FlakeMetadata struct {
-	Description string    `json:"description"`
-	Original    flake.Ref `json:"original"`
-	Resolved    flake.Ref `json:"resolved"`
-	Locked      flake.Ref `json:"locked"`
-	Path        string    `json:"path"`
+	Description  string    `json:"description"`
+	LastModified int64     `json:"lastModified"`
+	Locked       flake.Ref `json:"locked"`
+	Original     flake.Ref `json:"original"`
+	Path         string    `json:"path"`
+	Resolved     flake.Ref `json:"resolved"`
 }
 
 func ResolveFlake(ctx context.Context, ref flake.Ref) (FlakeMetadata, error) {
@@ -27,4 +34,19 @@ func ResolveFlake(ctx context.Context, ref flake.Ref) (FlakeMetadata, error) {
 		return FlakeMetadata{}, err
 	}
 	return meta, nil
+}
+
+func ResolveCachedFlake(ctx context.Context, ref flake.Ref) (FlakeMetadata, error) {
+	return flakeFileCache.GetOrSet(ref.String(), func() (FlakeMetadata, time.Duration, error) {
+		meta, err := ResolveFlake(ctx, ref)
+		if err != nil {
+			return FlakeMetadata{}, 0, err
+		}
+		return meta, flakeCacheTTL, nil
+	})
+}
+
+func ClearFlakeCache(ref flake.Ref) error {
+	// TODO: Add unset to filecache
+	return flakeFileCache.Set(ref.String(), FlakeMetadata{}, -1)
 }

--- a/internal/shellgen/tmpl/flake.nix.tmpl
+++ b/internal/shellgen/tmpl/flake.nix.tmpl
@@ -19,7 +19,7 @@
       let
         pkgs = nixpkgs.legacyPackages.{{ .System }};
         {{- range $_, $flake := .FlakeInputs }}
-        {{- if .IsNixpkgs }}
+        {{- if $flake.Ref.IsNixpkgs }}
         {{.PkgImportName}} = (import {{.Name}} {
           system = "{{ $.System }}";
           config.allowUnfree = true;

--- a/nix/flake/flakeref.go
+++ b/nix/flake/flakeref.go
@@ -465,6 +465,22 @@ func (r Ref) String() string {
 	}
 }
 
+// IsNixpkgs reports whether the flake reference looks like a nixpkgs flake.
+//
+// While there are many ways to specify this input, devbox always uses
+// github:NixOS/nixpkgs/<hash> as the URL. If the user wishes to reference nixpkgs
+// themselves, this function may not return true.
+func (r Ref) IsNixpkgs() bool {
+	switch r.Type {
+	case TypeGitHub:
+		return r.Owner == "NixOS" && r.Repo == "nixpkgs"
+	case TypeIndirect:
+		return r.ID == "nixpkgs"
+	default:
+		return false
+	}
+}
+
 func isGitHash(s string) bool {
 	if len(s) != 40 {
 		return false


### PR DESCRIPTION
## Summary

This caches resolutions for unlocked nixpkgs (the default) for 90 days on the user's machine.  Otherwise, everytime devbox tries to resolve `github:NixOS/nixpkgs/nixpkgs-unstable` it will download a new version of nixpkgs. This is slow (40+ seconds) and usually nothing changes.

### If a user wants to update nixpkgs there are two ways of doing it:

* `devbox update` without any arguments will update nixpkgs. This is existing functionality.
* `devbox update nixpkgs [...pkgs]` will also update nixpkgs.

I'm not convinced updating nixpkgs when using `update` without arguments is best, but I didn't want to break past functionality. It adds 40+ seconds to update operations when there is no package to update.

An alternative command syntax considered was `devbox update --nixpkgs`. The benefit of doing this would be to avoid conflicts in the future. 

I did not use `stdenv` because it already exists and it is a different package.

### Bug fixes:

* Updating a specific package (e.g. `devbox update go`) no longer updates nixpkgs

### Alternative approaches:

* We could try to search the local nix database to try to find existing nixpkgs, but this seemed more trouble than it was worth.

## How was it tested?

* Created a new project and logged the cache being used.
* Replaced the cache file data with an old version, created a new project and observed the old version used.
* Tried several permutations of `devbox update` with and without packages

## Community Contribution License

All community contributions in this pull request are licensed to the project
maintainers under the terms of the
[Apache 2 License](https://www.apache.org/licenses/LICENSE-2.0).

By creating this pull request, I represent that I have the right to license the
contributions to the project maintainers under the Apache 2 License as stated in
the
[Community Contribution License](https://github.com/jetify-com/opensource/blob/main/CONTRIBUTING.md#community-contribution-license).
