### PR TITLE
Update github_action.md to install latest devbox github action

### DIFF
--- a/docs/app/docs/continuous_integration/github_action.md
+++ b/docs/app/docs/continuous_integration/github_action.md
@@ -14,7 +14,7 @@ In your project's workflow YAML, add the following step:
 
 ```yaml
 - name: Install devbox
-  uses: jetify-com/devbox-install-action@v0.11.0
+  uses: jetify-com/devbox-install-action@v0.12.0
 ```
 
 ## Example Workflow
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install devbox
-        uses: jetify-com/devbox-install-action@v0.11.0
+        uses: jetify-com/devbox-install-action@v0.12.0
 
       - name: Run arbitrary commands
         run: devbox run -- echo "done!"


### PR DESCRIPTION
## Summary

I noticed the docs reference v0.11.0 instead of the latest version of v0.12.0, not sure if this was intended but I thought I'd update it for others to ensure new people install the latest version.

## Community Contribution License

All community contributions in this pull request are licensed to the project
maintainers under the terms of the
[Apache 2 License](https://www.apache.org/licenses/LICENSE-2.0).

By creating this pull request, I represent that I have the right to license the
contributions to the project maintainers under the Apache 2 License as stated in
the
[Community Contribution License](https://github.com/jetify-com/opensource/blob/main/CONTRIBUTING.md#community-contribution-license).
