### PR TITLE
[nixpkgs] Use lock.stdenv instead of NixPkgsCommitHash

### DIFF
--- a/internal/boxcli/midcobra/telemetry.go
+++ b/internal/boxcli/midcobra/telemetry.go
@@ -103,5 +103,5 @@ func getPackagesAndCommitHash(c *cobra.Command) ([]string, string) {
 	}
 
 	return box.AllPackageNamesIncludingRemovedTriggerPackages(),
-		box.Config().NixPkgsCommitHash()
+		box.Lockfile().Stdenv().Rev
 }

--- a/internal/boxcli/midcobra/telemetry_test.go
+++ b/internal/boxcli/midcobra/telemetry_test.go
@@ -1,0 +1,47 @@
+package midcobra
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+	"go.jetify.com/devbox/internal/devbox"
+	"go.jetify.com/devbox/internal/devbox/devopt"
+)
+
+func TestGetPackagesAndCommitHash(t *testing.T) {
+	dir := t.TempDir()
+	err := devbox.InitConfig(dir)
+	if err != nil {
+		t.Errorf("Expected no error, got %s", err)
+	}
+	box, err := devbox.Open(&devopt.Opts{
+		Dir: dir,
+	})
+	// Create a mock cobra command
+	cmd := &cobra.Command{
+		Use: "test",
+		Run: func(cmd *cobra.Command, args []string) {},
+	}
+
+	// Add a mock flag to the command
+	cmd.Flags().String("config", "", "config file")
+	if err := cmd.Flags().Set("config", dir); err != nil {
+		t.Errorf("Expected no error, got %s", err)
+	}
+
+	// Call the function with the mock command
+	packages, commitHash := getPackagesAndCommitHash(cmd)
+
+	// Check if the returned packages and commitHash are as expected
+	if len(packages) != 0 {
+		t.Errorf("Expected no packages, got %d", len(packages))
+	}
+
+	if err != nil {
+		t.Errorf("Expected no error, got %s", err)
+	}
+
+	if commitHash != box.Lockfile().Stdenv().Rev {
+		t.Errorf("Expected commitHash %s, got %s", box.Lockfile().Stdenv().Rev, commitHash)
+	}
+}

--- a/internal/shellgen/flake_plan.go
+++ b/internal/shellgen/flake_plan.go
@@ -90,7 +90,7 @@ type glibcPatchFlake struct {
 	Dependencies []string
 }
 
-func newGlibcPatchFlake(nixpkgsGlibcRev string, packages []*devpkg.Package) (glibcPatchFlake, error) {
+func newGlibcPatchFlake(nixpkgs flake.Ref, packages []*devpkg.Package) (glibcPatchFlake, error) {
 	patchFlake := glibcPatchFlake{
 		DevboxFlake: flake.Ref{
 			Type:  flake.TypeGitHub,
@@ -98,7 +98,7 @@ func newGlibcPatchFlake(nixpkgsGlibcRev string, packages []*devpkg.Package) (gli
 			Repo:  "devbox",
 			Ref:   build.Version,
 		},
-		NixpkgsGlibcFlakeRef: "flake:nixpkgs/" + nixpkgsGlibcRev,
+		NixpkgsGlibcFlakeRef: nixpkgs.String(),
 	}
 
 	// In dev builds, use the local Devbox flake for patching packages

--- a/internal/shellgen/flake_plan_test.go
+++ b/internal/shellgen/flake_plan_test.go
@@ -53,5 +53,4 @@ func TestNewGlibcPatchFlake(t *testing.T) {
 	if len(patchFlake.Outputs.Packages) != 1 {
 		t.Errorf("expected 1 package in Outputs, got %d", len(patchFlake.Outputs.Packages))
 	}
-
 }

--- a/internal/shellgen/flake_plan_test.go
+++ b/internal/shellgen/flake_plan_test.go
@@ -1,0 +1,57 @@
+package shellgen
+
+import (
+	"testing"
+
+	"go.jetify.com/devbox/internal/devbox/devopt"
+	"go.jetify.com/devbox/internal/devconfig/configfile"
+	"go.jetify.com/devbox/internal/devpkg"
+	"go.jetify.com/devbox/internal/lock"
+	"go.jetify.com/devbox/nix/flake"
+)
+
+type lockMock struct{}
+
+func (l *lockMock) Get(key string) *lock.Package {
+	return nil
+}
+
+func (l *lockMock) Stdenv() flake.Ref {
+	return flake.Ref{}
+}
+
+func (l *lockMock) ProjectDir() string {
+	return ""
+}
+
+func (l *lockMock) Resolve(key string) (*lock.Package, error) {
+	return &lock.Package{
+		Resolved: "github:NixOS/nixpkgs/10b813040df67c4039086db0f6eaf65c536886c6#python312",
+	}, nil
+}
+
+func TestNewGlibcPatchFlake(t *testing.T) {
+	stdenv := flake.Ref{
+		Type: flake.TypeGitHub,
+		URL:  "https://github.com/NixOS/nixpkgs",
+		Ref:  "nixpkgs-unstable",
+	}
+
+	packages := devpkg.PackagesFromStringsWithOptions([]string{"python@latest"}, &lockMock{}, devopt.AddOpts{
+		Patch: string(configfile.PatchAlways),
+	})
+
+	patchFlake, err := newGlibcPatchFlake(stdenv, packages)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if patchFlake.NixpkgsGlibcFlakeRef != stdenv.String() {
+		t.Errorf("expected NixpkgsGlibcFlakeRef to be %s, got %s", stdenv.String(), patchFlake.NixpkgsGlibcFlakeRef)
+	}
+
+	if len(patchFlake.Outputs.Packages) != 1 {
+		t.Errorf("expected 1 package in Outputs, got %d", len(patchFlake.Outputs.Packages))
+	}
+
+}

--- a/internal/shellgen/generate.go
+++ b/internal/shellgen/generate.go
@@ -49,7 +49,7 @@ func GenerateForPrintEnv(ctx context.Context, devbox devboxer) error {
 	}
 
 	if plan.needsGlibcPatch() {
-		patch, err := newGlibcPatchFlake(devbox.Config().NixPkgsCommitHash(), plan.Packages)
+		patch, err := newGlibcPatchFlake(devbox.Lockfile().Stdenv(), plan.Packages)
 		if err != nil {
 			return redact.Errorf("generate glibc patch flake: %v", err)
 		}


### PR DESCRIPTION
## Summary

`NixPkgsCommitHash` is no longer defaulted so it's best to use lockfile.Stdenv to get the nixpkgs for patching and telemetry. This ensures we use the correct resolved version at all times. (also I think, but have not confirmed that before this change, `newGlibcPatchFlake` will not work is nixpkgs hash is not specified in devbox.json)

## How was it tested?

unit tests 

## Community Contribution License

All community contributions in this pull request are licensed to the project
maintainers under the terms of the
[Apache 2 License](https://www.apache.org/licenses/LICENSE-2.0).

By creating this pull request, I represent that I have the right to license the
contributions to the project maintainers under the Apache 2 License as stated in
the
[Community Contribution License](https://github.com/jetify-com/opensource/blob/main/CONTRIBUTING.md#community-contribution-license).
