### PR TITLE
docs: Fix docs around what environment variable and commands to generate token(s)

### DIFF
--- a/docs/app/cloud/cache/authenticating.md
+++ b/docs/app/cloud/cache/authenticating.md
@@ -53,11 +53,11 @@ Treat your Personal Access Token as a password — keep it secret and secure, an
 To generate a Token, first authenticate as described above, and then run:
 
 ```bash
-devbox auth token new
+devbox auth tokens new
 ```
 
 To authenticate with the personal access token, export it as an environment variable on your host: 
 
 ```bash
-export DEVBOX_ACCESS_TOKEN=<personal_token>
+export DEVBOX_API_TOKEN=<personal_token>
 ```


### PR DESCRIPTION
## Summary

Updated docs around devbox api tokens.

## How was it tested?

```
% DEVBOX_API_TOKEN=a-token devbox cache info

* s3://<a-valid-devbox-cloud-cache>?region=us-west-2&trusted=true 
* s3://<jetify-devbox-cache>?region=us-west-2&trusted=true (read-only)
```

```
% devbox cache info
No cache configured
```