### PR TITLE
propagate output from process-compose invocation

### DIFF
--- a/internal/services/manager.go
+++ b/internal/services/manager.go
@@ -167,6 +167,8 @@ func StartProcessManager(
 }
 
 func runProcessManagerInForeground(cmd *exec.Cmd, config *globalProcessComposeConfig, port int, projectDir string, w io.Writer) error {
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
 	if err := cmd.Start(); err != nil {
 		return fmt.Errorf("failed to start process-compose: %w", err)
 	}


### PR DESCRIPTION
## Summary

Currently the invocation of process-compose in devbox is smothering useful error messaging from the `is_strict` parsing provided by process-compose.

## How was it tested?

```shell
devbox run build

# the below is to create a failing process-compose file, to reproduce issue #2579 
echo 'version: "0.5"
is_strict: true

processes:
  foo:
    commnad: echo "Hello, world!"
' > process-compose.yaml

devbox services up
```

## Referenced issue

#2579 

## Community Contribution License

All community contributions in this pull request are licensed to the project
maintainers under the terms of the
[Apache 2 License](https://www.apache.org/licenses/LICENSE-2.0).

By creating this pull request, I represent that I have the right to license the
contributions to the project maintainers under the Apache 2 License as stated in
the
[Community Contribution License](https://github.com/jetify-com/opensource/blob/main/CONTRIBUTING.md#community-contribution-license).
