### PR TITLE
Fix issue 2601 (dont fail on empty /nix folder)

### DIFF
--- a/internal/fileutil/fileutil.go
+++ b/internal/fileutil/fileutil.go
@@ -51,6 +51,14 @@ func Exists(path string) bool {
 	return err == nil
 }
 
+func IsDirEmpty(path string) bool {
+	entries, err := os.ReadDir(path)
+	if err != nil {
+		return false
+	}
+	return len(entries) == 0
+}
+
 // FileContains checks if a given file at 'path' contains the 'substring'
 func FileContains(path, substring string) (bool, error) {
 	data, err := os.ReadFile(path)

--- a/internal/nix/install.go
+++ b/internal/nix/install.go
@@ -25,8 +25,9 @@ func BinaryInstalled() bool {
 	return cmdutil.Exists("nix")
 }
 
-func dirExists() bool {
-	return fileutil.Exists("/nix")
+func dirExistsAndIsNotEmpty() bool {
+	dir := "/nix"
+	return fileutil.Exists(dir) && !fileutil.IsDirEmpty(dir)
 }
 
 var ensured = false
@@ -57,7 +58,7 @@ func EnsureNixInstalled(ctx context.Context, writer io.Writer, withDaemonFunc fu
 	if BinaryInstalled() {
 		return nil
 	}
-	if dirExists() {
+	if dirExistsAndIsNotEmpty() {
 		if _, err = SourceProfile(); err != nil {
 			return err
 		} else if BinaryInstalled() {


### PR DESCRIPTION
## Summary

Fix for https://github.com/jetify-com/devbox/issues/2601

## How was it tested?

1. created empty /nix folder
2. devbox succeeds now installing nix

## Community Contribution License

All community contributions in this pull request are licensed to the project
maintainers under the terms of the
[Apache 2 License](https://www.apache.org/licenses/LICENSE-2.0).

By creating this pull request, I represent that I have the right to license the
contributions to the project maintainers under the Apache 2 License as stated in
the
[Community Contribution License](https://github.com/jetify-com/opensource/blob/main/CONTRIBUTING.md#community-contribution-license).
