### PR TITLE
fix(python plugin): remove UV_PYTHON  env variable

### DIFF
--- a/plugins/python.json
+++ b/plugins/python.json
@@ -3,8 +3,7 @@
   "version": "0.0.4",
   "description": "Python in Devbox works best when used with a virtual environment (venv, virtualenv, etc.). Devbox will automatically create a virtual environment using `venv` for python3 projects, so you can install packages with pip as normal.\nTo activate the environment, run `. $VENV_DIR/bin/activate` or add it to the init_hook of your devbox.json\nTo change where your virtual environment is created, modify the $VENV_DIR environment variable in your init_hook",
   "env": {
-    "VENV_DIR": "{{ .DevboxProjectDir }}/.venv",
-    "UV_PYTHON": "{{ .DevboxProjectDir }}/.venv/bin/python"
+    "VENV_DIR": "{{ .DevboxProjectDir }}/.venv"
   },
   "create_files": {
     "{{ .Virtenv }}/bin/venvShellHook.sh": "python/venvShellHook.sh"


### PR DESCRIPTION
## Summary
Fixes: #2575

The current python plugin sets `UV_PYTHON` to path of python executable under default `VENV_DIR` directory. However if someone sets a custom `VENV_DIR` in their `devbox.json` file, this will cause an error. Since `uv` will attempt and fail to find python in the default VENV_DIR path where the venv would no longer exist.

This change removes the `UV_PYTHON` environment variable from the plugin altogether. This can be done, since `uv` will use the python executable of the active virtual environment its running in (https://docs.astral.sh/uv/reference/cli/#uv-python), and the venv is automatically created and activated by the python plugin.

This change allows flexibility for users to set their own `VENV_DIR`. It also still works with pip (`uv pip install`) as expected. 

## How was it tested?

1. devbox create uvtest --template python-pip
2. cd uvtest
3. mkdir -p src/uvtest
4. add `"VENV_DIR": "./src/uvtest/.venv"` to `env` section of `devbox.json` file
5. devbox shell
6. `uv run main.py`:  (this step would cause an error before these changes)
7. `uv pip install fastapi`

## Community Contribution License

All community contributions in this pull request are licensed to the project
maintainers under the terms of the
[Apache 2 License](https://www.apache.org/licenses/LICENSE-2.0).

By creating this pull request, I represent that I have the right to license the
contributions to the project maintainers under the Apache 2 License as stated in
the
[Community Contribution License](https://github.com/jetify-com/opensource/blob/main/CONTRIBUTING.md#community-contribution-license).
