### PR TITLE
[envvars] Fix error when env contains Bash function

### DIFF
--- a/internal/devbox/testdata/shellrc/basic/env
+++ b/internal/devbox/testdata/shellrc/basic/env
@@ -2,3 +2,4 @@ simple=value
 space=quote me
 quote=they said, "lasers"
 special=$`"\
+BASH_FUNC_echo_simple%%=() { echo "${simple}"; }

--- a/internal/devbox/testdata/shellrc/basic/shellrc.golden
+++ b/internal/devbox/testdata/shellrc/basic/shellrc.golden
@@ -3,6 +3,8 @@ if [ -f testdata/shellrc/basic/shellrc ]; then
 fi
 # Begin Devbox Post-init Hook
 
+echo_simple () { echo "${simple}"; }
+export -f echo_simple
 export quote="they said, \"lasers\"";
 export simple="value";
 export space="quote me";


### PR DESCRIPTION
## Summary

Fixes #995 - Error running `devbox shell` in environment with exported Bash function

## How was it tested?

Tested that when running the below commands:

- no errors are printed
- the `foo` function runs successfully and prints `foo`

Case 1 (simple):
```
foo() { echo foo; }
export -f foo
devbox shell
foo
```

Case 2 (function that contains special characters `"` and `$`):
```
foo() { echo "${bar}"; }
export -f foo
export bar=foo
devbox shell
foo
```

Case 3 (`shellenv`):

```
foo() { echo foo; }
export -f foo
devbox shellenv > shellrc

# open a new shell

source shellrc
foo
```

Also added a Bash function to the test data used by `TestWriteDevboxShellrc`.

## Community Contribution License

All community contributions in this pull request are licensed to the project
maintainers under the terms of the
[Apache 2 License](https://www.apache.org/licenses/LICENSE-2.0).

By creating this pull request, I represent that I have the right to license the
contributions to the project maintainers under the Apache 2 License as stated in
the
[Community Contribution License](https://github.com/jetify-com/opensource/blob/main/CONTRIBUTING.md#community-contribution-license).
