### PR TITLE
Add --envrc-dir flag to allow specifying location of direnv config

### DIFF
--- a/internal/devbox/devbox.go
+++ b/internal/devbox/devbox.go
@@ -527,21 +527,21 @@ func (d *Devbox) GenerateDockerfile(ctx context.Context, generateOpts devopt.Gen
 	}))
 }
 
-func PrintEnvrcContent(w io.Writer, envFlags devopt.EnvFlags) error {
-	return generate.EnvrcContent(w, envFlags)
+func PrintEnvrcContent(w io.Writer, opts devopt.EnvrcOpts) error {
+	return generate.EnvrcContent(w, opts)
 }
 
 // GenerateEnvrcFile generates a .envrc file that makes direnv integration convenient
-func (d *Devbox) GenerateEnvrcFile(ctx context.Context, force bool, envFlags devopt.EnvFlags) error {
+func (d *Devbox) GenerateEnvrcFile(ctx context.Context, force bool, opts devopt.EnvrcOpts) error {
 	ctx, task := trace.NewTask(ctx, "devboxGenerateEnvrc")
 	defer task.End()
 
-	envrcfilePath := filepath.Join(d.projectDir, ".envrc")
+	envrcfilePath := filepath.Join(opts.EnvrcDir, ".envrc")
 	filesExist := fileutil.Exists(envrcfilePath)
 	if !force && filesExist {
 		return usererr.New(
-			"A .envrc is already present in the current directory. " +
-				"Remove it or use --force to overwrite it.",
+			"A .envrc is already present in %q. Remove it or use --force to overwrite it.",
+			opts.EnvrcDir,
 		)
 	}
 
@@ -551,11 +551,11 @@ func (d *Devbox) GenerateEnvrcFile(ctx context.Context, force bool, envFlags dev
 	}
 
 	// .envrc file creation
-	err := generate.CreateEnvrc(ctx, d.projectDir, envFlags)
+	err := generate.CreateEnvrc(ctx, opts)
 	if err != nil {
 		return errors.WithStack(err)
 	}
-	ux.Fsuccessf(d.stderr, "generated .envrc file\n")
+	ux.Fsuccessf(d.stderr, "generated .envrc file in %q.\n", opts.EnvrcDir)
 	if cmdutil.Exists("direnv") {
 		cmd := exec.Command("direnv", "allow")
 		err := cmd.Run()

--- a/internal/devbox/devopt/devboxopts.go
+++ b/internal/devbox/devopt/devboxopts.go
@@ -34,6 +34,12 @@ type EnvFlags struct {
 	EnvFile string
 }
 
+type EnvrcOpts struct {
+	EnvFlags
+	EnvrcDir  string
+	ConfigDir string
+}
+
 type PullboxOpts struct {
 	Overwrite   bool
 	URL         string

--- a/internal/devbox/generate/devcontainer_util.go
+++ b/internal/devbox/generate/devcontainer_util.go
@@ -140,11 +140,11 @@ func (g *Options) CreateDevcontainer(ctx context.Context) error {
 	return err
 }
 
-func CreateEnvrc(ctx context.Context, path string, envFlags devopt.EnvFlags) error {
+func CreateEnvrc(ctx context.Context, opts devopt.EnvrcOpts) error {
 	defer trace.StartRegion(ctx, "createEnvrc").End()
 
 	// create .envrc file
-	file, err := os.Create(filepath.Join(path, ".envrc"))
+	file, err := os.Create(filepath.Join(opts.EnvrcDir, ".envrc"))
 	if err != nil {
 		return err
 	}
@@ -152,13 +152,13 @@ func CreateEnvrc(ctx context.Context, path string, envFlags devopt.EnvFlags) err
 
 	flags := []string{}
 
-	if len(envFlags.EnvMap) > 0 {
-		for k, v := range envFlags.EnvMap {
+	if len(opts.EnvMap) > 0 {
+		for k, v := range opts.EnvFlags.EnvMap {
 			flags = append(flags, fmt.Sprintf("--env %s=%s", k, v))
 		}
 	}
-	if envFlags.EnvFile != "" {
-		flags = append(flags, fmt.Sprintf("--env-file %s", envFlags.EnvFile))
+	if opts.EnvFile != "" {
+		flags = append(flags, fmt.Sprintf("--env-file %s", opts.EnvFlags.EnvFile))
 	}
 
 	t := template.Must(template.ParseFS(tmplFS, "tmpl/envrc.tmpl"))
@@ -166,6 +166,7 @@ func CreateEnvrc(ctx context.Context, path string, envFlags devopt.EnvFlags) err
 	// write content into file
 	return t.Execute(file, map[string]string{
 		"Flags": strings.Join(flags, " "),
+		"Dir":   opts.ConfigDir,
 	})
 }
 
@@ -219,7 +220,7 @@ func (g *Options) getDevcontainerContent() *devcontainerObject {
 	return devcontainerContent
 }
 
-func EnvrcContent(w io.Writer, envFlags devopt.EnvFlags) error {
+func EnvrcContent(w io.Writer, envFlags devopt.EnvrcOpts) error {
 	tmplName := "envrcContent.tmpl"
 	t := template.Must(template.ParseFS(tmplFS, "tmpl/"+tmplName))
 	envFlag := ""
@@ -231,5 +232,6 @@ func EnvrcContent(w io.Writer, envFlags devopt.EnvFlags) error {
 	return t.Execute(w, map[string]string{
 		"EnvFlag": envFlag,
 		"EnvFile": envFlags.EnvFile,
+		"Dir":     envFlags.EnvrcDir,
 	})
 }

--- a/internal/devbox/generate/tmpl/envrc.tmpl
+++ b/internal/devbox/generate/tmpl/envrc.tmpl
@@ -3,7 +3,7 @@
 # Automatically sets up your devbox environment whenever you cd into this
 # directory via our direnv integration:
 
-eval "$(devbox generate direnv --print-envrc{{ if .Flags}} {{ .Flags }}{{ end }})"
+eval "$(devbox generate direnv --print-envrc{{ if .Flags}} {{ .Flags }}{{ end }}{{ if .Dir }} --config {{ .Dir -}}{{ end }})"
 
 # check out https://www.jetpack.io/devbox/docs/ide_configuration/direnv/
 # for more details

--- a/internal/devbox/generate/tmpl/envrcContent.tmpl
+++ b/internal/devbox/generate/tmpl/envrcContent.tmpl
@@ -1,6 +1,7 @@
+{{define "DirPrefix"}}{{ if .Dir }}{{ .Dir }}/{{ end }}{{end}}
 use_devbox() {
-    watch_file devbox.json devbox.lock
-    eval "$(devbox shellenv --init-hook --install --no-refresh-alias{{ if .EnvFlag }} {{ .EnvFlag }}{{ end }})"
+    watch_file {{template "DirPrefix" .}}devbox.json {{template "DirPrefix" .}}devbox.lock
+    eval "$(devbox shellenv --init-hook --install --no-refresh-alias {{ if .EnvFlag }}{{ .EnvFlag }}{{ end }} {{- if .Dir }}--config {{ .Dir -}}{{ end }})"
 }
 use devbox
 {{ if .EnvFile }}

--- a/testscripts/generate/direnv-envrcdir-config-sibling.test.txt
+++ b/testscripts/generate/direnv-envrcdir-config-sibling.test.txt
@@ -1,0 +1,10 @@
+# Testscript to validate generating a direnv .envrc in a specified location (./dir) that also
+# references a devbox config in another dir (./cfg) that is a sibling to the first.
+
+mkdir cfg
+exec devbox init cfg
+exists cfg/devbox.json
+
+mkdir dir
+exec devbox generate direnv --envrc-dir dir --config cfg
+grep 'eval "\$\(devbox generate direnv --print-envrc --config ../cfg\)"' dir/.envrc

--- a/testscripts/generate/direnv-envrcdir-config-subdir.test.txt
+++ b/testscripts/generate/direnv-envrcdir-config-subdir.test.txt
@@ -1,0 +1,9 @@
+# Testscript to validate generating a direnv .envrc in a specified location (./dir) that also
+# references a devbox config in another dir (./cfg) that is a subdir of the first.
+
+mkdir dir/cfg
+exec devbox init dir/cfg
+exists dir/cfg/devbox.json
+
+exec devbox generate direnv --envrc-dir dir --config dir/cfg
+grep 'eval "\$\(devbox generate direnv --print-envrc --config cfg\)"' dir/.envrc

--- a/testscripts/generate/direnv-envrcdir-current-config-sub.test.txt
+++ b/testscripts/generate/direnv-envrcdir-current-config-sub.test.txt
@@ -1,0 +1,9 @@
+# Testscript to validate generating a direnv .envrc in the current location that
+# references a devbox config in a subdir (./cfg).
+
+mkdir cfg
+exec devbox init cfg
+exists cfg/devbox.json
+
+exec devbox generate direnv --envrc-dir . --config cfg
+grep 'eval "\$\(devbox generate direnv --print-envrc --config cfg\)"' ./.envrc

--- a/testscripts/generate/direnv-envrcdir.test.txt
+++ b/testscripts/generate/direnv-envrcdir.test.txt
@@ -1,0 +1,9 @@
+# Testscript to validate generating a direnv .envrc in a specified location (./cfg) that also
+# references a devbox config in the same location (no --config needed)
+
+mkdir cfg
+exec devbox init cfg
+exists cfg/devbox.json
+
+exec devbox generate direnv --envrc-dir cfg
+grep 'eval "\$\(devbox generate direnv --print-envrc\)"' cfg/.envrc

--- a/testscripts/generate/direnv-printenvrc-config.test.txt
+++ b/testscripts/generate/direnv-printenvrc-config.test.txt
@@ -1,0 +1,11 @@
+# Testscript to validate generating the contents of the .envrc file. In this case the
+# config location is ignored because there is no --envrc-dir param.
+
+exec devbox init
+exec devbox generate direnv --print-envrc --config config-dir
+cp stdout results.txt
+grep 'watch_file config-dir/devbox.json config-dir/devbox.lock' results.txt
+grep 'eval "\$\(devbox shellenv --init-hook --install --no-refresh-alias --config config-dir\)"' results.txt
+! exists .envrc
+! exists config-dir
+! exists config-dir/.envrc

--- a/testscripts/generate/direnv-printenvrc-envrcdir.test.txt
+++ b/testscripts/generate/direnv-printenvrc-envrcdir.test.txt
@@ -1,0 +1,6 @@
+# Testscript to validate that the --print-envrc and --envrc-dir params are not allowed
+# to be used at the same time.
+
+exec devbox init
+! exec devbox generate direnv --print-envrc --envrc-dir dir
+stderr 'Cannot use --print-envrc with --envrc-dir'

--- a/testscripts/generate/direnv-printenvrc.test.txt
+++ b/testscripts/generate/direnv-printenvrc.test.txt
@@ -1,0 +1,8 @@
+# Testscript to validate teh output of --print-envrc
+
+exec devbox init
+exec devbox generate direnv --print-envrc
+cp stdout results.txt
+grep 'watch_file devbox.json devbox.lock' results.txt
+grep 'eval "\$\(devbox shellenv --init-hook --install --no-refresh-alias \)"' results.txt
+! exists .envrc

--- a/testscripts/generate/direnv.test.txt
+++ b/testscripts/generate/direnv.test.txt
@@ -1,4 +1,7 @@
+# Testscript to validate generating the contents of the .envrc file.
+
 exec devbox init
 exec devbox generate direnv
 exists .envrc
-
+exists devbox.json
+grep 'eval "\$\(devbox generate direnv --print-envrc\)"' .envrc


### PR DESCRIPTION
## Summary
Fixes #2459 - devbox generate direnv does not respect --config

It seems that the previous mode of operation for `devbox generate direnv --config <some-dir>` used `--config` to determine the location of the resulting `.envrc` file, rather than as the location of the `devbox.json` file. But in some cases it is desired to be able to specify not only the location of not only the direnv `.envrc` file, but also the devbox config file. Or at least to be able to specify just the location of the devbox config with the `.envrc` being in the current directory.

To accomplish this, without breaking the current mode of operation, a new parameter is added, `--envrc-dir`, which specifies the location of  the resulting `.envrc` file. For example, the command `devbox generate direnv --envrc-dir ABC --config ABC/XYZ` would create `ABC/.envrc` and within that would be the command `eval "$(devbox generate direnv --print-envrc --config XYZ)"`

Without the new `--envrc-dir` param, operation is the same as it was previously, even with the `--config` (which will be used to specify the location of the `.envrc` file, NOT the devbox config file, `devbox.json`.

## How was it tested?
Several new tests have been created to cover cases with and without the new `--envrc-dir` param.

## Community Contribution License

All community contributions in this pull request are licensed to the project
maintainers under the terms of the
[Apache 2 License](https://www.apache.org/licenses/LICENSE-2.0).

By creating this pull request, I represent that I have the right to license the
contributions to the project maintainers under the Apache 2 License as stated in
the
[Community Contribution License](https://github.com/jetify-com/opensource/blob/main/CONTRIBUTING.md#community-contribution-license).
