### PR TITLE
[runx] Use standard github token env name

### DIFF
--- a/internal/devpkg/pkgtype/runx.go
+++ b/internal/devpkg/pkgtype/runx.go
@@ -12,7 +12,9 @@ import (
 const (
 	RunXScheme            = "runx"
 	RunXPrefix            = RunXScheme + ":"
-	githubAPITokenVarName = "DEVBOX_GITHUB_API_TOKEN"
+	githubAPITokenVarName = "GITHUB_TOKEN"
+	// TODO: Keep for backwards compatibility
+	oldGithubAPITokenVarName = "DEVBOX_GITHUB_API_TOKEN"
 )
 
 var cachedRegistry *registry.Registry
@@ -23,17 +25,25 @@ func IsRunX(s string) bool {
 
 func RunXClient() *runx.RunX {
 	return &runx.RunX{
-		GithubAPIToken: os.Getenv(githubAPITokenVarName),
+		GithubAPIToken: getGithubToken(),
 	}
 }
 
 func RunXRegistry(ctx context.Context) (*registry.Registry, error) {
 	if cachedRegistry == nil {
 		var err error
-		cachedRegistry, err = registry.NewLocalRegistry(ctx, os.Getenv(githubAPITokenVarName))
+		cachedRegistry, err = registry.NewLocalRegistry(ctx, getGithubToken())
 		if err != nil {
 			return nil, err
 		}
 	}
 	return cachedRegistry, nil
+}
+
+func getGithubToken() string {
+	token := os.Getenv(githubAPITokenVarName)
+	if token == "" {
+		token = os.Getenv(oldGithubAPITokenVarName)
+	}
+	return token
 }

--- a/internal/devpkg/pkgtype/runx.go
+++ b/internal/devpkg/pkgtype/runx.go
@@ -13,7 +13,7 @@ const (
 	RunXScheme            = "runx"
 	RunXPrefix            = RunXScheme + ":"
 	githubAPITokenVarName = "GITHUB_TOKEN"
-	// TODO: Keep for backwards compatibility
+	// Keep for backwards compatibility
 	oldGithubAPITokenVarName = "DEVBOX_GITHUB_API_TOKEN"
 )
 


### PR DESCRIPTION
## Summary

## How was it tested?

## Community Contribution License

All community contributions in this pull request are licensed to the project
maintainers under the terms of the
[Apache 2 License](https://www.apache.org/licenses/LICENSE-2.0).

By creating this pull request, I represent that I have the right to license the
contributions to the project maintainers under the Apache 2 License as stated in
the
[Community Contribution License](https://github.com/jetify-com/opensource/blob/main/CONTRIBUTING.md#community-contribution-license).
