### PR TITLE
Evaluate environment variables in the local plugin path

### DIFF
--- a/internal/plugin/local.go
+++ b/internal/plugin/local.go
@@ -55,7 +55,7 @@ func (l *LocalPlugin) LockfileKey() string {
 }
 
 func (l *LocalPlugin) Path() string {
-	path := l.ref.Path
+	path := os.ExpandEnv(l.ref.Path)
 	if !strings.HasSuffix(path, pluginConfigName) {
 		path = filepath.Join(path, pluginConfigName)
 	}


### PR DESCRIPTION
## Summary

Fixes #2638

See issue for description of the problem. This PR is just a one-line change to evaluate current environment variables as devbox assembles the path for local plugins. This will allow things like a dynamic root directory for plugin source.

## How was it tested?

Built devbox locally with code change and copied it to /usr/local/bin/devbox. Refreshed global environment and plugins defined with an environment variable in the path now resolve properly.

## Community Contribution License

All community contributions in this pull request are licensed to the project
maintainers under the terms of the
[Apache 2 License](https://www.apache.org/licenses/LICENSE-2.0).

By creating this pull request, I represent that I have the right to license the
contributions to the project maintainers under the Apache 2 License as stated in
the
[Community Contribution License](https://github.com/jetify-com/opensource/blob/main/CONTRIBUTING.md#community-contribution-license).
