### PR TITLE
Update process-compose version

### DIFF
--- a/internal/devbox/util.go
+++ b/internal/devbox/util.go
@@ -16,7 +16,7 @@ import (
 	"go.jetify.com/devbox/internal/xdg"
 )
 
-const processComposeVersion = "1.24.2"
+const processComposeVersion = "1.64.1"
 
 var utilProjectConfigPath string
 


### PR DESCRIPTION
## Summary

Bump the process compose version from 1.24.2 to the latest 1.64.1

## How was it tested?

Reran some services, will check tests in CI/CD

## Community Contribution License

All community contributions in this pull request are licensed to the project
maintainers under the terms of the
[Apache 2 License](https://www.apache.org/licenses/LICENSE-2.0).

By creating this pull request, I represent that I have the right to license the
contributions to the project maintainers under the Apache 2 License as stated in
the
[Community Contribution License](https://github.com/jetify-com/opensource/blob/main/CONTRIBUTING.md#community-contribution-license).
