### PR TITLE
fix(python-plugin): add UV_PROJECT_ENVIRONMENT env variable

### DIFF
--- a/docs/app/docs/devbox_examples/languages/python.md
+++ b/docs/app/docs/devbox_examples/languages/python.md
@@ -27,7 +27,7 @@ This will install Python 3.10 in your shell. You can find other versions of Pyth
 
 The `python` package automatically comes bundled with `pip`, and the `python` plugin for Devbox will automatically create a virtual environment for installing your packages locally
 
-Your virtual environment is created in the `.devbox/virtenv/python` directory by default, and can be activated by running `. $VENV_DIR/bin/activate` in your Devbox shell. You can activate the virtual environment automatically using the init_hook of your `devbox.json`:
+Your virtual environment is created in the root directory of your project by default, and can be activated by running `. $VENV_DIR/bin/activate` in your Devbox shell. You can activate the virtual environment automatically using the init_hook of your `devbox.json`:
 
 ```json
 {
@@ -46,7 +46,7 @@ For Fish or other shells, you may need to use a different activation script. See
 
 :::
 
-Devbox installs the virtual environment in `.devbox/virtenv/python/.venv` by default. You can modify this path by setting the `VENV_DIR` environment variable in your devbox.json:
+Devbox installs the virtual environment in `$DEVBOX_PROJECT_ROOT/.venv` by default. You can modify this path by setting the `VENV_DIR` environment variable in your devbox.json:
 
 ```json
 {

--- a/examples/development/python/pip/README.md
+++ b/examples/development/python/pip/README.md
@@ -25,7 +25,7 @@ This will install Python 3.10 in your shell. You can find other versions of Pyth
 
 You can install `pip` by running `devbox add python3xxPackages.pip`, where `3xx` is the version of Python you want to install. This will also install the pip plugin for Devbox, which automatically creates a virtual environment for installing your packages locally
 
-Your virtual environment is created in the `.devbox/virtenv/pip` directory by default, and can be activated by running `. $VENV_DIR/bin/activate` in your devbox shell. You can activate the virtual environment automatically using the init_hook of your `devbox.json`:
+Your virtual environment is created in the root directory of your project by default, and can be activated by running `. $VENV_DIR/bin/activate` in your devbox shell. You can activate the virtual environment automatically using the init_hook of your `devbox.json`:
 
 ```json
 {

--- a/plugins/python.json
+++ b/plugins/python.json
@@ -9,6 +9,9 @@
     "{{ .Virtenv }}/bin/venvShellHook.sh": "python/venvShellHook.sh"
   },
   "shell": {
-    "init_hook": ["{{ .Virtenv }}/bin/venvShellHook.sh"]
+    "init_hook": [
+      "export UV_PROJECT_ENVIRONMENT=\"$VENV_DIR\"",
+      "{{ .Virtenv }}/bin/venvShellHook.sh"
+    ]
   }
 }


### PR DESCRIPTION
## Summary

Fixes #2658 (i.e. errors such as the below):

_warning: VIRTUAL_ENV=src/uvtest/.venv does not match the project environment path .venv and will be ignored; use --active to target the active environment instead_

I have also updated the outdated docs which still contained the old default virtual environment path of `.devbox/virtenv/python`.

## How was it tested?

Using the steps from #2658:

```
devbox create uvtest --template python-pip
cd uvtest
devbox add uv@latest
mkdir -p src/uvtest
echo -e "[project]\nname = \"uvtest\"\nversion = \"1.0.0\"\nrequires-python = \">=3.12\"" > pyproject.toml
devbox shell --env VENV_DIR="./src/uvtest/.venv"
uv run main.py
```

With this fix, the last command now runs successfully.

## Community Contribution License

All community contributions in this pull request are licensed to the project
maintainers under the terms of the
[Apache 2 License](https://www.apache.org/licenses/LICENSE-2.0).

By creating this pull request, I represent that I have the right to license the
contributions to the project maintainers under the Apache 2 License as stated in
the
[Community Contribution License](https://github.com/jetify-com/opensource/blob/main/CONTRIBUTING.md#community-contribution-license).
