### PR TITLE
[docker image] set filter-syscalls = false in nix.conf to workaround missing `seccomp BPF program` in arm64 linux

### DIFF
--- a/internal/devbox/generate/tmpl/DevboxImageDockerfile
+++ b/internal/devbox/generate/tmpl/DevboxImageDockerfile
@@ -7,20 +7,27 @@ ARG DEVBOX_USE_VERSION
 RUN apt-get update
 RUN apt-get -y install bash binutils git xz-utils wget sudo
 
-# Step 1.5: Setting up devbox user
+# Step 2: Prepare for Nix
+ARG TARGETPLATFORM
+RUN mkdir -p /etc/nix/
+RUN if [ "$TARGETPLATFORM" = "linux/arm64" ] || [ "$TARGETPLATFORM" = "linux/arm64/v8" ]; then \
+        echo "filter-syscalls = false" >> /etc/nix/nix.conf; \
+    fi
+
+# Step 3: Setting up devbox user
 ENV DEVBOX_USER=devbox
 RUN adduser $DEVBOX_USER
 RUN usermod -aG sudo $DEVBOX_USER
 RUN echo "devbox ALL=(ALL:ALL) NOPASSWD: ALL" | sudo tee /etc/sudoers.d/$DEVBOX_USER
 USER $DEVBOX_USER
 
-# Step 2: Installing Nix
+# Step 4: Installing Nix
 RUN wget --output-document=/dev/stdout https://nixos.org/nix/install | sh -s -- --no-daemon
 RUN . ~/.nix-profile/etc/profile.d/nix.sh
 
 ENV PATH="/home/${DEVBOX_USER}/.nix-profile/bin:$PATH"
 
-# Step 3: Installing devbox
+# Step 5: Installing devbox
 ENV DEVBOX_USE_VERSION=$DEVBOX_USE_VERSION
 RUN wget --quiet --output-document=/dev/stdout https://get.jetify.com/devbox   | bash -s -- -f
 RUN chown -R "${DEVBOX_USER}:${DEVBOX_USER}" /usr/local/bin/devbox

--- a/internal/devbox/generate/tmpl/DevboxImageDockerfileRootUser
+++ b/internal/devbox/generate/tmpl/DevboxImageDockerfileRootUser
@@ -8,8 +8,12 @@ RUN apt-get update
 RUN apt-get -y install bash binutils git xz-utils wget sudo
 
 # Step 2: Installing Nix
+ARG TARGETPLATFORM
 RUN mkdir -p /etc/nix/
-RUN echo "filter-syscalls = false" >> /etc/nix/nix.conf && wget --output-document=/dev/stdout https://nixos.org/nix/install | sh -s -- --daemon
+RUN if [ "$TARGETPLATFORM" = "linux/arm64" ] || [ "$TARGETPLATFORM" = "linux/arm64/v8" ]; then \
+        echo "filter-syscalls = false" >> /etc/nix/nix.conf; \
+    fi 
+RUN wget --output-document=/dev/stdout https://nixos.org/nix/install | sh -s -- --daemon
 RUN . ~/.nix-profile/etc/profile.d/nix.sh
 
 ENV PATH="/root/.nix-profile/bin:$PATH"


### PR DESCRIPTION
## Summary

The docker-image is failing to build in GHA:
https://github.com/jetify-com/devbox/actions/runs/16204700194/job/47358742840

The error indicates that the seccomp (secure computing mode) BPF (Berkeley Packet Filter) program that Nix tries to load is incompatible with the Docker container environment on ARM64.

When filter-syscalls = true (the default), Nix uses seccomp BPF to filter system calls for security sandboxing. Setting filter-syscalls = false disables Nix's syscall filtering, which bypasses the seccomp BPF program entirely and prevents the error.

This PR uses the approach from #1811 to fix this for arm64 platforms.


## How was it tested?

`docker build --platform linux/arm64 -t devbox-image-arm64 -f /Users/savil/code/jetpack/devbox/internal/devbox/generate/tmpl/DevboxImageDockerfile .`
`docker build --platform linux/arm64 -t devbox-image-arm64 -f /Users/savil/code/jetpack/devbox/internal/devbox/generate/tmpl/DevboxImageDockerfileRootUser .`

BEFORE: these failed with the error seen in the GHA above
AFTER: build successfully

Also confirmed that --platform linux/amd64 would build successfully

## Community Contribution License

All community contributions in this pull request are licensed to the project
maintainers under the terms of the
[Apache 2 License](https://www.apache.org/licenses/LICENSE-2.0).

By creating this pull request, I represent that I have the right to license the
contributions to the project maintainers under the Apache 2 License as stated in
the
[Community Contribution License](https://github.com/jetify-com/opensource/blob/main/CONTRIBUTING.md#community-contribution-license).
