### PR TITLE
[cicd] Fix github rate limit issue

### DIFF
--- a/.github/workflows/cache-upload.yml
+++ b/.github/workflows/cache-upload.yml
@@ -22,6 +22,9 @@ env:
   DEVBOX_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   DEVBOX_DEBUG: 1
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  # I think this should be added to individual nix commands within devbox, but this is quick fix for now
+  NIX_CONFIG: |
+    access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
 
 jobs:
   upload-cache:


### PR DESCRIPTION
## Summary

Fixes https://github.com/jetify-com/devbox/actions/runs/16847493651/job/47729104601

This is a very specific fix to this job. I think a better solution is to pass `--extra-access-tokens` flag into nix commands that may interact with github.

## How was it tested?

Not sure how to test.

## Community Contribution License

All community contributions in this pull request are licensed to the project
maintainers under the terms of the
[Apache 2 License](https://www.apache.org/licenses/LICENSE-2.0).

By creating this pull request, I represent that I have the right to license the
contributions to the project maintainers under the Apache 2 License as stated in
the
[Community Contribution License](https://github.com/jetify-com/opensource/blob/main/CONTRIBUTING.md#community-contribution-license).
