### PR TITLE
fixes reference to nixpkgs in pre fetch command

### DIFF
--- a/internal/nix/nix.go
+++ b/internal/nix/nix.go
@@ -112,7 +112,7 @@ func savePrintDevEnvCache(path string, out PrintDevEnvOut) error {
 func FlakeNixpkgs(commit string) string {
 	// Using nixpkgs/<commit> means:
 	// The nixpkgs entry in the flake registry, with its Git revision overridden to a specific value.
-	return "nixpkgs/" + commit
+	return "github:nixpkgs/" + commit
 }
 
 func ExperimentalFlags() []string {


### PR DESCRIPTION
## Summary

Adding a flake reference is reporting an error when loading the devbox shell, however everything works as expected.

The offending internal command is the prefetch here: https://github.com/t-monaghan/devbox/blob/eed56cd6e516bb86577c9abcaf421fe88c714296/internal/nix/nixpkgs.go#L40-L52

And the reported error I receive is: `error: getting status of '/Users/tom.monaghan/dev/scratch/nixpkgs/d7600c775f877cd87b4f5a831c28aa94137377aa': No such file or directory`

This is due to the prefetch missing the `github:` prepended to the flake reference, and as such nix goes looking for a local copy of nixpkgs.

## How was it tested?

With a devbox.json containing the below, I ran the build for this change and noticed no raised error, and the claude-code package I expected was available.

```
{
  "$schema": "https://raw.githubusercontent.com/jetify-com/devbox/0.16.0/.schema/devbox.schema.json",
  "packages": [
    "github:NixOS/nixpkgs/nixos-unstable#claude-code"
  ],
  "shell": {
    "init_hook": [
      "echo 'Welcome to devbox!' > /dev/null"
    ],
    "scripts": {
      "test": [
        "echo \"Error: no test specified\" && exit 1"
      ]
    }
  }
}
```

## Community Contribution License

All community contributions in this pull request are licensed to the project
maintainers under the terms of the
[Apache 2 License](https://www.apache.org/licenses/LICENSE-2.0).

By creating this pull request, I represent that I have the right to license the
contributions to the project maintainers under the Apache 2 License as stated in
the
[Community Contribution License](https://github.com/jetify-com/opensource/blob/main/CONTRIBUTING.md#community-contribution-license).
