### PR TITLE
fix(vscode): Keep  HOME variable when starting VSCode

### DIFF
--- a/internal/boxcli/integrate.go
+++ b/internal/boxcli/integrate.go
@@ -108,7 +108,7 @@ func runIntegrateVSCodeCmd(cmd *cobra.Command, flags integrateCmdFlags) error {
 		// PATH after VSCode opens and resets it to global shellenv. This causes the VSCode
 		// terminal to not be able to find devbox packages after the reopen in devbox
 		// environment action is called.
-		return ok && (strings.HasPrefix(k, "DEVBOX_OG_PATH") || k == "HOME" || k == "NODE_CHANNEL_FD")
+		return ok && (strings.HasPrefix(k, "DEVBOX_OG_PATH") || k == "NODE_CHANNEL_FD")
 	})
 
 	// Send message to parent process to terminate


### PR DESCRIPTION
## Summary

Removing the HOME variable has adverse effects on many tools, most notable git. Without it, tools can't find the configurations.

## How was it tested?

- Overrode the derivation and applied the patch
- Restarted VSCode
- Triggered the "Reopen in devbox shell" action
- `echo $HOME` in the shell
- Make this commit with the opened VSCode

## Community Contribution License

All community contributions in this pull request are licensed to the project
maintainers under the terms of the
[Apache 2 License](https://www.apache.org/licenses/LICENSE-2.0).

By creating this pull request, I represent that I have the right to license the
contributions to the project maintainers under the Apache 2 License as stated in
the
[Community Contribution License](https://github.com/jetify-com/opensource/blob/main/CONTRIBUTING.md#community-contribution-license).
