### PR TITLE
de-duplicate `-f <pc.yaml>` flags to avoid the issue in #2700

### DIFF
--- a/internal/services/manager.go
+++ b/internal/services/manager.go
@@ -150,8 +150,13 @@ func StartProcessManager(
 		fmt.Fprintf(w, "Starting all services: %s \n", strings.Join(services, ", "))
 	}
 
+	seenPCFiles := make(map[string]bool)
 	for _, s := range availableServices {
-		flags = append(flags, "-f", s.ProcessComposePath)
+		if !seenPCFiles[s.ProcessComposePath] {
+			// Only add -f flag if we haven't seen this file path before
+			flags = append(flags, "-f", s.ProcessComposePath)
+			seenPCFiles[s.ProcessComposePath] = true
+		}
 	}
 
 	flags = append(flags, processComposeConfig.ExtraFlags...)


### PR DESCRIPTION
## Summary
Using the `--process-compose-file` flag to merge configurations fails with `FTL error="project /Users/jack/code/my-porject/process-compose.yaml is already specified in files to load"`

See #2700 for details

## How was it tested?
Using the method described here https://github.com/jetify-com/devbox/issues/2699 to build and "install" a local devbox then:
1. Create a process-compose.yaml file
2. Create a second process-compose.extras.yaml file that overrides some of the config defined in the main one (i.e set `is_disabled: "false"`)
3. run `devbox services up --process-compose-file process-compose.extras.yaml` and see error message above instead of running services

The above fails with devbox 0.16.0 but works fine with this PR.

## Notes

I'm happy with this fix but not certain this is the best place to implement this fix, it feels like a bit of a bandaid rather than fixing it at the source. But reading the code I couldn't find the root cause.

## Community Contribution License

All community contributions in this pull request are licensed to the project
maintainers under the terms of the
[Apache 2 License](https://www.apache.org/licenses/LICENSE-2.0).

By creating this pull request, I represent that I have the right to license the
contributions to the project maintainers under the Apache 2 License as stated in
the
[Community Contribution License](https://github.com/jetify-com/opensource/blob/main/CONTRIBUTING.md#community-contribution-license).
