### PR TITLE
[devbox] attempt 2: add GITHUB_TOKEN for nix

### DIFF
--- a/.github/workflows/cli-tests.yaml
+++ b/.github/workflows/cli-tests.yaml
@@ -178,6 +178,11 @@ jobs:
         uses: jetify-com/devbox-install-action@jl/migrate-installer
         with:
           enable-cache: true
+      - name: Setup Nix GitHub authentication
+        run: |
+          # Setup github authentication to ensure Github's rate limits are not hit
+          mkdir -p ~/.config/nix
+          echo "access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}" > ~/.config/nix/nix.conf
       - name: Run fast tests
         if: matrix.run-project-tests == 'project-tests-off'
         run: |


### PR DESCRIPTION
## Summary

Unfortunately, the overnight tests again experienced 403 responses from github
Hoping this fix works better...

## How was it tested?

cicd should be green

## Community Contribution License

All community contributions in this pull request are licensed to the project
maintainers under the terms of the
[Apache 2 License](https://www.apache.org/licenses/LICENSE-2.0).

By creating this pull request, I represent that I have the right to license the
contributions to the project maintainers under the Apache 2 License as stated in
the
[Community Contribution License](https://github.com/jetify-com/opensource/blob/main/CONTRIBUTING.md#community-contribution-license).
