### PR TITLE
fix(generate): use relative paths for env vars in generated README

### DIFF
--- a/internal/devbox/docgen/docgen.go
+++ b/internal/devbox/docgen/docgen.go
@@ -2,6 +2,7 @@ package docgen
 
 import (
 	_ "embed"
+	"maps"
 	"os"
 	"strings"
 	"text/template"
@@ -71,7 +72,7 @@ func GenerateReadme(
 // scripts in the generated README.
 func envWithRelativePaths(env map[string]string, projectDir string) map[string]string {
 	if projectDir == "" {
-		return env
+		return maps.Clone(env)
 	}
 	result := make(map[string]string, len(env))
 	for key, value := range env {

--- a/internal/devbox/docgen/docgen.go
+++ b/internal/devbox/docgen/docgen.go
@@ -3,6 +3,7 @@ package docgen
 import (
 	_ "embed"
 	"os"
+	"strings"
 	"text/template"
 
 	"go.jetify.com/devbox/internal/devbox"
@@ -55,11 +56,28 @@ func GenerateReadme(
 		"Description": devbox.Config().Root.Description,
 		"Scripts": devbox.Config().Scripts().
 			WithRelativePaths(devbox.ProjectDir()),
-		"EnvVars":  devbox.Config().Env(),
+		"EnvVars":  envWithRelativePaths(devbox.Config().Env(), devbox.ProjectDir()),
 		"InitHook": devbox.Config().InitHook(),
 		"Packages": devbox.TopLevelPackages(),
 		// TODO add includes
 	})
+}
+
+// envWithRelativePaths returns a copy of env where occurrences of the absolute
+// project directory are replaced with ".". This keeps generated READMEs free of
+// machine-specific absolute paths (such as a user's home directory) that plugins
+// expand into environment variables like PGDATA and PGHOST. It mirrors the
+// behavior of configfile.Scripts.WithRelativePaths, which is already applied to
+// scripts in the generated README.
+func envWithRelativePaths(env map[string]string, projectDir string) map[string]string {
+	if projectDir == "" {
+		return env
+	}
+	result := make(map[string]string, len(env))
+	for key, value := range env {
+		result[key] = strings.ReplaceAll(value, projectDir, ".")
+	}
+	return result
 }
 
 func SaveDefaultReadmeTemplate(outputPath string) error {

--- a/internal/devbox/docgen/docgen_test.go
+++ b/internal/devbox/docgen/docgen_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestEnvWithRelativePaths(t *testing.T) {
-	projectDir := "/home/carloratm/ooo/oha"
+	projectDir := "/home/user/myproject"
 
 	t.Run("replaces project dir with relative path", func(t *testing.T) {
 		env := map[string]string{

--- a/internal/devbox/docgen/docgen_test.go
+++ b/internal/devbox/docgen/docgen_test.go
@@ -1,0 +1,44 @@
+package docgen
+
+import (
+	"maps"
+	"testing"
+)
+
+func TestEnvWithRelativePaths(t *testing.T) {
+	projectDir := "/home/carloratm/ooo/oha"
+
+	t.Run("replaces project dir with relative path", func(t *testing.T) {
+		env := map[string]string{
+			"PGDATA": projectDir + "/.devbox/virtenv/postgresql/data",
+			"PGHOST": projectDir + "/.devbox/virtenv/postgresql",
+			"PGPORT": "5432",
+		}
+		got := envWithRelativePaths(env, projectDir)
+		want := map[string]string{
+			"PGDATA": "./.devbox/virtenv/postgresql/data",
+			"PGHOST": "./.devbox/virtenv/postgresql",
+			"PGPORT": "5432",
+		}
+		if !maps.Equal(got, want) {
+			t.Errorf("envWithRelativePaths() = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("does not mutate the input map", func(t *testing.T) {
+		original := projectDir + "/.devbox/virtenv/postgresql"
+		env := map[string]string{"PGHOST": original}
+		envWithRelativePaths(env, projectDir)
+		if env["PGHOST"] != original {
+			t.Errorf("input map was mutated: PGHOST = %q, want %q", env["PGHOST"], original)
+		}
+	})
+
+	t.Run("empty project dir returns env unchanged", func(t *testing.T) {
+		env := map[string]string{"PGHOST": "/some/abs/path"}
+		got := envWithRelativePaths(env, "")
+		if !maps.Equal(got, env) {
+			t.Errorf("envWithRelativePaths() = %v, want %v", got, env)
+		}
+	})
+}


### PR DESCRIPTION
## Summary

Fixes #2178.

`devbox generate readme` rendered plugin-provided environment variables with their **fully expanded absolute paths**. For example, enabling the `postgresql` plugin produced a README containing:

```sh
PGDATA="/home/carloratm/ooo/oha/.devbox/virtenv/postgresql/data"
PGHOST="/home/carloratm/ooo/oha/.devbox/virtenv/postgresql"
```

This leaks machine-specific paths — including the user's home directory / username — into a file that is typically committed to the repository.

The generated README already strips the absolute project directory out of **scripts** via `configfile.Scripts.WithRelativePaths(projectDir)`. Environment variables were the one place this wasn't applied, because `Config().Env()` expands included-plugin env values to absolute paths before they reach the template.

## Fix

Apply the same relative-path treatment to env var values before rendering: replace the absolute project directory with `.`, so the example above becomes:

```sh
PGDATA="./.devbox/virtenv/postgresql/data"
PGHOST="./.devbox/virtenv/postgresql"
```

This is intentionally consistent with the existing `Scripts.WithRelativePaths` behavior (same `strings.ReplaceAll(value, projectDir, ".")` transformation), and matches what was requested on the issue:

> It would indeed be nice, when the generated README.md file only has relative references.

Values that don't contain the project dir (e.g. `PGPORT="5432"`) are left untouched.

## How was it tested?

- Added `internal/devbox/docgen/docgen_test.go` covering: project-dir substitution, that the input map is not mutated, and that an empty project dir returns env unchanged.
- `go test ./internal/devbox/docgen/` passes; `go vet` and `gofmt` are clean.

cc the original reporter (the issue's author account has since been deleted) and @ametad, who reconfirmed the request on the issue.

---
_Generated by [Claude Code](https://claude.ai/code/session_01J7UpXTjfVU9iAZiRmuUPSy)_