### PR TITLE
fix(plugin): regenerate local plugin create_files when their content changes

### DIFF
--- a/internal/plugin/local_test.go
+++ b/internal/plugin/local_test.go
@@ -1,0 +1,102 @@
+package plugin
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"go.jetify.com/devbox/nix/flake"
+)
+
+// newTestLocalPlugin writes a plugin.json (with the given create_files content
+// file) into a temp dir and returns a *LocalPlugin pointing at it along with the
+// path of the referenced content file.
+func newTestLocalPlugin(t *testing.T, fileContents string) (*LocalPlugin, string) {
+	t.Helper()
+	pluginDir := t.TempDir()
+
+	pluginJSON := `{
+		"name": "testplugin",
+		"create_files": {
+			"{{ .Virtenv }}/test.txt": "test.txt"
+		}
+	}`
+	if err := os.WriteFile(filepath.Join(pluginDir, pluginConfigName), []byte(pluginJSON), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	contentPath := filepath.Join(pluginDir, "test.txt")
+	if err := os.WriteFile(contentPath, []byte(fileContents), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	local, err := newLocalPlugin(flake.Ref{Type: flake.TypePath, Path: pluginDir}, pluginDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return local, contentPath
+}
+
+// TestLocalPluginHashIncludesCreateFilesContent verifies that editing a file
+// referenced by a local plugin's create_files changes the plugin config hash,
+// even though devbox.json and the plugin.json are unchanged. This is what allows
+// Devbox to detect the change and regenerate the file in the virtenv.
+// See https://github.com/jetify-com/devbox/issues/2755.
+func TestLocalPluginHashIncludesCreateFilesContent(t *testing.T) {
+	local, contentPath := newTestLocalPlugin(t, "123")
+
+	pluginJSON, err := local.Fetch()
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := buildConfig(local, filepath.Dir(contentPath), string(pluginJSON))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	before, err := cfg.Hash()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Edit the referenced content file without touching plugin.json.
+	if err := os.WriteFile(contentPath, []byte("456"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	after, err := cfg.Hash()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if before == after {
+		t.Errorf("hash did not change after editing create_files content: %q", before)
+	}
+}
+
+// TestLocalPluginHashStableWithoutContentChange verifies the hash is stable when
+// the referenced files don't change.
+func TestLocalPluginHashStableWithoutContentChange(t *testing.T) {
+	local, contentPath := newTestLocalPlugin(t, "123")
+
+	pluginJSON, err := local.Fetch()
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := buildConfig(local, filepath.Dir(contentPath), string(pluginJSON))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	first, err := cfg.Hash()
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := cfg.Hash()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first != second {
+		t.Errorf("hash is not stable: %q != %q", first, second)
+	}
+}

--- a/internal/plugin/local_test.go
+++ b/internal/plugin/local_test.go
@@ -74,6 +74,39 @@ func TestLocalPluginHashIncludesCreateFilesContent(t *testing.T) {
 	}
 }
 
+// TestLocalPluginHashIncludesCreateFilesDestinations verifies that changing a
+// create_files destination (a plugin-only field not covered by
+// configfile.ConfigFile.Hash()) changes the plugin config hash.
+func TestLocalPluginHashIncludesCreateFilesDestinations(t *testing.T) {
+	local, contentPath := newTestLocalPlugin(t, "123")
+
+	pluginJSON, err := local.Fetch()
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := buildConfig(local, filepath.Dir(contentPath), string(pluginJSON))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	before, err := cfg.Hash()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Point the same source file at a different destination in the virtenv.
+	cfg.CreateFiles = map[string]string{"renamed.txt": "test.txt"}
+
+	after, err := cfg.Hash()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if before == after {
+		t.Errorf("hash did not change after changing create_files destination: %q", before)
+	}
+}
+
 // TestLocalPluginHashStableWithoutContentChange verifies the hash is stable when
 // the referenced files don't change.
 func TestLocalPluginHashStableWithoutContentChange(t *testing.T) {

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -72,14 +72,18 @@ func (c *Config) Services() (services.Services, error) {
 }
 
 // Hash returns a hash of the plugin config. It shadows the embedded
-// configfile.ConfigFile.Hash() so that, for local plugins, the contents of the
-// files referenced by create_files are folded into the hash.
+// configfile.ConfigFile.Hash() so that, for local plugins, the plugin-only
+// fields and the contents of the files referenced by create_files are folded
+// into the hash.
 //
 // Devbox uses this hash (via Devbox.ConfigHash) to decide whether the cached
-// environment is still up to date. Local plugin files can be edited without any
-// corresponding change to devbox.json or the lockfile, so without this a local
-// plugin's create_files would never be regenerated in the virtenv after the
-// source files change. See https://github.com/jetify-com/devbox/issues/2755.
+// environment is still up to date. configfile.ConfigFile.Hash() only hashes the
+// ConfigFile fields, so on its own it omits plugin-only fields (create_files,
+// version, ...) and the create_files content files. For a local plugin all of
+// these live on disk and can be edited without any corresponding change to
+// devbox.json or the lockfile, so without this a local plugin's create_files
+// would never be regenerated in the virtenv after the source changes. See
+// https://github.com/jetify-com/devbox/issues/2755.
 //
 // Built-in plugin files are embedded in the Devbox binary (covered by the
 // Devbox version in the state hash) and remote plugins are addressed by an
@@ -95,27 +99,37 @@ func (c *Config) Hash() (string, error) {
 		return configHash, nil
 	}
 
-	buf := bytes.Buffer{}
-	buf.WriteString(configHash)
-
-	// Sort the content paths so the resulting hash is deterministic.
-	contentPaths := make([]string, 0, len(c.CreateFiles))
+	// Hash each referenced file independently, keyed by its source path, rather
+	// than concatenating raw bytes. Concatenation is ambiguous (different
+	// file/content splits can produce identical byte streams) and would buffer
+	// every file at once.
+	fileHashes := make(map[string]string, len(c.CreateFiles))
 	for _, contentPath := range c.CreateFiles {
-		if contentPath != "" {
-			contentPaths = append(contentPaths, contentPath)
+		if contentPath == "" {
+			continue
 		}
-	}
-	slices.Sort(contentPaths)
-
-	for _, contentPath := range contentPaths {
 		content, err := local.FileContent(contentPath)
 		if err != nil {
 			return "", errors.WithStack(err)
 		}
-		buf.Write(content)
+		fileHashes[contentPath] = cachehash.Bytes(content)
 	}
 
-	return cachehash.Bytes(buf.Bytes()), nil
+	return cachehash.JSON(struct {
+		ConfigHash           string            `json:"config_hash"`
+		CreateFiles          map[string]string `json:"create_files"`
+		Version              string            `json:"version"`
+		Readme               string            `json:"readme"`
+		RemoveTriggerPackage bool              `json:"remove_trigger_package"`
+		FileHashes           map[string]string `json:"file_hashes"`
+	}{
+		ConfigHash:           configHash,
+		CreateFiles:          c.CreateFiles,
+		Version:              c.Version,
+		Readme:               c.DeprecatedDescription,
+		RemoveTriggerPackage: c.RemoveTriggerPackage,
+		FileHashes:           fileHashes,
+	})
 }
 
 func (m *Manager) CreateFilesForConfig(cfg *Config) error {

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/tailscale/hujson"
+	"go.jetify.com/devbox/internal/cachehash"
 	"go.jetify.com/devbox/internal/devconfig/configfile"
 	"go.jetify.com/devbox/internal/devpkg"
 	"go.jetify.com/devbox/internal/lock"
@@ -68,6 +69,53 @@ func (c *Config) Services() (services.Services, error) {
 		return services.FromProcessCompose(file)
 	}
 	return nil, nil
+}
+
+// Hash returns a hash of the plugin config. It shadows the embedded
+// configfile.ConfigFile.Hash() so that, for local plugins, the contents of the
+// files referenced by create_files are folded into the hash.
+//
+// Devbox uses this hash (via Devbox.ConfigHash) to decide whether the cached
+// environment is still up to date. Local plugin files can be edited without any
+// corresponding change to devbox.json or the lockfile, so without this a local
+// plugin's create_files would never be regenerated in the virtenv after the
+// source files change. See https://github.com/jetify-com/devbox/issues/2755.
+//
+// Built-in plugin files are embedded in the Devbox binary (covered by the
+// Devbox version in the state hash) and remote plugins are addressed by an
+// immutable ref, so for those the config hash alone is sufficient.
+func (c *Config) Hash() (string, error) {
+	configHash, err := c.ConfigFile.Hash()
+	if err != nil {
+		return "", err
+	}
+
+	local, ok := c.Source.(*LocalPlugin)
+	if !ok {
+		return configHash, nil
+	}
+
+	buf := bytes.Buffer{}
+	buf.WriteString(configHash)
+
+	// Sort the content paths so the resulting hash is deterministic.
+	contentPaths := make([]string, 0, len(c.CreateFiles))
+	for _, contentPath := range c.CreateFiles {
+		if contentPath != "" {
+			contentPaths = append(contentPaths, contentPath)
+		}
+	}
+	slices.Sort(contentPaths)
+
+	for _, contentPath := range contentPaths {
+		content, err := local.FileContent(contentPath)
+		if err != nil {
+			return "", errors.WithStack(err)
+		}
+		buf.Write(content)
+	}
+
+	return cachehash.Bytes(buf.Bytes()), nil
 }
 
 func (m *Manager) CreateFilesForConfig(cfg *Config) error {


### PR DESCRIPTION
## Summary

Fixes #2755.

When developing a **local plugin** (included via `path:`), editing a file referenced by the plugin's `create_files` does not update the copy in `.devbox/virtenv/...`. Even deleting the generated file and re-entering the shell leaves it missing/stale, which makes local plugin development confusing.

### Root cause

Devbox skips recomputing the environment (and rewriting plugin files) when its **state hash** is unchanged (`internal/lock/statehash.go`). That state hash is derived in part from `Devbox.ConfigHash()`, which hashes each included plugin config via `plugin.Config.Hash()` — and that resolved to the embedded `configfile.ConfigFile.Hash()`, which only hashes **`plugin.json`**.

The files referenced by `create_files` are read from local disk separately and are **not** part of any hash. So editing a local plugin's source file (e.g. `plugin/test/test.txt`) changes nothing the state hash tracks:

- `devbox.json` — unchanged
- the plugin's `plugin.json` — unchanged
- `devbox.lock`, nix manifest, print-dev-env cache — unchanged

`isStateUpToDate` therefore returns `true`, `CreateFilesForConfig` is never called, and the stale virtenv copy stays in place.

(Note: `shouldCreateFile` already returns `true` for files under `.devbox/`, so once recomputation is triggered the file *is* rewritten correctly — the gap was purely in cache invalidation.)

### Fix

Add a `Hash()` method on `plugin.Config` that shadows the embedded `ConfigFile.Hash()`. For **local plugins**, it folds the contents of the files referenced by `create_files` into the hash (sorted for determinism), so editing them invalidates Devbox's cached state and regenerates the virtenv files on the next `devbox shell`/`run`.

This is scoped to local plugins on purpose:
- **Built-in** plugin files are embedded in the Devbox binary, already covered by the `DevboxVersion` field in the state hash.
- **Remote** (github/git) plugins are addressed by an immutable ref, and reading their content can require network/cache access we don't want on every command.

The only caller of `plugin.Config.Hash()` is `Devbox.ConfigHash()`, so the override is tightly scoped to the cache-invalidation path.

## How was it tested?

- `go build ./internal/...`, `go vet ./internal/plugin/`, and `gofumpt` — all clean.
- New unit tests in `internal/plugin/local_test.go`:
  - `TestLocalPluginHashIncludesCreateFilesContent` — hash changes when a `create_files` source file is edited (plugin.json untouched). Fails before this change, passes after.
  - `TestLocalPluginHashStableWithoutContentChange` — hash is stable across calls when nothing changes.

> Note: the nix-backed end-to-end testscripts could not be executed in the authoring environment (no `nix` binary), but the unit tests exercise the exact hashing logic that gates regeneration.

---

cc @tomtaylor (issue reporter) — thanks for the clear repro repo, it made this easy to pin down.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EAJ8ZxjbxPrxrVpx4Atddd)_