### PR TITLE
fix(plugin): re-create create_files when a local plugin's source changes

### DIFF
--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/tailscale/hujson"
+	"go.jetify.com/devbox/internal/cachehash"
 	"go.jetify.com/devbox/internal/devconfig/configfile"
 	"go.jetify.com/devbox/internal/devpkg"
 	"go.jetify.com/devbox/internal/lock"
@@ -52,6 +53,51 @@ type PluginOnlyData struct {
 	// 1. Built-in plugins are triggered by packages (See plugins.builtInMap)
 	// 2. Plugins can be added via the "include" field in devbox.json or plugin.json
 	Source Includable
+}
+
+// Hash returns a hash of the plugin's config that also incorporates the
+// contents of the files referenced by create_files. The embedded
+// ConfigFile.Hash only covers the plugin.json itself, so without this a change
+// to a create_files source file leaves the project's state hash unchanged and
+// the file is never re-created in the virtenv. This matters most for local
+// (path:) plugins under active development, whose source files can change
+// without any edit to devbox.json or the plugin.json.
+// See https://github.com/jetify-com/devbox/issues/2755
+func (c *Config) Hash() (string, error) {
+	h, err := c.ConfigFile.Hash()
+	if err != nil {
+		return "", err
+	}
+	if c.Source == nil || len(c.CreateFiles) == 0 {
+		return h, nil
+	}
+
+	buf := bytes.Buffer{}
+	buf.WriteString(h)
+
+	// Iterate deterministically so the hash is stable across runs.
+	filePaths := make([]string, 0, len(c.CreateFiles))
+	for filePath := range c.CreateFiles {
+		filePaths = append(filePaths, filePath)
+	}
+	slices.Sort(filePaths)
+
+	for _, filePath := range filePaths {
+		buf.WriteString(filePath)
+		contentPath := c.CreateFiles[filePath]
+		if contentPath == "" {
+			continue
+		}
+		content, err := c.Source.FileContent(contentPath)
+		if err != nil {
+			// A missing or unreadable source file should not hard-fail the
+			// shell; the path is still part of the hash above.
+			continue
+		}
+		buf.Write(content)
+	}
+
+	return cachehash.Bytes(buf.Bytes()), nil
 }
 
 func (c *Config) ProcessComposeYaml() (string, string) {

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"cmp"
 	"encoding/json"
+	"fmt"
 	"io/fs"
 	"log/slog"
 	"os"
@@ -55,20 +56,26 @@ type PluginOnlyData struct {
 	Source Includable
 }
 
-// Hash returns a hash of the plugin's config that also incorporates the
-// contents of the files referenced by create_files. The embedded
-// ConfigFile.Hash only covers the plugin.json itself, so without this a change
-// to a create_files source file leaves the project's state hash unchanged and
-// the file is never re-created in the virtenv. This matters most for local
-// (path:) plugins under active development, whose source files can change
-// without any edit to devbox.json or the plugin.json.
+// Hash returns a hash of the plugin's config that, for local (path:) plugins,
+// also incorporates the contents of the files referenced by create_files. The
+// embedded ConfigFile.Hash only covers the plugin.json itself, so without this
+// a change to a create_files source file leaves the project's state hash
+// unchanged and the file is never re-created in the virtenv. This matters for
+// local plugins under active development, whose source files can change without
+// any edit to devbox.json or the plugin.json.
 // See https://github.com/jetify-com/devbox/issues/2755
+//
+// Only local plugins are handled: for built-in/git/github plugins the source
+// content is stable for a given plugin version, and reading it here would risk
+// network I/O (HTTP fetch / git clone) on the otherwise-fast "is up to date"
+// path, making `devbox shell` slow or fail offline.
 func (c *Config) Hash() (string, error) {
 	h, err := c.ConfigFile.Hash()
 	if err != nil {
 		return "", err
 	}
-	if c.Source == nil || len(c.CreateFiles) == 0 {
+	local, ok := c.Source.(*LocalPlugin)
+	if !ok || len(c.CreateFiles) == 0 {
 		return h, nil
 	}
 
@@ -83,18 +90,27 @@ func (c *Config) Hash() (string, error) {
 	slices.Sort(filePaths)
 
 	for _, filePath := range filePaths {
-		buf.WriteString(filePath)
 		contentPath := c.CreateFiles[filePath]
-		if contentPath == "" {
-			continue
+
+		// Fold in a fixed-size hash of the source content rather than the raw
+		// bytes, so the buffer stays small even for large source files. A
+		// missing or unreadable source file should not hard-fail the shell, so
+		// it just contributes an empty content hash.
+		contentHash := ""
+		if contentPath != "" {
+			if content, err := local.FileContent(contentPath); err == nil {
+				contentHash = cachehash.Bytes(content)
+			}
 		}
-		content, err := c.Source.FileContent(contentPath)
-		if err != nil {
-			// A missing or unreadable source file should not hard-fail the
-			// shell; the path is still part of the hash above.
-			continue
-		}
-		buf.Write(content)
+
+		// Length-prefix every field (netstring-style) so the concatenation is
+		// unambiguous: no two distinct (filePath, contentPath, content) sets
+		// can produce the same byte stream.
+		fmt.Fprintf(&buf, "%d:%s%d:%s%d:%s",
+			len(filePath), filePath,
+			len(contentPath), contentPath,
+			len(contentHash), contentHash,
+		)
 	}
 
 	return cachehash.Bytes(buf.Bytes()), nil

--- a/internal/plugin/plugin_test.go
+++ b/internal/plugin/plugin_test.go
@@ -1,0 +1,65 @@
+// Copyright 2024 Jetify Inc. and contributors. All rights reserved.
+// Use of this source code is governed by the license in the LICENSE file.
+
+package plugin
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.jetify.com/devbox/nix/flake"
+)
+
+// TestConfigHashIncludesCreateFilesContent verifies that a plugin's hash
+// changes when the content of a create_files source file changes. This is what
+// makes local plugins under active development re-create their virtenv files
+// when their source changes (https://github.com/jetify-com/devbox/issues/2755).
+func TestConfigHashIncludesCreateFilesContent(t *testing.T) {
+	pluginDir := t.TempDir()
+	projectDir := t.TempDir()
+
+	pluginJSON := `{
+		"name": "testplugin",
+		"version": "0.0.1",
+		"create_files": {
+			"{{ .Virtenv }}/test.txt": "test.txt"
+		}
+	}`
+	require.NoError(t, os.WriteFile(
+		filepath.Join(pluginDir, "plugin.json"), []byte(pluginJSON), 0o644))
+	srcFile := filepath.Join(pluginDir, "test.txt")
+	require.NoError(t, os.WriteFile(srcFile, []byte("123"), 0o644))
+
+	cfg := localPluginConfigForTest(t, pluginDir, projectDir)
+
+	hash1, err := cfg.Hash()
+	require.NoError(t, err)
+
+	// Re-hashing without any change must be stable.
+	hash1Again, err := cfg.Hash()
+	require.NoError(t, err)
+	assert.Equal(t, hash1, hash1Again, "hash should be stable when nothing changes")
+
+	// Changing the create_files source content must change the hash so that the
+	// file gets re-created in the virtenv on the next shell.
+	require.NoError(t, os.WriteFile(srcFile, []byte("456"), 0o644))
+	hash2, err := cfg.Hash()
+	require.NoError(t, err)
+	assert.NotEqual(t, hash1, hash2,
+		"hash should change when create_files source content changes")
+}
+
+func localPluginConfigForTest(t *testing.T, pluginDir, projectDir string) *Config {
+	t.Helper()
+	ref, err := flake.ParseRef("path:" + pluginDir)
+	require.NoError(t, err)
+	localPlugin, err := newLocalPlugin(ref, projectDir)
+	require.NoError(t, err)
+	cfg, err := getConfigIfAny(localPlugin, projectDir)
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
+	return cfg
+}


### PR DESCRIPTION
## Summary

Fixes #2755.

When iterating on a **local plugin** (`include: ["path:./plugins/..."]`), editing one of the files referenced by the plugin's `create_files` had no effect: the file in `.devbox/virtenv/...` was never updated, and even deleting it didn't get it re-created on the next `devbox shell`.

### Root cause

`devbox shell` short-circuits in `ensureStateIsUpToDate` when the project's **state hash is unchanged** (`File.IsUpToDateAndInstalled` → `Devbox.ConfigHash` → per-plugin `Config.Hash`).

For plugins, `Config.Hash` resolved to the embedded `configfile.ConfigFile.Hash`, which only hashes the **plugin.json** itself. It never looked at the *contents of the files referenced by `create_files`*. So when a local plugin's source file changed (without any edit to `devbox.json` or `plugin.json`), the state hash stayed the same, the project was considered up to date, and `CreateFilesForConfig` was never called — leaving the stale (or missing) file in place.

`LocalPlugin.Hash` similarly only hashes the plugin's *path*, not its content, so it didn't help either.

### Fix

Add a `Config.Hash` method on `plugin.Config` that starts from `ConfigFile.Hash` and additionally folds in the content of each `create_files` source file (read via the plugin's `Source.FileContent`). The map is walked in sorted order so the hash is deterministic.

- **Local (`path:`) plugins** — source edits now change the hash, invalidate the state, and trigger a re-create of the virtenv files. ✅
- **Built-in / git / github plugins** — their file contents are stable for a given version (embedded FS / cached fetch), so the hash is unchanged and there is no behavior change or spurious recompute.

A missing/unreadable source file is tolerated (the file path is still part of the hash) so hashing never hard-fails shell startup.

## How was it tested?

- Added `internal/plugin/plugin_test.go::TestConfigHashIncludesCreateFilesContent`, which builds a local plugin `Config`, asserts the hash is stable across repeated calls with no change, and asserts it changes when a `create_files` source file's content changes.
- `go test ./internal/plugin/ -run TestConfigHashIncludesCreateFilesContent` passes.
- `go build ./...` and `gofmt`/`go vet` are clean for the changed package.

(The two unrelated `TestGitPluginFileContentCache*` failures in this sandbox are pre-existing — they `git commit` and the sandbox's commit-signing server rejects it; they don't touch this code path.)

cc @tomtaylor (issue reporter)


---
_Generated by [Claude Code](https://claude.ai/code/session_01BURbKokeurXFkBYFuCd7k8)_