### PR TITLE
Fix Nix version parsing for prereleases that omit the patch component

### DIFF
--- a/nix/nix.go
+++ b/nix/nix.go
@@ -311,8 +311,9 @@ func (i Info) AtLeast(version string) bool {
 	// valid version (2.23.0-pre.20240526+7de033d6) so we can compare it.
 	prerelease := preReleaseRegexp.ReplaceAllString(i.Version, "-pre.$date+$commit")
 	// Some Nix prereleases omit the patch component (e.g.,
-	// 2.33pre20251107_479b6b73 -> 2.33-pre.20251107+479b6b73). semver
-	// requires a patch component when there's a prerelease, so insert ".0".
+	// 2.33pre20251107_479b6b73 -> 2.33-pre.20251107+479b6b73).
+	// golang.org/x/mod/semver won't parse a prerelease without an explicit
+	// patch component, so insert ".0".
 	prerelease = missingPatchRegexp.ReplaceAllString(prerelease, "${1}.0${2}")
 	return semver.Compare("v"+prerelease, version) >= 0
 }

--- a/nix/nix.go
+++ b/nix/nix.go
@@ -179,12 +179,19 @@ const (
 //
 // The semantic component is sourced from <https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string>.
 // It's been modified to tolerate Nix prerelease versions, which don't have a
-// hyphen before the prerelease component and contain underscores.
-var versionRegexp = regexp.MustCompile(`^(.+) \(.+\) ((?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)(?:(?:-|pre)(?P<prerelease>(?:0|[1-9]\d*|\d*[_a-zA-Z-][_0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[_a-zA-Z-][_0-9a-zA-Z-]*))*))?(?:\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)$`)
+// hyphen before the prerelease component and contain underscores. The patch
+// component is optional because some Nix prereleases omit it (for example,
+// 2.33pre20251107_479b6b73).
+var versionRegexp = regexp.MustCompile(`^(.+) \(.+\) ((?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)(?:\.(?P<patch>0|[1-9]\d*))?(?:(?:-|pre)(?P<prerelease>(?:0|[1-9]\d*|\d*[_a-zA-Z-][_0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[_a-zA-Z-][_0-9a-zA-Z-]*))*))?(?:\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)$`)
 
 // preReleaseRegexp matches Nix prerelease version strings, which are not valid
 // semvers.
 var preReleaseRegexp = regexp.MustCompile(`pre(?P<date>[0-9]+)_(?P<commit>[a-f0-9]{4,40})$`)
+
+// missingPatchRegexp matches a leading major.minor version that has no patch
+// component (for example, the "2.33" in "2.33-pre.20251107+479b6b73"). It's
+// used to insert a ".0" patch so the version is a valid semver.
+var missingPatchRegexp = regexp.MustCompile(`^(\d+\.\d+)(-|\+|$)`)
 
 // Info contains information about a Nix installation.
 type Info struct {
@@ -303,6 +310,10 @@ func (i Info) AtLeast(version string) bool {
 	// prerelease (e.g., 2.23.0pre20240526_7de033d6) and coerce it to a
 	// valid version (2.23.0-pre.20240526+7de033d6) so we can compare it.
 	prerelease := preReleaseRegexp.ReplaceAllString(i.Version, "-pre.$date+$commit")
+	// Some Nix prereleases omit the patch component (e.g.,
+	// 2.33pre20251107_479b6b73 -> 2.33-pre.20251107+479b6b73). semver
+	// requires a patch component when there's a prerelease, so insert ".0".
+	prerelease = missingPatchRegexp.ReplaceAllString(prerelease, "${1}.0${2}")
 	return semver.Compare("v"+prerelease, version) >= 0
 }
 

--- a/nix/nix_test.go
+++ b/nix/nix_test.go
@@ -112,6 +112,9 @@ func TestParseVersionInfoShort(t *testing.T) {
 		{"nix (Nix) 2.23.0pre20240526_7de033d6", "nix", "2.23.0pre20240526_7de033d6"},
 		{"command (Nix) name (Nix) 2.21.2", "command (Nix) name", "2.21.2"},
 		{"nix (Lix, like Nix) 2.90.0-beta.1", "nix", "2.90.0-beta.1"},
+		// Some Nix prereleases omit the patch component.
+		// https://github.com/jetify-com/devbox/issues/2766
+		{"nix (Nix) 2.33pre20251107_479b6b73", "nix", "2.33pre20251107_479b6b73"},
 	}
 
 	for _, tt := range cases {
@@ -184,6 +187,25 @@ func TestVersionInfoAtLeast(t *testing.T) {
 	}
 	if !info.AtLeast("2.23.0-pre.1") {
 		t.Errorf("got %s < %s", info.Version, "2.23.0-pre.1")
+	}
+
+	// Nix prereleases that omit the patch component must still compare.
+	// https://github.com/jetify-com/devbox/issues/2766
+	info.Version = "2.33pre20251107_479b6b73"
+	if !info.AtLeast(Version2_12) {
+		t.Errorf("got %s < %s", info.Version, Version2_12)
+	}
+	if !info.AtLeast(MinVersion) {
+		t.Errorf("got %s < %s", info.Version, MinVersion)
+	}
+	if !info.AtLeast("2.33.0-pre.1") {
+		t.Errorf("got %s < %s", info.Version, "2.33.0-pre.1")
+	}
+	if info.AtLeast("2.33.0") {
+		t.Errorf("got %s >= %s", info.Version, "2.33.0")
+	}
+	if info.AtLeast("2.34.0") {
+		t.Errorf("got %s >= %s", info.Version, "2.34.0")
 	}
 
 	t.Run("ArgEmptyPanic", func(t *testing.T) {


### PR DESCRIPTION
## Summary

Fixes #2766.

Modern Nix prerelease versions report a version string that omits the patch component, e.g. `nix (Nix) 2.33pre20251107_479b6b73` (`2.33` rather than `2.33.0`). Devbox's `versionRegexp` required a `MAJOR.MINOR.PATCH` core, so these versions failed to parse. As a result `Info.Version` came back empty and `EnsureNixInstalled` aborted with:

```
Error: Devbox requires nix of version >= 2.12.0. Your version is . Please upgrade nix and try again.
```

even though the installed Nix was perfectly recent enough.

## Changes

- `versionRegexp`: make the patch component optional so `2.33pre20251107_479b6b73` parses and `Info.Version` is populated correctly.
- `Info.AtLeast`: when coercing a patch-less Nix prerelease to a valid semver for comparison, inject a `.0` patch (`2.33-pre.20251107+479b6b73` → `2.33.0-pre.20251107+479b6b73`), since `golang.org/x/mod/semver` requires a patch component when a prerelease is present. A new `missingPatchRegexp` handles this.
- Added test coverage in `nix/nix_test.go` for both parsing and `AtLeast` comparisons of the patch-less prerelease format.

## Testing

```
go test ./nix/
go vet ./nix/
```

Both pass.

cc @Electrenator (issue reporter)

---
_Generated by [Claude Code](https://claude.ai/code/session_01C4fADfXqVwdbn9cL62KxZb)_