### PR TITLE
fix(nodejs plugin): warn when Corepack is enabled but unavailable

### DIFF
--- a/plugins/nodejs.json
+++ b/plugins/nodejs.json
@@ -1,8 +1,8 @@
 {
     "$schema": "https://raw.githubusercontent.com/jetify-com/devbox/main/.schema/devbox-plugin.schema.json",
-    "version": "0.0.4",
+    "version": "0.0.5",
     "name": "nodejs",
-    "readme": "Devbox automatically configures Corepack for Nodejs when DEVBOX_COREPACK_ENABLED=1. You can install Yarn or Pnpm by adding them to your `package.json` file using `packageManager`\nCorepack binaries will be installed in your local `.devbox` directory\n\nWhen Corepack is enabled, Devbox also activates the package manager pinned in your `package.json` `packageManager` field automatically. Set DEVBOX_DISABLE_NODEJS_PACKAGE_MANAGER_AUTODETECT=1 to disable this behavior.\n\nNote: newer versions of Nodejs (25+) no longer bundle Corepack, so you must add the `corepack` package to your devbox.json separately for Corepack to be available.",
+    "readme": "Devbox automatically configures Corepack for Nodejs when DEVBOX_COREPACK_ENABLED=1. You can install Yarn or Pnpm by adding them to your `package.json` file using `packageManager`\nCorepack binaries will be installed in your local `.devbox` directory\n\nWhen Corepack is enabled, Devbox also activates the package manager pinned in your `package.json` `packageManager` field automatically. Set DEVBOX_DISABLE_NODEJS_PACKAGE_MANAGER_AUTODETECT=1 to disable this behavior.\n\nNote: some Nodejs packages do not bundle Corepack, including `nodejs-slim` and newer Nodejs versions (25+). With those packages you must add the `corepack` package to your devbox.json separately (for example, run `devbox add corepack`) for Corepack to be available.",
     "env": {
         "DEVBOX_COREPACK_BIN_DIR": "{{ .Virtenv }}/corepack-bin",
         "PATH": "{{ .Virtenv }}/corepack-bin:$PATH"

--- a/plugins/nodejs/setup-corepack.mjs
+++ b/plugins/nodejs/setup-corepack.mjs
@@ -27,11 +27,42 @@ if (!corepackBinDir) {
   process.exit(0);
 }
 
-// Enable Corepack, installing the pnpm/yarn/npm shims into corepackBinDir.
-run("corepack", ["enable", "--install-directory", corepackBinDir]);
+// Enable Corepack, installing the pnpm/yarn/npm shims into corepackBinDir. If
+// Corepack isn't available there's nothing more to do, so skip activation.
+if (enableCorepack()) {
+  // Activate the package manager pinned in package.json's "packageManager"
+  // field.
+  activatePinnedPackageManager();
+}
 
-// Activate the package manager pinned in package.json's "packageManager" field.
-activatePinnedPackageManager();
+// enableCorepack runs `corepack enable`. It returns true on success. If the
+// `corepack` binary itself is missing it prints an actionable warning and
+// returns false, because some Node packages (such as nodejs-slim, and Node.js
+// 25+) no longer bundle Corepack (see issue #2791). Other failures (e.g. being
+// offline) are ignored so they don't block shell initialization.
+function enableCorepack() {
+  try {
+    execFileSync("corepack", ["enable", "--install-directory", corepackBinDir], {
+      stdio: "inherit",
+    });
+    return true;
+  } catch (err) {
+    if (err && err.code === "ENOENT") {
+      warnCorepackUnavailable();
+    }
+    return false;
+  }
+}
+
+function warnCorepackUnavailable() {
+  process.stderr.write(
+    "[devbox] Warning: DEVBOX_COREPACK_ENABLED is set but the `corepack` " +
+      "command was not found. Some Node packages (such as nodejs-slim, and " +
+      "Node.js 25+) no longer bundle Corepack. Add the `corepack` package to " +
+      "your devbox.json (for example, run `devbox add corepack`) to use " +
+      "Yarn or pnpm.\n",
+  );
+}
 
 function activatePinnedPackageManager() {
   if (process.env.DEVBOX_DISABLE_NODEJS_PACKAGE_MANAGER_AUTODETECT) {

--- a/plugins/nodejs/setup-corepack.mjs
+++ b/plugins/nodejs/setup-corepack.mjs
@@ -27,8 +27,9 @@ if (!corepackBinDir) {
   process.exit(0);
 }
 
-// Enable Corepack, installing the pnpm/yarn/npm shims into corepackBinDir. If
-// Corepack isn't available there's nothing more to do, so skip activation.
+// Enable Corepack, installing the pnpm/yarn/npm shims into corepackBinDir.
+// Only attempt package-manager activation if enabling succeeded; if it failed
+// for any reason (Corepack missing, offline, etc.) there's nothing to activate.
 if (enableCorepack()) {
   // Activate the package manager pinned in package.json's "packageManager"
   // field.

--- a/testscripts/plugin/nodejs_corepack_autodetect.test.txt
+++ b/testscripts/plugin/nodejs_corepack_autodetect.test.txt
@@ -30,6 +30,16 @@ cp package-esm.json package.json
 exec devbox run -- node -e 'console.log("case3-ok")'
 stdout 'case3-ok'
 
+# Case 4: a Node package that does not bundle Corepack, e.g. nodejs-slim
+# (issue #2791). Shell init must still succeed, and the plugin must print an
+# actionable warning instead of failing later with a cryptic
+# "corepack: command not found".
+exec devbox rm nodejs
+exec devbox add nodejs-slim
+exec devbox run -- node -e 'console.log("case4-ok")'
+stdout 'case4-ok'
+stderr 'command was not found'
+
 -- package-no-pkgmgr.json --
 {
   "name": "nodejs-corepack-autodetect",

--- a/testscripts/plugin/nodejs_corepack_autodetect.test.txt
+++ b/testscripts/plugin/nodejs_corepack_autodetect.test.txt
@@ -38,7 +38,7 @@ exec devbox rm nodejs
 exec devbox add nodejs-slim
 exec devbox run -- node -e 'console.log("case4-ok")'
 stdout 'case4-ok'
-stderr 'command was not found'
+stderr 'Warning: DEVBOX_COREPACK_ENABLED is set but the .corepack. command was not found'
 
 -- package-no-pkgmgr.json --
 {


### PR DESCRIPTION
## Summary

Fixes #2791.

When `DEVBOX_COREPACK_ENABLED` is set, the nodejs plugin's `init_hook` runs `corepack enable`. Some Node packages no longer bundle Corepack — notably `nodejs-slim` ([nixpkgs#487796](https://github.com/NixOS/nixpkgs/pull/487796)) and Node.js 25+. In those cases the `corepack` binary is missing, the enable step failed silently, and the user later hit a cryptic error with no indication of the cause:

```
bash: corepack: command not found
bash: yarn: command not found
```

## Fix

- **`plugins/nodejs/setup-corepack.mjs`**: detect the missing `corepack` binary (`ENOENT`) when running `corepack enable` and print an actionable warning pointing the user to add the `corepack` package, instead of failing silently. Package-manager activation is skipped when Corepack couldn't be enabled. Other failures (e.g. being offline) are still ignored so they never block shell initialization.

  ```
  [devbox] Warning: DEVBOX_COREPACK_ENABLED is set but the `corepack` command
  was not found. Some Node packages (such as nodejs-slim, and Node.js 25+) no
  longer bundle Corepack. Add the `corepack` package to your devbox.json (for
  example, run `devbox add corepack`) to use Yarn or pnpm.
  ```

- **`plugins/nodejs.json`**: bump the plugin version to `0.0.5` (so existing projects regenerate the script) and clarify the readme to call out `nodejs-slim` alongside Node.js 25+.

- **`testscripts/plugin/nodejs_corepack_autodetect.test.txt`**: add a case that switches the project to `nodejs-slim` and asserts the shell still initializes successfully and the warning is printed.

## How was it tested?

- `go test ./plugins/...` passes.
- `node --check` on the script passes, and I exercised it directly under Node 22:
  - no-op when `DEVBOX_COREPACK_ENABLED` is unset;
  - with `corepack` on `PATH`: installs the `yarn`/`pnpm`/... shims into the bin dir, exit 0;
  - with `corepack` removed from `PATH`: prints the warning, exits 0, does not crash.
- Added testscript coverage for the `nodejs-slim` (no bundled Corepack) path.

cc @apgrucza (issue reporter)


---
_Generated by [Claude Code](https://claude.ai/code/session_0112TqTA3ttT2HsVuz7gWUY3)_