### PR TITLE
feat(config): discover devbox.json in a .config subdirectory

### DIFF
--- a/internal/devconfig/config.go
+++ b/internal/devconfig/config.go
@@ -141,8 +141,17 @@ func Find(path string) (*Config, error) {
 
 // searchDir looks for a config file in dir. It does not search parent
 // directories.
+//
+// In addition to a top-level devbox.json, searchDir also looks for the config
+// inside a .config subdirectory (.config/devbox.json). This lets users keep the
+// project root tidy by moving devbox's files out of the way, while still being
+// discoverable. A top-level devbox.json always takes precedence over one in
+// .config.
 func searchDir(dir string) (*Config, error) {
-	try := []string{configfile.DefaultName}
+	try := []string{
+		configfile.DefaultName,
+		filepath.Join(".config", configfile.DefaultName),
+	}
 	for _, name := range try {
 		path := filepath.Join(dir, name)
 		slog.Debug("trying config file", "path", path)

--- a/internal/devconfig/config_test.go
+++ b/internal/devconfig/config_test.go
@@ -49,6 +49,69 @@ func TestOpen(t *testing.T) {
 	})
 }
 
+func TestOpenDotConfig(t *testing.T) {
+	t.Run("FindsConfigInDotConfigDir", func(t *testing.T) {
+		root, _, _ := mkNestedDirs(t)
+		dotConfig := filepath.Join(root, ".config")
+		if err := os.MkdirAll(dotConfig, 0o777); err != nil {
+			t.Fatalf("os.MkdirAll(%q) error: %v", dotConfig, err)
+		}
+		if _, err := Init(dotConfig); err != nil {
+			t.Fatalf("Init(%q) error: %v", dotConfig, err)
+		}
+
+		cfg, err := Open(root)
+		if err != nil {
+			t.Fatalf("Open(%q) error: %v", root, err)
+		}
+		want := filepath.Join(dotConfig, configfile.DefaultName)
+		if cfg.Root.AbsRootPath != want {
+			t.Errorf("cfg.Root.AbsRootPath = %q, want %q", cfg.Root.AbsRootPath, want)
+		}
+	})
+	t.Run("TopLevelConfigTakesPrecedence", func(t *testing.T) {
+		root, _, _ := mkNestedDirs(t)
+		dotConfig := filepath.Join(root, ".config")
+		if err := os.MkdirAll(dotConfig, 0o777); err != nil {
+			t.Fatalf("os.MkdirAll(%q) error: %v", dotConfig, err)
+		}
+		if _, err := Init(root); err != nil {
+			t.Fatalf("Init(%q) error: %v", root, err)
+		}
+		if _, err := Init(dotConfig); err != nil {
+			t.Fatalf("Init(%q) error: %v", dotConfig, err)
+		}
+
+		cfg, err := Open(root)
+		if err != nil {
+			t.Fatalf("Open(%q) error: %v", root, err)
+		}
+		want := filepath.Join(root, configfile.DefaultName)
+		if cfg.Root.AbsRootPath != want {
+			t.Errorf("cfg.Root.AbsRootPath = %q, want %q", cfg.Root.AbsRootPath, want)
+		}
+	})
+	t.Run("FindWalksUpToParentDotConfig", func(t *testing.T) {
+		root, child, _ := mkNestedDirs(t)
+		dotConfig := filepath.Join(root, ".config")
+		if err := os.MkdirAll(dotConfig, 0o777); err != nil {
+			t.Fatalf("os.MkdirAll(%q) error: %v", dotConfig, err)
+		}
+		if _, err := Init(dotConfig); err != nil {
+			t.Fatalf("Init(%q) error: %v", dotConfig, err)
+		}
+
+		cfg, err := Find(child)
+		if err != nil {
+			t.Fatalf("Find(%q) error: %v", child, err)
+		}
+		want := filepath.Join(dotConfig, configfile.DefaultName)
+		if cfg.Root.AbsRootPath != want {
+			t.Errorf("cfg.Root.AbsRootPath = %q, want %q", cfg.Root.AbsRootPath, want)
+		}
+	})
+}
+
 func TestOpenError(t *testing.T) {
 	t.Run("NotExist", func(t *testing.T) {
 		root, _, _ := mkNestedDirs(t)


### PR DESCRIPTION
## Summary

Addresses the auto-discovery half of #2792.

That issue asks to make the location of `devbox.json` more flexible so users can keep the project root tidy — either via an env var **and/or** by looking for the config in an alternative place such as `./.config/devbox.json`. The env-var half is already supported (`DEVBOX_CONFIG`, merged in #2838). This PR adds the remaining piece: auto-discovery of `.config/devbox.json`.

## Change

`searchDir` (in `internal/devconfig/config.go`) already had a `try []string` list of candidate config filenames that previously contained only `devbox.json`. This PR adds `.config/devbox.json` as a second candidate:

```go
try := []string{
    configfile.DefaultName,
    filepath.Join(".config", configfile.DefaultName),
}
```

Behavior:
- A top-level `devbox.json` always takes precedence over `.config/devbox.json` (it's tried first).
- Because `searchDir` is used by both `Open` and `Find`, this works when running from the project directory and when walking up parent directories.
- When the config is found at `.config/devbox.json`, that directory (`.config`) becomes the project directory, so devbox's generated files (`.devbox/`, `devbox.lock`) live alongside it inside `.config` — keeping the repository root clean, which is the goal of the issue.

## Tests

Added `TestOpenDotConfig` in `internal/devconfig/config_test.go`:
- `FindsConfigInDotConfigDir` — config in `.config/devbox.json` is discovered.
- `TopLevelConfigTakesPrecedence` — a root `devbox.json` wins when both exist.
- `FindWalksUpToParentDotConfig` — `Find` from a child dir locates a parent's `.config/devbox.json`.

```
go test ./internal/devconfig/ -run 'TestOpen|TestFind'
go build ./...
go vet ./internal/devconfig/
```

All pass. (Two unrelated pre-existing tests — `TestFindError/Permissions` and `TestFindError/ExactFilePermissions` — fail in a root environment because `chmod 0o000` doesn't restrict root; they fail identically on `main` and are untouched by this change.)

## Notes / scope

This intentionally focuses on the core discovery path used by `Open`/`Find`, which is what the CLI commands rely on. If maintainers would prefer the project root to remain the *parent* of `.config` (keeping `.devbox` at the top level instead of inside `.config`), that's a larger change to how the project directory is derived from the config path and can be a follow-up — happy to adjust based on preference.

cc @eknowles (issue reporter)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L4HytKeYVy9zYHadK7TfWN

---
_Generated by [Claude Code](https://claude.ai/code/session_01L4HytKeYVy9zYHadK7TfWN)_