### PR TITLE
fix(nodejs plugin): warn when Corepack is unavailable instead of failing silently

### DIFF
--- a/plugins/nodejs.json
+++ b/plugins/nodejs.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://raw.githubusercontent.com/jetify-com/devbox/main/.schema/devbox-plugin.schema.json",
-    "version": "0.0.4",
+    "version": "0.0.5",
     "name": "nodejs",
     "readme": "Devbox automatically configures Corepack for Nodejs when DEVBOX_COREPACK_ENABLED=1. You can install Yarn or Pnpm by adding them to your `package.json` file using `packageManager`\nCorepack binaries will be installed in your local `.devbox` directory\n\nWhen Corepack is enabled, Devbox also activates the package manager pinned in your `package.json` `packageManager` field automatically. Set DEVBOX_DISABLE_NODEJS_PACKAGE_MANAGER_AUTODETECT=1 to disable this behavior.\n\nNote: newer versions of Nodejs (25+) no longer bundle Corepack, so you must add the `corepack` package to your devbox.json separately for Corepack to be available.",
     "env": {

--- a/plugins/nodejs/setup-corepack.mjs
+++ b/plugins/nodejs/setup-corepack.mjs
@@ -27,11 +27,22 @@ if (!corepackBinDir) {
   process.exit(0);
 }
 
-// Enable Corepack, installing the pnpm/yarn/npm shims into corepackBinDir. If
-// Corepack itself is missing, stop here: there is nothing to activate, and
-// run() has already printed actionable guidance.
-if (!run("corepack", ["enable", "--install-directory", corepackBinDir])) {
-  process.exit(0);
+// Enable Corepack, installing the pnpm/yarn/npm shims into corepackBinDir.
+try {
+  execFileSync("corepack", ["enable", "--install-directory", corepackBinDir], {
+    stdio: "inherit",
+  });
+} catch (err) {
+  if (err && err.code === "ENOENT") {
+    // Corepack isn't bundled with this Node.js package (e.g. nodejs-slim, or
+    // Node.js 25+, see issue #2791). Without a message the user is later left
+    // with a cryptic "command not found" for yarn/pnpm and no idea why, so warn
+    // with actionable guidance and stop: there is nothing to activate.
+    warnCorepackMissing();
+    process.exit(0);
+  }
+  // Any other failure (e.g. a non-zero exit while offline) is non-fatal: fall
+  // through and still attempt activation, as the plugin did before.
 }
 
 // Activate the package manager pinned in package.json's "packageManager" field.
@@ -68,31 +79,26 @@ function activatePinnedPackageManager() {
   run("corepack", ["prepare", "--activate", packageManager]);
 }
 
-// Run a command, inheriting stdio so Corepack's output is visible. Returns
-// true on success and false on failure. Failures must not block shell
-// initialization, so errors are reported but never rethrown.
+// Run a command, inheriting stdio so Corepack's output is visible. Failures
+// must not block shell initialization, so errors are reported but never
+// rethrown.
 function run(command, args) {
   try {
     execFileSync(command, args, { stdio: "inherit" });
-    return true;
-  } catch (err) {
-    // ENOENT means the command itself is missing. For Corepack this happens
-    // with nodejs-slim and Node.js 25+, which no longer bundle it (see issue
-    // #2791). Without a message, the user is left with a cryptic
-    // "command not found" for yarn/pnpm and no idea why, so point them at the
-    // fix instead of failing silently.
-    if (err && err.code === "ENOENT") {
-      console.error(
-        `[devbox] nodejs plugin: \`${command}\` was not found, so Corepack-managed ` +
-          `package managers (such as yarn and pnpm) will be unavailable.`,
-      );
-      console.error(
-        `[devbox] Your Node.js package does not bundle Corepack (e.g. nodejs-slim, ` +
-          `or Node.js 25+). Add it explicitly with \`devbox add corepack\` to enable it.`,
-      );
-      return false;
-    }
-    // Other failures (e.g. offline during activation) are non-fatal.
-    return false;
+  } catch {
+    // Ignore: e.g. Corepack unavailable, or offline during activation.
   }
+}
+
+// Print actionable guidance when the `corepack` binary is missing, so the user
+// understands why yarn/pnpm aren't available and how to fix it.
+function warnCorepackMissing() {
+  console.error(
+    "[devbox] nodejs plugin: `corepack` was not found, so Corepack-managed " +
+      "package managers (such as yarn and pnpm) will be unavailable.",
+  );
+  console.error(
+    "[devbox] Your Node.js package does not bundle Corepack (e.g. nodejs-slim, " +
+      "or Node.js 25+). Add it explicitly with `devbox add corepack` to enable it.",
+  );
 }

--- a/plugins/nodejs/setup-corepack.mjs
+++ b/plugins/nodejs/setup-corepack.mjs
@@ -27,8 +27,12 @@ if (!corepackBinDir) {
   process.exit(0);
 }
 
-// Enable Corepack, installing the pnpm/yarn/npm shims into corepackBinDir.
-run("corepack", ["enable", "--install-directory", corepackBinDir]);
+// Enable Corepack, installing the pnpm/yarn/npm shims into corepackBinDir. If
+// Corepack itself is missing, stop here: there is nothing to activate, and
+// run() has already printed actionable guidance.
+if (!run("corepack", ["enable", "--install-directory", corepackBinDir])) {
+  process.exit(0);
+}
 
 // Activate the package manager pinned in package.json's "packageManager" field.
 activatePinnedPackageManager();
@@ -64,12 +68,31 @@ function activatePinnedPackageManager() {
   run("corepack", ["prepare", "--activate", packageManager]);
 }
 
-// Run a command, inheriting stdio so Corepack's output is visible. Failures
-// must not block shell initialization.
+// Run a command, inheriting stdio so Corepack's output is visible. Returns
+// true on success and false on failure. Failures must not block shell
+// initialization, so errors are reported but never rethrown.
 function run(command, args) {
   try {
     execFileSync(command, args, { stdio: "inherit" });
-  } catch {
-    // Ignore: e.g. Corepack unavailable, or offline during activation.
+    return true;
+  } catch (err) {
+    // ENOENT means the command itself is missing. For Corepack this happens
+    // with nodejs-slim and Node.js 25+, which no longer bundle it (see issue
+    // #2791). Without a message, the user is left with a cryptic
+    // "command not found" for yarn/pnpm and no idea why, so point them at the
+    // fix instead of failing silently.
+    if (err && err.code === "ENOENT") {
+      console.error(
+        `[devbox] nodejs plugin: \`${command}\` was not found, so Corepack-managed ` +
+          `package managers (such as yarn and pnpm) will be unavailable.`,
+      );
+      console.error(
+        `[devbox] Your Node.js package does not bundle Corepack (e.g. nodejs-slim, ` +
+          `or Node.js 25+). Add it explicitly with \`devbox add corepack\` to enable it.`,
+      );
+      return false;
+    }
+    // Other failures (e.g. offline during activation) are non-fatal.
+    return false;
   }
 }


### PR DESCRIPTION
## Summary

Fixes #2791.

The nodejs plugin's `setup-corepack.mjs` init_hook runs `corepack enable` and silently swallows any failure. On `nodejs-slim` and Node.js 25+ — which [no longer bundle Corepack](https://github.com/NixOS/nixpkgs/pull/487796) — this leaves users with a cryptic, unexplained failure at shell startup:

```
bash: corepack: command not found
bash: yarn: command not found
```

…and no indication of *why* Corepack/yarn are missing or how to fix it.

## Fix

`run()` now detects the missing-binary case (`ENOENT`) and prints actionable guidance pointing the user at the documented fix, then cleanly skips package-manager activation:

```
[devbox] nodejs plugin: `corepack` was not found, so Corepack-managed package managers (such as yarn and pnpm) will be unavailable.
[devbox] Your Node.js package does not bundle Corepack (e.g. nodejs-slim, or Node.js 25+). Add it explicitly with `devbox add corepack` to enable it.
```

This matches the guidance already present in the plugin's `readme`. Shell initialization still succeeds (the warning is non-fatal) and the **happy path is unchanged**: when Corepack is present, `corepack enable` and `corepack prepare --activate <packageManager>` run exactly as before.

The plugin `version` is bumped `0.0.4` → `0.0.5` so cached copies in users' `virtenv` are refreshed.

## How was it tested?

- `node --check plugins/nodejs/setup-corepack.mjs` passes.
- Ran the script against a `PATH` with `node` but no `corepack`: it prints the guidance above and exits 0 (non-fatal).
- Ran it with a stub `corepack` on `PATH` and a pinned `packageManager` in `package.json`: it still calls `corepack enable --install-directory …` followed by `corepack prepare --activate yarn@4.0.0`, confirming the happy path is unaffected.

cc @apgrucza (issue reporter)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MEAWvyABicqkLncj6irnQq

---
_Generated by [Claude Code](https://claude.ai/code/session_01MEAWvyABicqkLncj6irnQq)_