### PR TITLE
docs(contributing): document how to debug Devbox locally

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,8 +82,9 @@ There are two ways to work around this:
    there and point the launcher at it:
 
        devbox run build
-       mkdir -p "$HOME/.cache/devbox/bin/0.0.0-dev_$(go env GOOS)_$(go env GOARCH)"
-       cp dist/devbox "$HOME/.cache/devbox/bin/0.0.0-dev_$(go env GOOS)_$(go env GOARCH)/devbox"
+       cache_dir="${XDG_CACHE_HOME:-$HOME/.cache}/devbox/bin/0.0.0-dev_$(go env GOOS)_$(go env GOARCH)"
+       mkdir -p "$cache_dir"
+       cp dist/devbox "$cache_dir/devbox"
        export DEVBOX_USE_VERSION=0.0.0-dev
 
    With `DEVBOX_USE_VERSION` exported, every `devbox` invocation — including the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,6 +63,43 @@ environment by following the steps below.
        go build ./cmd/devbox
        ./devbox run -- echo hello, world
 
+### Debugging Devbox Locally
+
+Several Devbox commands (for example `devbox shell` and `devbox services up`)
+do little work themselves. Instead, they re-exec a nested `devbox` subprocess
+inside the project's shell environment, and that subprocess does the real work.
+The nested process is resolved from your `PATH`, so it is usually the *installed*
+version of Devbox rather than the local build you are editing. As a result,
+`devbox run build && dist/devbox services up` may not pick up your changes, and
+debug logs (`DEVBOX_DEBUG=1`) or breakpoints you add won't fire, because the
+interesting work happens in a different binary.
+
+There are two ways to work around this:
+
+1. **Make the launcher use your local build (most faithful).** The Devbox
+   launcher selects which CLI binary to run based on the `DEVBOX_USE_VERSION`
+   environment variable, looking it up in its binary cache. Place your build
+   there and point the launcher at it:
+
+       devbox run build
+       mkdir -p "$HOME/.cache/devbox/bin/0.0.0-dev_$(go env GOOS)_$(go env GOARCH)"
+       cp dist/devbox "$HOME/.cache/devbox/bin/0.0.0-dev_$(go env GOOS)_$(go env GOARCH)/devbox"
+       export DEVBOX_USE_VERSION=0.0.0-dev
+
+   With `DEVBOX_USE_VERSION` exported, every `devbox` invocation — including the
+   nested subprocesses — runs your local build, so debug logs and breakpoints
+   work end to end. Rebuild and re-copy the binary whenever you change the code.
+
+2. **Run the work in the current process (quick).** Many commands accept a
+   hidden `--run-in-current-shell` flag that skips the nested re-exec and does
+   the work in place:
+
+       dist/devbox services up --run-in-current-shell
+
+   This is fast to iterate on, but because it bypasses the nested subprocess its
+   behavior differs slightly from a normal invocation, so some issues won't
+   reproduce this way.
+
 ## Pull Request Process
 
 1. For new features or non-trivial changes, consider first filing an issue to


### PR DESCRIPTION
## Summary

Resolves #2699.

Several Devbox commands (e.g. `devbox shell`, `devbox services up`) do little work themselves — they re-exec a **nested `devbox` subprocess** inside the project's shell environment, and that subprocess does the real work. The nested process is resolved from `PATH`, so it's usually the *installed* version of Devbox rather than the local build you're editing. This is why `devbox run build && dist/devbox services up` may silently run old code, and why `DEVBOX_DEBUG=1` logs / breakpoints added to a local build don't fire.

The issue author hit exactly this and asked for it to be documented in the repo. This PR adds a **"Debugging Devbox Locally"** section to `CONTRIBUTING.md` describing the two workarounds they found:

1. **Point the launcher at your local build via `DEVBOX_USE_VERSION`** (most faithful — every invocation, including nested subprocesses, uses your build).
2. **The hidden `--run-in-current-shell` flag** (quick to iterate, but bypasses the nested re-exec so behavior differs slightly).

## Verification

The documented behavior was confirmed against the code:
- `devbox run build` → `dist/devbox` (`devbox.json`).
- `devbox services …` re-execs a nested `devbox` subprocess unless `--run-in-current-shell` is set (`internal/devbox/services.go` — `runDevboxServicesScript` runs the `devbox` on PATH inside the shell; the flag is registered hidden in `internal/boxcli/services.go`).
- `DEVBOX_USE_VERSION` is the version-override env the launcher honors and that Devbox preserves across re-launches (`internal/setup/setup.go`, `internal/devbox/providers/nixcache/setup.go`).

Docs-only change; no code paths affected.

cc @jay-aye-see-kay (issue author) — thanks for the detailed write-up of the workaround.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014fiBLNEAEGUcCJPZ1qpGp6

---
_Generated by [Claude Code](https://claude.ai/code/session_014fiBLNEAEGUcCJPZ1qpGp6)_