### PR TITLE
fix(nix): parse Nix versions that omit the patch component

### DIFF
--- a/nix/nix.go
+++ b/nix/nix.go
@@ -179,12 +179,20 @@ const (
 //
 // The semantic component is sourced from <https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string>.
 // It's been modified to tolerate Nix prerelease versions, which don't have a
-// hyphen before the prerelease component and contain underscores.
-var versionRegexp = regexp.MustCompile(`^(.+) \(.+\) ((?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)(?:(?:-|pre)(?P<prerelease>(?:0|[1-9]\d*|\d*[_a-zA-Z-][_0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[_a-zA-Z-][_0-9a-zA-Z-]*))*))?(?:\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)$`)
+// hyphen before the prerelease component and contain underscores. The patch
+// component is also optional because newer Nix prereleases omit it, e.g.
+// "2.33pre20251107_479b6b73" (see jetify-com/devbox#2766).
+var versionRegexp = regexp.MustCompile(`^(.+) \(.+\) ((?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)(?:\.(?P<patch>0|[1-9]\d*))?(?:(?:-|pre)(?P<prerelease>(?:0|[1-9]\d*|\d*[_a-zA-Z-][_0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[_a-zA-Z-][_0-9a-zA-Z-]*))*))?(?:\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)$`)
 
 // preReleaseRegexp matches Nix prerelease version strings, which are not valid
 // semvers.
 var preReleaseRegexp = regexp.MustCompile(`pre(?P<date>[0-9]+)_(?P<commit>[a-f0-9]{4,40})$`)
+
+// missingPatchRegexp matches a "major.minor" version immediately followed by a
+// "pre" prerelease component, i.e. a Nix prerelease that omits the patch
+// component (e.g. "2.33pre20251107_479b6b73"). It is used to insert a ".0"
+// patch so the version can be coerced into a valid semver.
+var missingPatchRegexp = regexp.MustCompile(`^([0-9]+\.[0-9]+)pre`)
 
 // Info contains information about a Nix installation.
 type Info struct {
@@ -302,7 +310,11 @@ func (i Info) AtLeast(version string) bool {
 	// If the version isn't a valid semver, check to see if it's a
 	// prerelease (e.g., 2.23.0pre20240526_7de033d6) and coerce it to a
 	// valid version (2.23.0-pre.20240526+7de033d6) so we can compare it.
-	prerelease := preReleaseRegexp.ReplaceAllString(i.Version, "-pre.$date+$commit")
+	// Newer Nix prereleases omit the patch component
+	// (e.g. 2.33pre20251107_479b6b73), so insert a ".0" patch first to keep
+	// the coerced string a valid semver (see jetify-com/devbox#2766).
+	current := missingPatchRegexp.ReplaceAllString(i.Version, "$1.0pre")
+	prerelease := preReleaseRegexp.ReplaceAllString(current, "-pre.$date+$commit")
 	return semver.Compare("v"+prerelease, version) >= 0
 }
 

--- a/nix/nix_test.go
+++ b/nix/nix_test.go
@@ -110,6 +110,9 @@ func TestParseVersionInfoShort(t *testing.T) {
 	}{
 		{"nix (Nix) 2.21.2", "nix", "2.21.2"},
 		{"nix (Nix) 2.23.0pre20240526_7de033d6", "nix", "2.23.0pre20240526_7de033d6"},
+		// Newer Nix prereleases omit the patch component.
+		// https://github.com/jetify-com/devbox/issues/2766
+		{"nix (Nix) 2.33pre20251107_479b6b73", "nix", "2.33pre20251107_479b6b73"},
 		{"command (Nix) name (Nix) 2.21.2", "command (Nix) name", "2.21.2"},
 		{"nix (Lix, like Nix) 2.90.0-beta.1", "nix", "2.90.0-beta.1"},
 	}
@@ -184,6 +187,19 @@ func TestVersionInfoAtLeast(t *testing.T) {
 	}
 	if !info.AtLeast("2.23.0-pre.1") {
 		t.Errorf("got %s < %s", info.Version, "2.23.0-pre.1")
+	}
+
+	// Newer Nix prereleases omit the patch component.
+	// https://github.com/jetify-com/devbox/issues/2766
+	info.Version = "2.33pre20251107_479b6b73"
+	if !info.AtLeast(Version2_12) {
+		t.Errorf("got %s < %s", info.Version, Version2_12)
+	}
+	if !info.AtLeast(MinVersion) {
+		t.Errorf("got %s < %s", info.Version, MinVersion)
+	}
+	if info.AtLeast("2.34.0") {
+		t.Errorf("got %s >= %s", info.Version, "2.34.0")
 	}
 
 	t.Run("ArgEmptyPanic", func(t *testing.T) {


### PR DESCRIPTION
## Summary

Fixes #2766.

Newer Nix prereleases report versions without a patch component, e.g.
`nix (Nix) 2.33pre20251107_479b6b73`. Devbox's `versionRegexp` required a
`major.minor.patch` triple, so parsing failed and the Nix version was reported
as empty. The result was that `devbox shell`/`devbox init` aborted with:

```
Error: Devbox requires nix of version >= 2.18.0. Your version is . Please upgrade nix and try again.
```

even on a perfectly recent Nix.

This PR:

- Makes the patch component optional in `versionRegexp` so `2.33pre…` parses.
- Inserts a `.0` patch when coercing such patch-less prereleases into a valid
  semver inside `Info.AtLeast`, so version comparisons work
  (`golang.org/x/mod/semver` rejects `2.33-pre…` but accepts `2.33.0-pre…`).
- Adds test coverage for the new format in both `TestParseVersionInfoShort` and
  `TestVersionInfoAtLeast`.

cc @Electrenator (issue reporter)

## How was it tested?

- `go test ./nix/` passes, including the new cases that parse
  `nix (Nix) 2.33pre20251107_479b6b73` and verify `AtLeast` comparisons against
  the minimum required version.
- `go build` / `go vet ./nix/` are clean.

## Community Contribution License

All community contributions in this pull request are licensed to the project
maintainers under the terms of the
[Apache 2 License](https://www.apache.org/licenses/LICENSE-2.0).

By creating this pull request, I represent that I have the right to license the
contributions to the project maintainers under the Apache 2 License as stated in
the
[Community Contribution License](https://github.com/jetify-com/opensource/blob/main/CONTRIBUTING.md#community-contribution-license).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bn74x1PmF9Wq7F59rCW5Sh

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bn74x1PmF9Wq7F59rCW5Sh)_