### PR TITLE
fix(nix): parse patch-less Nix prerelease versions

### DIFF
--- a/nix/nix.go
+++ b/nix/nix.go
@@ -318,6 +318,12 @@ func (i Info) AtLeast(version string) bool {
 	// becomes 2.33-pre.20251107+479b6b73). x/mod/semver requires major.minor.patch
 	// before a prerelease, so insert a ".0" patch when it's missing.
 	prerelease = majorMinorNoPatchRegexp.ReplaceAllString(prerelease, "$1.0$2")
+	// If the coercion didn't produce a valid semver (e.g. i.Version was empty
+	// or in an unrecognized format), report false rather than relying on
+	// semver.Compare's handling of invalid inputs.
+	if !semver.IsValid("v" + prerelease) {
+		return false
+	}
 	return semver.Compare("v"+prerelease, version) >= 0
 }
 

--- a/nix/nix.go
+++ b/nix/nix.go
@@ -180,11 +180,22 @@ const (
 // The semantic component is sourced from <https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string>.
 // It's been modified to tolerate Nix prerelease versions, which don't have a
 // hyphen before the prerelease component and contain underscores.
-var versionRegexp = regexp.MustCompile(`^(.+) \(.+\) ((?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)(?:(?:-|pre)(?P<prerelease>(?:0|[1-9]\d*|\d*[_a-zA-Z-][_0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[_a-zA-Z-][_0-9a-zA-Z-]*))*))?(?:\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)$`)
+//
+// The patch component is optional: recent Nix prereleases report versions like
+// "2.33pre20251107_479b6b73" (major.minor only, no patch) instead of the older
+// "2.23.0pre20240526_7de033d6" form. Without this, such versions failed to
+// parse and Devbox reported an empty version. See issue #2766.
+var versionRegexp = regexp.MustCompile(`^(.+) \(.+\) ((?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)(?:\.(?P<patch>0|[1-9]\d*))?(?:(?:-|pre)(?P<prerelease>(?:0|[1-9]\d*|\d*[_a-zA-Z-][_0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[_a-zA-Z-][_0-9a-zA-Z-]*))*))?(?:\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)$`)
 
 // preReleaseRegexp matches Nix prerelease version strings, which are not valid
 // semvers.
 var preReleaseRegexp = regexp.MustCompile(`pre(?P<date>[0-9]+)_(?P<commit>[a-f0-9]{4,40})$`)
+
+// majorMinorNoPatchRegexp matches a version that begins with major.minor but has
+// no patch component (e.g. "2.33" or "2.33-pre.20251107"). Group 1 captures the
+// "major.minor" prefix and group 2 captures the rest (prerelease/build), so a
+// ".0" patch can be inserted between them.
+var majorMinorNoPatchRegexp = regexp.MustCompile(`^(\d+\.\d+)([^.\d].*|)$`)
 
 // Info contains information about a Nix installation.
 type Info struct {
@@ -303,6 +314,10 @@ func (i Info) AtLeast(version string) bool {
 	// prerelease (e.g., 2.23.0pre20240526_7de033d6) and coerce it to a
 	// valid version (2.23.0-pre.20240526+7de033d6) so we can compare it.
 	prerelease := preReleaseRegexp.ReplaceAllString(i.Version, "-pre.$date+$commit")
+	// Some prereleases omit the patch component (e.g. 2.33pre20251107_479b6b73
+	// becomes 2.33-pre.20251107+479b6b73). x/mod/semver requires major.minor.patch
+	// before a prerelease, so insert a ".0" patch when it's missing.
+	prerelease = majorMinorNoPatchRegexp.ReplaceAllString(prerelease, "$1.0$2")
 	return semver.Compare("v"+prerelease, version) >= 0
 }
 

--- a/nix/nix_test.go
+++ b/nix/nix_test.go
@@ -110,6 +110,9 @@ func TestParseVersionInfoShort(t *testing.T) {
 	}{
 		{"nix (Nix) 2.21.2", "nix", "2.21.2"},
 		{"nix (Nix) 2.23.0pre20240526_7de033d6", "nix", "2.23.0pre20240526_7de033d6"},
+		// Recent Nix prereleases omit the patch component (major.minor only).
+		// See https://github.com/jetify-com/devbox/issues/2766
+		{"nix (Nix) 2.33pre20251107_479b6b73", "nix", "2.33pre20251107_479b6b73"},
 		{"command (Nix) name (Nix) 2.21.2", "command (Nix) name", "2.21.2"},
 		{"nix (Lix, like Nix) 2.90.0-beta.1", "nix", "2.90.0-beta.1"},
 	}
@@ -184,6 +187,19 @@ func TestVersionInfoAtLeast(t *testing.T) {
 	}
 	if !info.AtLeast("2.23.0-pre.1") {
 		t.Errorf("got %s < %s", info.Version, "2.23.0-pre.1")
+	}
+
+	// Patch-less prerelease versions must still compare correctly.
+	// See https://github.com/jetify-com/devbox/issues/2766
+	info.Version = "2.33pre20251107_479b6b73"
+	if !info.AtLeast(Version2_12) {
+		t.Errorf("got %s < %s", info.Version, Version2_12)
+	}
+	if !info.AtLeast(MinVersion) {
+		t.Errorf("got %s < %s", info.Version, MinVersion)
+	}
+	if info.AtLeast("2.34.0") {
+		t.Errorf("got %s >= %s", info.Version, "2.34.0")
 	}
 
 	t.Run("ArgEmptyPanic", func(t *testing.T) {


### PR DESCRIPTION
## Summary

Fixes #2766.

`devbox shell` (and any command that checks the Nix version) failed on recent Nix prereleases with:

```
Error: Devbox requires nix of version >= 2.12.0. Your version is . Please upgrade nix and try again.
```

Note the empty version — Devbox could not parse it at all.

### Root cause

Recent Nix prereleases report their version with only a `major.minor` component and no patch, e.g. `2.33pre20251107_479b6b73`, instead of the older `2.23.0pre20240526_7de033d6` form. `versionRegexp` in `nix/nix.go` required a patch component (`major.minor.patch`), so the newer form did not match, `Info.Version` was left empty, and the `>= 2.12.0` check failed with the empty version shown above.

### Fix

- **`nix/nix.go`**
  - Make the patch component optional in `versionRegexp` so `2.33pre...` parses to `2.33pre20251107_479b6b73`.
  - In `Info.AtLeast`, when coercing a Nix prerelease into a comparable semver, insert a `.0` patch when it is missing. `x/mod/semver` requires `major.minor.patch` before a prerelease, so `2.33-pre.20251107+479b6b73` is invalid while `2.33.0-pre.20251107+479b6b73` compares correctly.
- **`nix/nix_test.go`**
  - Add the patch-less prerelease form to `TestParseVersionInfoShort`.
  - Add `AtLeast` assertions for `2.33pre20251107_479b6b73` (>= 2.12.0 / MinVersion, and < 2.34.0).

The existing three-component prerelease and Lix version cases are unchanged and still pass.

## How was it tested?

- `go test ./nix/` — passes, including the new patch-less prerelease cases.
- `go vet ./nix/` and `go build ./...` — clean.

## Community Contribution License

All community contributions in this pull request are licensed to the project
maintainers under the terms of the
[Apache 2 License](https://www.apache.org/licenses/LICENSE-2.0).

By creating this pull request, I represent that I have the right to license the
contributions to the project maintainers under the Apache 2 License as stated in
the
[Community Contribution License](https://github.com/jetify-com/opensource/blob/main/CONTRIBUTING.md#community-contribution-license).

---

cc @Electrenator (issue reporter) — thanks for the detailed debug logs, which pinpointed the empty parsed version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BDHcDV3qqUJGLATaek65BJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01BDHcDV3qqUJGLATaek65BJ)_