### PR TITLE
fix(php plugin): reference php output via explicit flake fragment

### DIFF
--- a/plugins/php.json
+++ b/plugins/php.json
@@ -1,9 +1,9 @@
 {
   "name": "php",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "PHP is compiled with default extensions. If you would like to use non-default extensions you can add them with devbox add php81Extensions.{extension} . For example, for the memcache extension you can do `devbox add php81Extensions.memcached`.",
   "packages": [
-    "path:{{ .Virtenv }}/flake",
+    "path:{{ .Virtenv }}/flake#php",
     "path:{{ .Virtenv }}/flake#composer"
   ],
   "__remove_trigger_package": true,

--- a/plugins/php/flake.nix
+++ b/plugins/php/flake.nix
@@ -21,7 +21,12 @@
     in
     {
       packages.{{ .System }} = {
+        # This flake exports more than one package (php and composer), so each
+        # must be referenced from the plugin via an explicit url fragment
+        # (e.g. path:.../flake#php). The bare `default` output is kept for
+        # backwards compatibility with anyone referencing the flake directly.
         default = php;
+        php = php;
         composer = php.packages.composer;
       };
     };


### PR DESCRIPTION
## Summary

Fixes #2788.

The php plugin's generated flake (`plugins/php/flake.nix`) exports **two**
packages:

```nix
packages.${system} = {
  default = php;
  composer = php.packages.composer;
};
```

but the plugin (`plugins/php.json`) referenced them inconsistently — php via the
**bare** `path:{{ .Virtenv }}/flake` (i.e. the flake's `default` output) and
composer via an explicit `#composer` fragment:

```json
"packages": [
  "path:{{ .Virtenv }}/flake",
  "path:{{ .Virtenv }}/flake#composer"
]
```

### Root cause

Devbox's own flake example documents that a flake exporting more than one
package must be referenced with explicit url fragments, and that the bare
`default` reference is meant for single-output flakes:

> Flakes can export multiple packages. To include specific packages in
> devbox.json you can use url fragments (e.g. `path:my-flake#my-package`) […]
> If you only want to export a single package, you can name it `default` which
> allows installation without using url fragment.
> — `examples/flakes/php/my-php-flake/flake.nix`

Relying on the bare `default` for one of two outputs is fragile. In #2788 this
surfaced as the `php` binary not being linked into the environment (only
`composer` appeared under `.devbox/nix/profile/default/bin`), leaving `php`
unavailable in the shell.

### Fix

- **`plugins/php/flake.nix`**: add a named `php` output alongside the existing
  outputs. `default = php` is kept for backwards compatibility with anyone
  referencing the flake directly.
- **`plugins/php.json`**: reference php explicitly as
  `path:{{ .Virtenv }}/flake#php`, mirroring the working `#composer` entry, so
  both plugin packages are resolved the same way. Bump the plugin version
  (`0.0.3` → `0.0.4`) so cached `create_files` are regenerated for existing
  projects.

This aligns the php plugin with the documented best practice for multi-output
flakes and with the working `examples/flakes/php` example, which already
references its php output as `path:my-php-flake#php`.

## How was it tested?

- `go build ./...` — clean.
- `go test ./internal/plugin/... ./internal/shellgen/... ./internal/devconfig/configfile/...` — pass.
- Verified the plugin flake template still renders and that the extension-name
  matcher in `flake.nix` is unaffected (the new `#php`/`#composer` refs do not
  match the `^php.*Extensions…` pattern, same as before).

Note: the existing `testscripts/languages/php.test.txt` (which runs `devbox run
php`) exercises both the cached and non-cached php paths and passes on `main`,
so the failure in #2788 appears to be environment-specific (the reporter was on
devbox 0.16/0.17 with Lix). This change removes the fragile bare-`default`
reliance that is the most likely cause, and makes the plugin consistent with
devbox's documented multi-output flake usage.

cc @assyrus-favolo (issue reporter) — thanks for the detailed reproduction and
the generated `flake.nix` in the issue comments, which pinpointed that only the
`composer` output was making it into the environment.

## Community Contribution License

All community contributions in this pull request are licensed to the project
maintainers under the terms of the
[Apache 2 License](https://www.apache.org/licenses/LICENSE-2.0).

By creating this pull request, I represent that I have the right to license the
contributions to the project maintainers under the Apache 2 License as stated in
the
[Community Contribution License](https://github.com/jetify-com/opensource/blob/main/CONTRIBUTING.md#community-contribution-license).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011G5YZ3hdoiBSd3T9GGLYox

---
_Generated by [Claude Code](https://claude.ai/code/session_011G5YZ3hdoiBSd3T9GGLYox)_