### PR TITLE
fix(env): warn instead of failing when env_from file is missing

### DIFF
--- a/internal/devbox/devbox.go
+++ b/internal/devbox/devbox.go
@@ -1029,7 +1029,17 @@ func (d *Devbox) configEnvs(
 	} else if d.cfg.Root.IsdotEnvEnabled() {
 		// if env_from points to a .env file, parse and add it
 		parsedEnvs, err := d.cfg.Root.ParseEnvsFromDotEnv()
-		if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			// A missing env_from file should not stop Devbox from enabling the
+			// environment. The referenced file is often untracked and may be
+			// created by a command in init_hook (e.g. `cp -n .env.example
+			// .env`). Warn and continue instead of erroring out. See #2504.
+			ux.Fwarningf(
+				d.stderr,
+				"Ignoring env_from directive: file %q does not exist.\n",
+				d.cfg.Root.EnvFrom,
+			)
+		} else if err != nil {
 			// it's fine to include the error ParseEnvsFromDotEnv here because
 			// the error message is relevant to the user
 			return nil, usererr.New(

--- a/internal/devconfig/configfile/env.go
+++ b/internal/devconfig/configfile/env.go
@@ -33,7 +33,10 @@ func (c *ConfigFile) ParseEnvsFromDotEnv() (map[string]string, error) {
 	}
 	file, err := os.Open(envFileAbsPath)
 	if err != nil {
-		return nil, fmt.Errorf("failed to open file: %s", envFileAbsPath)
+		// Wrap the underlying error (which is os.ErrNotExist for a missing
+		// file) so callers can distinguish a missing env_from file from a
+		// genuine parse error via errors.Is(err, os.ErrNotExist).
+		return nil, fmt.Errorf("failed to open file: %s: %w", envFileAbsPath, err)
 	}
 	defer file.Close()
 

--- a/internal/devconfig/configfile/env_test.go
+++ b/internal/devconfig/configfile/env_test.go
@@ -1,0 +1,42 @@
+package configfile
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestParseEnvsFromDotEnv(t *testing.T) {
+	dir := t.TempDir()
+	rootPath := filepath.Join(dir, "devbox.json")
+
+	t.Run("parses an existing .env file", func(t *testing.T) {
+		envPath := filepath.Join(dir, "exists.env")
+		if err := os.WriteFile(envPath, []byte("FOO=bar\nBAZ=qux\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		c := &ConfigFile{EnvFrom: "exists.env", AbsRootPath: rootPath}
+		got, err := c.ParseEnvsFromDotEnv()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got["FOO"] != "bar" || got["BAZ"] != "qux" {
+			t.Errorf("unexpected env map: %v", got)
+		}
+	})
+
+	t.Run("missing file returns an os.ErrNotExist error", func(t *testing.T) {
+		// Regression test for #2504: a missing env_from file must be
+		// distinguishable from a genuine parse error so callers can warn and
+		// continue instead of failing to enable the environment.
+		c := &ConfigFile{EnvFrom: "does-not-exist.env", AbsRootPath: rootPath}
+		_, err := c.ParseEnvsFromDotEnv()
+		if err == nil {
+			t.Fatal("expected an error for a missing file, got nil")
+		}
+		if !errors.Is(err, os.ErrNotExist) {
+			t.Errorf("expected error to wrap os.ErrNotExist, got: %v", err)
+		}
+	})
+}


### PR DESCRIPTION
## Summary

Fixes #2504.

When `env_from` points to a `.env` file that does not exist yet, Devbox exited early with:

```
Error: failed parsing .private.env file. Error: failed to open file: /path/.private.env
```

This is a papercut on first-time setup: the referenced file is typically untracked and intended to be created by a command in `init_hook` (e.g. `cp -n .env.example .env`). Because parsing `env_from` happens before `init_hook` runs, the environment could never be enabled to bootstrap the file in the first place.

### Fix

- **`internal/devconfig/configfile/env.go`**: `ParseEnvsFromDotEnv` now wraps the underlying `os.Open` error with `%w`, so callers can distinguish a *missing file* (`errors.Is(err, os.ErrNotExist)`) from a *genuine parse error*.
- **`internal/devbox/devbox.go`**: `configEnvs` treats a missing `env_from` file as a warning and continues enabling the environment, instead of returning a hard error. Real parse errors (file exists but is malformed) still fail as before.

New behavior when the file is missing:

```
Warning: Ignoring env_from directive: file ".private.env" does not exist.
```

### Changes

- `internal/devconfig/configfile/env.go`: wrap the open error so missing files are detectable.
- `internal/devbox/devbox.go`: warn-and-continue on a missing `env_from` file.
- `internal/devconfig/configfile/env_test.go`: new `TestParseEnvsFromDotEnv` covering a valid `.env` file and the missing-file (`os.ErrNotExist`) regression.

## How was it tested?

- `go test ./internal/devconfig/configfile/ -run TestParseEnvsFromDotEnv -v` — passes.
- `go build ./internal/...` and `go vet ./internal/devconfig/configfile/ ./internal/devbox/` — clean.

## Community Contribution License

All community contributions in this pull request are licensed to the project
maintainers under the terms of the
[Apache 2 License](https://www.apache.org/licenses/LICENSE-2.0).

By creating this pull request, I represent that I have the right to license the
contributions to the project maintainers under the Apache 2 License as stated in
the
[Community Contribution License](https://github.com/jetify-com/opensource/blob/main/CONTRIBUTING.md#community-contribution-license).

---

cc @t-monaghan (issue reporter) — thanks for the clear write-up and reproduction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UiVJfTdwpkKJ4UDn9opMMX

---
_Generated by [Claude Code](https://claude.ai/code/session_01UiVJfTdwpkKJ4UDn9opMMX)_