### PR TITLE
fix(shellenv): only export env vars Devbox actually modifies

### DIFF
--- a/internal/devbox/devbox.go
+++ b/internal/devbox/devbox.go
@@ -379,6 +379,15 @@ func (d *Devbox) EnvExports(ctx context.Context, opts devopt.EnvExportsOpts) (st
 		return "", err
 	}
 
+	// Only export the variables that Devbox actually adds or changes relative to
+	// the current environment. The output of this function is meant to be eval'd
+	// in the caller's shell (e.g. `eval "$(devbox shellenv)"`), so re-exporting
+	// variables that are already set to the same value is unnecessary and can
+	// fail in shells that mark some inherited variables as read-only (e.g.
+	// PROFILEREAD on openSUSE). See
+	// https://github.com/jetify-com/devbox/issues/2826.
+	envs = onlyModifiedEnvs(envs, envir.PairsToMap(os.Environ()))
+
 	// Use the appropriate export format based on shell type
 	var envStr string
 	if opts.ShellFormat == devopt.ShellFormatNushell {

--- a/internal/devbox/envvars.go
+++ b/internal/devbox/envvars.go
@@ -14,6 +14,27 @@ import (
 
 const devboxSetPrefix = "__DEVBOX_SET_"
 
+// onlyModifiedEnvs returns the subset of envs whose values differ from those in
+// baseEnv (or that are absent from baseEnv entirely).
+//
+// It is used to avoid emitting `export` statements for variables that Devbox did
+// not actually change. Re-exporting a variable with the value it already has is
+// not only redundant, it can break shells that mark some inherited variables as
+// read-only. For example, openSUSE marks PROFILEREAD read-only, so
+// `eval "$(devbox global shellenv)"` failed with
+// "read-only variable: PROFILEREAD". See
+// https://github.com/jetify-com/devbox/issues/2826.
+func onlyModifiedEnvs(envs, baseEnv map[string]string) map[string]string {
+	modified := make(map[string]string, len(envs))
+	for k, v := range envs {
+		if base, ok := baseEnv[k]; ok && base == v {
+			continue
+		}
+		modified[k] = v
+	}
+	return modified
+}
+
 // exportify formats vars as a line-separated string of shell export statements.
 // Each line is of the form `export key="value";` with any special characters in
 // value escaped. This means that the shell will always interpret values as

--- a/internal/devbox/envvars_test.go
+++ b/internal/devbox/envvars_test.go
@@ -1,0 +1,88 @@
+// Copyright 2024 Jetify Inc. and contributors. All rights reserved.
+// Use of this source code is governed by the license in the LICENSE file.
+
+package devbox
+
+import (
+	"maps"
+	"testing"
+)
+
+func TestOnlyModifiedEnvs(t *testing.T) {
+	tests := []struct {
+		name    string
+		envs    map[string]string
+		baseEnv map[string]string
+		want    map[string]string
+	}{
+		{
+			name:    "empty",
+			envs:    map[string]string{},
+			baseEnv: map[string]string{},
+			want:    map[string]string{},
+		},
+		{
+			name: "drops unchanged variables",
+			envs: map[string]string{
+				"HOSTNAME":    "myhost",
+				"LANG":        "en_US.UTF-8",
+				"PROFILEREAD": "true",
+			},
+			baseEnv: map[string]string{
+				"HOSTNAME":    "myhost",
+				"LANG":        "en_US.UTF-8",
+				"PROFILEREAD": "true",
+			},
+			want: map[string]string{},
+		},
+		{
+			name: "keeps changed and new variables",
+			envs: map[string]string{
+				"PATH":                "/nix/store/bin:/usr/bin", // changed
+				"HOSTNAME":            "myhost",                  // unchanged
+				"DEVBOX_PROJECT_ROOT": "/home/user/project",      // new
+			},
+			baseEnv: map[string]string{
+				"PATH":     "/usr/bin",
+				"HOSTNAME": "myhost",
+			},
+			want: map[string]string{
+				"PATH":                "/nix/store/bin:/usr/bin",
+				"DEVBOX_PROJECT_ROOT": "/home/user/project",
+			},
+		},
+		{
+			name: "keeps variable that became empty",
+			envs: map[string]string{
+				"FOO": "",
+			},
+			baseEnv: map[string]string{
+				"FOO": "bar",
+			},
+			want: map[string]string{
+				"FOO": "",
+			},
+		},
+		{
+			name: "empty base env keeps everything",
+			envs: map[string]string{
+				"FOO": "bar",
+				"BAZ": "qux",
+			},
+			baseEnv: map[string]string{},
+			want: map[string]string{
+				"FOO": "bar",
+				"BAZ": "qux",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := onlyModifiedEnvs(test.envs, test.baseEnv)
+			if !maps.Equal(got, test.want) {
+				t.Errorf("onlyModifiedEnvs() = %v, want %v", got, test.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #2826.

`devbox shellenv` and `devbox global shellenv` emit an `export` statement for **every** variable in the computed environment — including inherited variables that Devbox never touched, such as `HOSTNAME`, `LANG`, and `PROFILEREAD`. Re-exporting an unchanged variable is redundant, and it breaks in shells that mark some inherited variables as read-only. On openSUSE, `eval "$(devbox global shellenv)"` failed on every prompt with:

```
(eval):55: read-only variable: PROFILEREAD
```

### Root cause

`Devbox.computeEnv` (`internal/devbox/devbox.go`) builds the environment by copying the entire parent environment (`os.Environ()`) and then layering Nix- and Devbox-specific variables on top. `EnvExports` then runs `exportify` over that whole map, so unchanged variables like `PROFILEREAD` are re-emitted as `export PROFILEREAD="true";`. When that output is `eval`'d in a shell that has marked `PROFILEREAD` read-only, the assignment errors out.

### Fix

Filter the computed environment down to just the variables whose value **differs** from the current environment (or that are new) before formatting the export statements:

- New helper `onlyModifiedEnvs(envs, baseEnv)` in `internal/devbox/envvars.go` returns only entries that are absent from, or changed relative to, `baseEnv`.
- `EnvExports` now calls `onlyModifiedEnvs(envs, envir.PairsToMap(os.Environ()))` before choosing the bash/nushell export format.

The output of `EnvExports` is meant to be `eval`'d in the caller's shell (`devbox shellenv`, and `devbox shell --print-env` used by direnv), so dropping variables that already hold the same value is a no-op in the normal case and avoids the read-only error. Variables Devbox actually changes — `PATH`, `XDG_DATA_DIRS`, `DEVBOX_*`, Nix and plugin/config variables, the shellenv hash — all differ from the parent value and are still exported.

The interactive `devbox shell` path (which sources a generated shellrc in a child shell via `shell.go`) is intentionally **unchanged**; only `EnvExports` is affected.

## How was it tested?

- Added `internal/devbox/envvars_test.go::TestOnlyModifiedEnvs`, covering unchanged variables being dropped, changed/new/emptied variables being kept, and empty-base-env behavior.
- `go test ./internal/devbox/ -run TestOnlyModifiedEnvs` — passes.
- `go build ./internal/devbox/`, `go vet ./internal/devbox/`, and `gofmt` — all clean.
- Verified the existing `testscripts/shell/shellenv.test.txt` flow is unaffected: it sources the `export PATH=` line from `devbox shellenv`, and `PATH` is always modified by Devbox, so it is still emitted.

cc @gasuketsu (issue reporter) — thanks for the clear write-up and pinpointing the read-only variable failure.

## Community Contribution License

All community contributions in this pull request are licensed to the project
maintainers under the terms of the
[Apache 2 License](https://www.apache.org/licenses/LICENSE-2.0).

By creating this pull request, I represent that I have the right to license the
contributions to the project maintainers under the Apache 2 License as stated in
the
[Community Contribution License](https://github.com/jetify-com/opensource/blob/main/CONTRIBUTING.md#community-contribution-license).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WiTxPixVaWVbpBsZf1DLeG

---
_Generated by [Claude Code](https://claude.ai/code/session_01WiTxPixVaWVbpBsZf1DLeG)_