### PR TITLE
fix(nix): detect nix at known locations, not just $PATH (#2787)

### DIFF
--- a/internal/nix/install.go
+++ b/internal/nix/install.go
@@ -16,13 +16,18 @@ import (
 	"github.com/mattn/go-isatty"
 
 	"go.jetify.com/devbox/internal/boxcli/usererr"
-	"go.jetify.com/devbox/internal/cmdutil"
 	"go.jetify.com/devbox/internal/fileutil"
 	"go.jetify.com/devbox/nix"
 )
 
 func BinaryInstalled() bool {
-	return cmdutil.Exists("nix")
+	// Use the same resolver that Devbox uses to run nix commands (searching
+	// $PATH and well-known install locations), rather than a bare $PATH lookup.
+	// Otherwise Devbox can wrongly report nix as missing when it exists at a
+	// known location but isn't on $PATH — e.g. on NixOS, or when a non-POSIX
+	// login shell such as fish hasn't sourced the Nix profile (issue #2787).
+	_, err := nix.Default.LookPath()
+	return err == nil
 }
 
 func dirExistsAndIsNotEmpty(dir string) bool {

--- a/nix/nix.go
+++ b/nix/nix.go
@@ -34,6 +34,11 @@ func System() string {
 	return Default.System()
 }
 
+// LookPath calls [Nix.LookPath] on the default Nix installation.
+func LookPath() (string, error) {
+	return Default.LookPath()
+}
+
 // Version calls [Nix.Version] on the default Nix installation.
 func Version() string {
 	return Default.Version()
@@ -88,22 +93,44 @@ func (n *Nix) resolvePath() (string, error) {
 		return path, nil
 	}
 
-	try := []string{
-		"/nix/var/nix/profiles/default/bin/nix",
-		"/run/current-system/sw/bin",
-	}
-	for _, path := range try {
+	for _, path := range nixBinaryFallbackPaths() {
 		stat, err := os.Stat(path)
-		if err == nil {
-			// Is it executable and not a directory?
-			m := stat.Mode()
-			if !m.IsDir() && m.Perm()&0o111 != 0 {
-				n.lookPath.Store(&path)
-				return path, nil
-			}
+		if err != nil {
+			continue
+		}
+		// Is it an executable file (and not a directory)?
+		m := stat.Mode()
+		if !m.IsDir() && m.Perm()&0o111 != 0 {
+			n.lookPath.Store(&path)
+			return path, nil
 		}
 	}
 	return "", pathErr
+}
+
+// LookPath returns the absolute path to the nix executable. It searches $PATH
+// (after attempting to source the Nix profile) and, failing that, the
+// well-known installation locations in [nixBinaryFallbackPaths]. It returns an
+// error if nix cannot be found.
+//
+// Because Devbox invokes nix by absolute path, a non-error result here means
+// nix commands will run even when nix is not on $PATH — which happens, for
+// example, when the login shell has not sourced the Nix profile (common with
+// non-POSIX shells such as fish).
+func (n *Nix) LookPath() (string, error) {
+	return n.resolvePath()
+}
+
+// nixBinaryFallbackPaths returns well-known absolute paths to the nix
+// executable, searched in order when nix is not found on $PATH. Each entry must
+// point at the nix binary itself, not the directory that contains it.
+func nixBinaryFallbackPaths() []string {
+	return []string{
+		"/nix/var/nix/profiles/default/bin/nix",
+		// On NixOS, nix is provided through the current system profile rather
+		// than /nix/var/nix/profiles/default.
+		"/run/current-system/sw/bin/nix",
+	}
 }
 
 func (n *Nix) logger() *slog.Logger {

--- a/nix/nix_test.go
+++ b/nix/nix_test.go
@@ -2,6 +2,7 @@
 package nix
 
 import (
+	"path/filepath"
 	"slices"
 	"testing"
 )
@@ -203,4 +204,26 @@ func TestVersionInfoAtLeast(t *testing.T) {
 		}()
 		info.AtLeast(v)
 	})
+}
+
+func TestNixBinaryFallbackPaths(t *testing.T) {
+	paths := nixBinaryFallbackPaths()
+	if len(paths) == 0 {
+		t.Fatal("expected at least one fallback path")
+	}
+	// Every fallback must point at the nix binary itself, not a directory that
+	// contains it. resolvePath rejects directories, so a bare bin dir here
+	// would silently never match (regression guard for issue #2787).
+	for _, p := range paths {
+		if filepath.Base(p) != "nix" {
+			t.Errorf("fallback path %q must end in the nix binary, got base %q", p, filepath.Base(p))
+		}
+		if !filepath.IsAbs(p) {
+			t.Errorf("fallback path %q must be absolute", p)
+		}
+	}
+	// The NixOS system-profile location must be covered.
+	if !slices.Contains(paths, "/run/current-system/sw/bin/nix") {
+		t.Errorf("expected NixOS system-profile nix path in fallbacks, got %v", paths)
+	}
 }


### PR DESCRIPTION
## Summary

Fixes #2787.

Users on setups where nix is installed but not on the interactive shell's `$PATH` — notably **NixOS**, and shells that don't source the Nix profile the way devbox expects (e.g. **fish**) — hit this even though nix is present and working:

```
Error: We found a /nix directory but nix binary is not in your PATH and we were not able to find it in the usual locations. Your nix installation might be broken.
```

The root cause is that devbox used **two different mechanisms** to find nix:

- To *run* nix commands, `nix.(*Nix).resolvePath()` searches `$PATH` and then falls back to well-known install locations, invoking nix by **absolute path**. This works even when nix isn't on `$PATH`.
- To *detect* whether nix is installed, `BinaryInstalled()` used a bare `exec.LookPath("nix")` — a `$PATH`-only check.

So detection could report nix as missing and abort in `EnsureNixInstalled`, even though devbox would have been perfectly able to run nix by absolute path.

On top of that, `resolvePath`'s fallback list had a latent bug: the NixOS entry was the bin **directory** `/run/current-system/sw/bin`, but the loop only accepts a path that is a non-directory executable — so that entry could never match, and the NixOS system-profile location was effectively never searched.

## Fix

- `internal/nix/install.go`: `BinaryInstalled()` now uses the same resolver that runs nix commands, via a new exported `nix.(*Nix).LookPath` / `nix.LookPath`. Detection and execution can no longer disagree.
- `nix/nix.go`: fix the fallback list so the NixOS entry points at the nix **binary** (`/run/current-system/sw/bin/nix`), and extract the list into `nixBinaryFallbackPaths()`.
- The happy path is unchanged: nix on `$PATH` is still found first; behavior only differs when nix is off-`$PATH` but present at a known location, where devbox now proceeds instead of erroring.

## How was it tested?

- `go build ./nix/... ./internal/nix/... ./internal/boxcli/...` passes.
- `go test ./nix/...` passes, including a new `TestNixBinaryFallbackPaths` regression test asserting every fallback entry is an absolute path to the nix binary (guarding against the directory-vs-binary bug) and that the NixOS system-profile path is covered.
- `go test ./internal/nix/...`: the added/affected tests pass. (`TestConfigIsUserTrusted` fails in this sandbox only because it shells out to a real `nix`, which isn't installed here — it fails identically on the unchanged base branch and is unrelated to this change.)

cc @simulatedcode (issue reporter)

## Community Contribution License

All community contributions in this pull request are licensed to the project
maintainers under the terms of the
[Apache 2 License](https://www.apache.org/licenses/LICENSE-2.0).

By creating this pull request, I represent that I have the right to license the
contributions to the project maintainers under the Apache 2 License as stated in
the
[Community Contribution License](https://github.com/jetify-com/opensource/blob/main/CONTRIBUTING.md#community-contribution-license).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BXJuDH6keqvU1ydywuyizq

---
_Generated by [Claude Code](https://claude.ai/code/session_01BXJuDH6keqvU1ydywuyizq)_