### PR TITLE
fix(shellenv): preserve newlines in exported env values (ambiguous redirect)

### DIFF
--- a/internal/devbox/envvars.go
+++ b/internal/devbox/envvars.go
@@ -89,8 +89,8 @@ func exportify(w io.Writer, vars map[string]string) string {
 			strb.WriteString("export ")
 			strb.WriteString(key)
 			strb.WriteString(`="`)
-			for _, r := range vars[key] {
-				switch r {
+			for _, char := range vars[key] {
+				switch char {
 				// Special characters inside double quotes:
 				// https://pubs.opengroup.org/onlinepubs/009604499/utilities/xcu_chap02.html#tag_02_02_03
 				//
@@ -103,7 +103,7 @@ func exportify(w io.Writer, vars map[string]string) string {
 				case '$', '`', '"', '\\':
 					strb.WriteRune('\\')
 				}
-				strb.WriteRune(r)
+				strb.WriteRune(char)
 			}
 			strb.WriteString("\";\n")
 		}

--- a/internal/devbox/envvars.go
+++ b/internal/devbox/envvars.go
@@ -93,7 +93,14 @@ func exportify(w io.Writer, vars map[string]string) string {
 				switch r {
 				// Special characters inside double quotes:
 				// https://pubs.opengroup.org/onlinepubs/009604499/utilities/xcu_chap02.html#tag_02_02_03
-				case '$', '`', '"', '\\', '\n':
+				//
+				// Note: a literal newline is NOT escaped. Inside double quotes
+				// a bare newline is preserved verbatim, whereas a backslash
+				// immediately followed by a newline is a line continuation that
+				// the shell deletes. Escaping it would join a multi-line value's
+				// adjacent lines and corrupt values like a multi-command
+				// PROMPT_COMMAND (see jetify-com/devbox#2814).
+				case '$', '`', '"', '\\':
 					strb.WriteRune('\\')
 				}
 				strb.WriteRune(r)

--- a/internal/devbox/envvars_test.go
+++ b/internal/devbox/envvars_test.go
@@ -47,6 +47,27 @@ func TestExportifySkipsInvalidNames(t *testing.T) {
 	}
 }
 
+// TestExportifyPreservesNewlines ensures that multi-line values (e.g. a
+// PROMPT_COMMAND made of several commands separated by newlines) are emitted so
+// that the shell preserves the newlines. A backslash before a newline would be a
+// line continuation that the shell deletes, joining adjacent lines and corrupting
+// the value (see jetify-com/devbox#2814).
+func TestExportifyPreservesNewlines(t *testing.T) {
+	value := "__bp_precmd_invoke_cmd\ndbus-send ... >/dev/null 2>&1\n__bp_interactive_mode"
+	got := exportify(io.Discard, map[string]string{"PROMPT_COMMAND": value})
+
+	// The emitted value must contain a bare newline, not an escaped one. If the
+	// newline were escaped, "2>&1\" and "__bp_interactive_mode" would collapse
+	// into "2>&1__bp_interactive_mode" when the shell sourced the export.
+	if strings.Contains(got, "\\\n") {
+		t.Errorf("newline should not be backslash-escaped, got:\n%q", got)
+	}
+	want := "export PROMPT_COMMAND=\"" + value + "\";"
+	if !strings.Contains(got, want) {
+		t.Errorf("expected exported value to preserve newlines.\ngot:\n%q\nwant to contain:\n%q", got, want)
+	}
+}
+
 func TestExportifyNushellSkipsInvalidNames(t *testing.T) {
 	got := exportifyNushell(io.Discard, map[string]string{
 		"GOOD": "value",


### PR DESCRIPTION
## Summary

Fixes #2814.

`eval "$(devbox global shellenv)"` printed `bash: 1__bp_interactive_mode: ambiguous redirect` at every prompt when the user's environment carried a multi-line `PROMPT_COMMAND` (e.g. the bash-preexec value some terminals set).

**Root cause:** `exportify` in `internal/devbox/envvars.go` escaped literal newlines in a value as `\` followed by a newline. Inside a double-quoted shell string that sequence is a **line continuation**, which the shell deletes — joining the value's adjacent lines. A line ending in `2>&1` collapsed into the following command `__bp_interactive_mode`, producing `2>&1__bp_interactive_mode`, which bash parses as a redirect to the file `1__bp_interactive_mode` → "ambiguous redirect".

A bare newline inside double quotes is already preserved verbatim, so the escape was both unnecessary and the source of the corruption. The fix drops the backslash escape for `\n`; the other special characters (`$`, `` ` ``, `"`, `\`) are still escaped.

```
# before (buggy):  export PC="... 2>&1\<newline>__bp_interactive_mode";  -> value: "... 2>&1__bp_interactive_mode"
# after  (fixed):  export PC="... 2>&1<newline>__bp_interactive_mode";   -> value preserves the newline
```

## How was it tested?

- Added `TestExportifyPreservesNewlines` asserting the emitted export contains a bare (not backslash-escaped) newline and preserves the multi-line value. Existing `exportify` tests still pass.
- Reproduced the shell behavior directly: sourcing the previous output collapsed the two lines (`... 2>&1__bp_interactive_mode`); sourcing the fixed output keeps them as separate commands.
- `go build` / `go vet` on `internal/devbox` are clean.

## Community Contribution License

All community contributions in this pull request are licensed to the project
maintainers under the terms of the
[Apache 2 License](https://www.apache.org/licenses/LICENSE-2.0).

By creating this pull request, I represent that I have the right to license the
contributions to the project maintainers under the Apache 2 License as stated in
the
[Community Contribution License](https://github.com/jetify-com/opensource/blob/main/CONTRIBUTING.md#community-contribution-license).

---

cc @proedie (issue reporter)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XMi8bm4fhxGAdxSCt5YJY3

---
_Generated by [Claude Code](https://claude.ai/code/session_01XMi8bm4fhxGAdxSCt5YJY3)_