### PR TITLE
fix(nix): honor NIXPKGS_ALLOW_UNFREE/INSECURE in print-dev-env

### DIFF
--- a/internal/devbox/devbox.go
+++ b/internal/devbox/devbox.go
@@ -629,10 +629,19 @@ func (d *Devbox) execPrintDevEnv(ctx context.Context, usePrintDevEnvCache bool) 
 		spinny.Start()
 	}
 
+	// Allow unfree/insecure packages to evaluate when the user opts in via
+	// devbox.json's "env" (the process environment is handled separately
+	// inside PrintDevEnv). See https://github.com/jetify-com/devbox/issues/2196.
+	configEnv := d.cfg.Env()
+	allowUnfree, _ := strconv.ParseBool(configEnv["NIXPKGS_ALLOW_UNFREE"])
+	allowInsecure, _ := strconv.ParseBool(configEnv["NIXPKGS_ALLOW_INSECURE"])
+
 	vaf, err := d.nix.PrintDevEnv(ctx, &nix.PrintDevEnvArgs{
 		FlakeDir:             d.flakeDir(),
 		PrintDevEnvCachePath: d.nixPrintDevEnvCachePath(),
 		UsePrintDevEnvCache:  usePrintDevEnvCache,
+		AllowUnfree:          allowUnfree,
+		AllowInsecure:        allowInsecure,
 	})
 	if spinny != nil {
 		spinny.Stop()

--- a/internal/nix/eval.go
+++ b/internal/nix/eval.go
@@ -59,3 +59,10 @@ func IsInsecureAllowed() bool {
 	allowed, _ := strconv.ParseBool(os.Getenv("NIXPKGS_ALLOW_INSECURE"))
 	return allowed
 }
+
+// IsUnfreeAllowed reports whether the user has opted into unfree packages by
+// setting the NIXPKGS_ALLOW_UNFREE environment variable to a truthy value.
+func IsUnfreeAllowed() bool {
+	allowed, _ := strconv.ParseBool(os.Getenv("NIXPKGS_ALLOW_UNFREE"))
+	return allowed
+}

--- a/internal/nix/nix.go
+++ b/internal/nix/nix.go
@@ -45,6 +45,13 @@ type PrintDevEnvArgs struct {
 	FlakeDir             string
 	PrintDevEnvCachePath string
 	UsePrintDevEnvCache  bool
+
+	// AllowUnfree and AllowInsecure report whether the user has opted into
+	// unfree or insecure packages through the resolved devbox config (for
+	// example via NIXPKGS_ALLOW_UNFREE in devbox.json's "env"). They are in
+	// addition to the same variables read from the process environment.
+	AllowUnfree   bool
+	AllowInsecure bool
 }
 
 // PrintDevEnv calls `nix print-dev-env -f <path>` and returns its output. The output contains
@@ -75,10 +82,27 @@ func (*NixInstance) PrintDevEnv(ctx context.Context, args *PrintDevEnvArgs) (*Pr
 	ref := flake.Ref{Type: flake.TypePath, Path: flakeDirResolved}
 
 	if len(data) == 0 {
+		// Honor unfree/insecure opt-in from either the process environment
+		// or the resolved devbox config.
+		allowUnfree := args.AllowUnfree || IsUnfreeAllowed()
+		allowInsecure := args.AllowInsecure || IsInsecureAllowed()
+
 		cmd := Command("print-dev-env", "--json")
-		if usePrintDevEnvImpure() {
+		if usePrintDevEnvImpure(allowUnfree, allowInsecure) {
 			cmd.Args = append(cmd.Args, "--impure")
-			cmd.Env = allowUnfreeEnv(allowInsecureEnv(os.Environ()))
+			// Only inject the allow-* variables the user actually opted
+			// into. When impure mode is enabled solely via the feature
+			// flag, cmd.Env is left inheriting the parent environment.
+			if allowUnfree || allowInsecure {
+				env := os.Environ()
+				if allowUnfree {
+					env = allowUnfreeEnv(env)
+				}
+				if allowInsecure {
+					env = allowInsecureEnv(env)
+				}
+				cmd.Env = env
+			}
 		}
 		cmd.Args = append(cmd.Args, ref)
 		slog.Debug("running print-dev-env cmd", "cmd", cmd)
@@ -109,10 +133,8 @@ func (*NixInstance) PrintDevEnv(ctx context.Context, args *PrintDevEnvArgs) (*Pr
 // when building and installing packages. Pure mode is kept otherwise because
 // --impure disables Nix's evaluation caching, which makes the command slower.
 // See https://github.com/jetify-com/devbox/issues/2196.
-func usePrintDevEnvImpure() bool {
-	return featureflag.ImpurePrintDevEnv.Enabled() ||
-		IsUnfreeAllowed() ||
-		IsInsecureAllowed()
+func usePrintDevEnvImpure(allowUnfree, allowInsecure bool) bool {
+	return featureflag.ImpurePrintDevEnv.Enabled() || allowUnfree || allowInsecure
 }
 
 func savePrintDevEnvCache(path string, out PrintDevEnvOut) error {

--- a/internal/nix/nix.go
+++ b/internal/nix/nix.go
@@ -76,8 +76,9 @@ func (*NixInstance) PrintDevEnv(ctx context.Context, args *PrintDevEnvArgs) (*Pr
 
 	if len(data) == 0 {
 		cmd := Command("print-dev-env", "--json")
-		if featureflag.ImpurePrintDevEnv.Enabled() {
+		if usePrintDevEnvImpure() {
 			cmd.Args = append(cmd.Args, "--impure")
+			cmd.Env = allowUnfreeEnv(allowInsecureEnv(os.Environ()))
 		}
 		cmd.Args = append(cmd.Args, ref)
 		slog.Debug("running print-dev-env cmd", "cmd", cmd)
@@ -98,6 +99,20 @@ func (*NixInstance) PrintDevEnv(ctx context.Context, args *PrintDevEnvArgs) (*Pr
 	}
 
 	return &out, nil
+}
+
+// usePrintDevEnvImpure reports whether `nix print-dev-env` should be run with
+// the --impure flag. By default print-dev-env runs in pure mode, which ignores
+// the NIXPKGS_ALLOW_UNFREE and NIXPKGS_ALLOW_INSECURE environment variables.
+// When the user has opted into unfree or insecure packages, we run with
+// --impure so those variables take effect, matching what devbox already does
+// when building and installing packages. Pure mode is kept otherwise because
+// --impure disables Nix's evaluation caching, which makes the command slower.
+// See https://github.com/jetify-com/devbox/issues/2196.
+func usePrintDevEnvImpure() bool {
+	return featureflag.ImpurePrintDevEnv.Enabled() ||
+		IsUnfreeAllowed() ||
+		IsInsecureAllowed()
 }
 
 func savePrintDevEnvCache(path string, out PrintDevEnvOut) error {

--- a/internal/nix/nix_test.go
+++ b/internal/nix/nix_test.go
@@ -4,6 +4,52 @@ import (
 	"testing"
 )
 
+func TestIsUnfreeAllowed(t *testing.T) {
+	cases := map[string]bool{
+		"":      false,
+		"0":     false,
+		"false": false,
+		"1":     true,
+		"true":  true,
+	}
+	for value, want := range cases {
+		t.Run(value, func(t *testing.T) {
+			t.Setenv("NIXPKGS_ALLOW_UNFREE", value)
+			if got := IsUnfreeAllowed(); got != want {
+				t.Errorf("IsUnfreeAllowed() with NIXPKGS_ALLOW_UNFREE=%q = %v, want %v", value, got, want)
+			}
+		})
+	}
+}
+
+// TestUsePrintDevEnvImpure verifies the fix for
+// https://github.com/jetify-com/devbox/issues/2196: print-dev-env must run
+// with --impure whenever the user opts into unfree or insecure packages so
+// those environment variables are honored.
+func TestUsePrintDevEnvImpure(t *testing.T) {
+	cases := []struct {
+		name   string
+		unfree string
+		insec  string
+		want   bool
+	}{
+		{name: "neither set", want: false},
+		{name: "unfree disabled", unfree: "0", want: false},
+		{name: "unfree allowed", unfree: "1", want: true},
+		{name: "insecure allowed", insec: "true", want: true},
+		{name: "both allowed", unfree: "1", insec: "1", want: true},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("NIXPKGS_ALLOW_UNFREE", tt.unfree)
+			t.Setenv("NIXPKGS_ALLOW_INSECURE", tt.insec)
+			if got := usePrintDevEnvImpure(); got != tt.want {
+				t.Errorf("usePrintDevEnvImpure() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestParseInsecurePackagesFromExitError(t *testing.T) {
 	errorText := `
   at /nix/store/xwl0am98klc8mz074jdyvpnyc6vwzlla-source/lib/customisation.nix:267:17:

--- a/internal/nix/nix_test.go
+++ b/internal/nix/nix_test.go
@@ -28,25 +28,35 @@ func TestIsUnfreeAllowed(t *testing.T) {
 // those environment variables are honored.
 func TestUsePrintDevEnvImpure(t *testing.T) {
 	cases := []struct {
-		name   string
-		unfree string
-		insec  string
-		want   bool
+		name          string
+		allowUnfree   bool
+		allowInsecure bool
+		want          bool
 	}{
-		{name: "neither set", want: false},
-		{name: "unfree disabled", unfree: "0", want: false},
-		{name: "unfree allowed", unfree: "1", want: true},
-		{name: "insecure allowed", insec: "true", want: true},
-		{name: "both allowed", unfree: "1", insec: "1", want: true},
+		{name: "neither opted in", want: false},
+		{name: "unfree opted in", allowUnfree: true, want: true},
+		{name: "insecure opted in", allowInsecure: true, want: true},
+		{name: "both opted in", allowUnfree: true, allowInsecure: true, want: true},
 	}
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
-			t.Setenv("NIXPKGS_ALLOW_UNFREE", tt.unfree)
-			t.Setenv("NIXPKGS_ALLOW_INSECURE", tt.insec)
-			if got := usePrintDevEnvImpure(); got != tt.want {
-				t.Errorf("usePrintDevEnvImpure() = %v, want %v", got, tt.want)
+			// Keep the result independent of any ambient feature-flag env.
+			t.Setenv("DEVBOX_FEATURE_IMPURE_PRINT_DEV_ENV", "0")
+			if got := usePrintDevEnvImpure(tt.allowUnfree, tt.allowInsecure); got != tt.want {
+				t.Errorf("usePrintDevEnvImpure(%v, %v) = %v, want %v",
+					tt.allowUnfree, tt.allowInsecure, got, tt.want)
 			}
 		})
+	}
+}
+
+// TestUsePrintDevEnvImpureFeatureFlag verifies that the IMPURE_PRINT_DEV_ENV
+// feature flag forces impure mode even when the user hasn't opted into unfree
+// or insecure packages.
+func TestUsePrintDevEnvImpureFeatureFlag(t *testing.T) {
+	t.Setenv("DEVBOX_FEATURE_IMPURE_PRINT_DEV_ENV", "1")
+	if !usePrintDevEnvImpure(false, false) {
+		t.Error("usePrintDevEnvImpure(false, false) = false with feature flag set, want true")
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes #2196.

`devbox shell` computes its environment with `nix print-dev-env`, which runs in **pure mode** by default. Pure mode ignores the `NIXPKGS_ALLOW_UNFREE` and `NIXPKGS_ALLOW_INSECURE` environment variables, so unfree (or insecure) flake inputs fail to evaluate inside a devbox shell — even when the user runs `NIXPKGS_ALLOW_UNFREE=1 devbox shell` or sets it in `devbox.json`'s `env`.

This is inconsistent with the rest of devbox: building and installing packages (`internal/nix/build.go`, `profiles.go`, `cache.go`, `store.go`) already pass `--impure` together with the allow-unfree/insecure env, so those flows work. Only `print-dev-env` was left pure — gated behind the `IMPURE_PRINT_DEV_ENV` feature flag, which is disabled by default because `--impure` disables Nix's evaluation caching and makes the command slower.

## Fix

Run `print-dev-env` with `--impure` (and the corresponding allow-unfree / allow-insecure environment) **when the user has actually opted into unfree or insecure packages** via `NIXPKGS_ALLOW_UNFREE` / `NIXPKGS_ALLOW_INSECURE`. Pure mode — and its caching benefit — is preserved for everyone else, so there is no performance regression for the common case. The existing `IMPURE_PRINT_DEV_ENV` feature flag still forces impure mode unconditionally.

- **`internal/nix/eval.go`**: add `IsUnfreeAllowed()`, mirroring the existing `IsInsecureAllowed()`.
- **`internal/nix/nix.go`**: extract the impure decision into `usePrintDevEnvImpure()` (feature flag OR unfree opt-in OR insecure opt-in) and, when impure, set `cmd.Env` with the allow-unfree/insecure vars, matching the other Nix call sites.
- **`internal/nix/nix_test.go`**: unit tests for `IsUnfreeAllowed` and `usePrintDevEnvImpure` across the env-var combinations.

## How was it tested?

- `go test ./internal/nix/ -run 'TestIsUnfreeAllowed|TestUsePrintDevEnvImpure'` — passes.
- `go build ./...` and `go vet ./internal/nix/` — clean.
- (The only failing tests in the package, `TestConfigIsUserTrusted`, require a real `nix` binary that isn't present in the CI sandbox and are unrelated to this change.)

## Community Contribution License

All community contributions in this pull request are licensed to the project
maintainers under the terms of the
[Apache 2 License](https://www.apache.org/licenses/LICENSE-2.0).

By creating this pull request, I represent that I have the right to license the
contributions to the project maintainers under the Apache 2 License as stated in
the
[Community Contribution License](https://github.com/jetify-com/opensource/blob/main/CONTRIBUTING.md#community-contribution-license).

---

cc @eyevanovich (issue reporter)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KJZ8U5cYG5xLc4caCHt9jg

---
_Generated by [Claude Code](https://claude.ai/code/session_01KJZ8U5cYG5xLc4caCHt9jg)_