### PR TITLE
fix(config): preserve multiple outputs from the same remote flake

### DIFF
--- a/internal/devconfig/config.go
+++ b/internal/devconfig/config.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 	"syscall"
 	"time"
 
@@ -334,15 +335,37 @@ func (c *Config) Packages(
 		}
 	}
 
-	// Keep only the last occurrence of each package (by name).
+	// Keep only the last occurrence of each package. Plain packages are
+	// deduped by name so that a later "pkg@v2" replaces an earlier
+	// "pkg@v1". Flake references, however, can install several distinct
+	// outputs from the same flake via a "#fragment" (for example
+	// "git+https://host/repo.git#toolA" and "...#toolB"). Once parsed those
+	// share a name (and for URLs containing "user@host" the name is even
+	// truncated to the part before the "@"), so keying on name alone
+	// collapses them into a single package. Key such references on their
+	// full reference so each output is preserved. See jetify-com/devbox#2662.
 	mutable.Reverse(packages)
 	packages = lo.UniqBy(
 		packages,
-		func(p configfile.Package) string { return p.Name },
+		func(p configfile.Package) string {
+			if ref := p.VersionedName(); isFlakeReference(ref) {
+				return ref
+			}
+			return p.Name
+		},
 	)
 	mutable.Reverse(packages)
 
 	return packages
+}
+
+// isFlakeReference reports whether ref looks like a flake installable rather
+// than a plain "name@version" package. Flake references contain a URL scheme
+// separator ("://") or an output fragment ("#"); plain package versions never
+// do. Such references may point at distinct outputs of the same flake, so they
+// must not be collapsed by package name.
+func isFlakeReference(ref string) bool {
+	return strings.Contains(ref, "://") || strings.Contains(ref, "#")
 }
 
 func (c *Config) NixPkgsCommitHash() string {

--- a/internal/devconfig/config_test.go
+++ b/internal/devconfig/config_test.go
@@ -560,6 +560,63 @@ func TestLoadRecursiveMultipleBuiltinPluginIncludes(t *testing.T) {
 	}
 }
 
+// TestPackagesPreservesMultipleFlakeOutputs is a regression test for
+// jetify-com/devbox#2662: adding two outputs from the same remote flake used to
+// drop the first one. Both outputs are parsed with the same package Name (the
+// "#fragment" that distinguishes them, and part of the "user@host" URL, is
+// parsed into the version), so deduping by Name alone collapsed them.
+func TestPackagesPreservesMultipleFlakeOutputs(t *testing.T) {
+	cfg, err := loadBytes([]byte(`{
+		"packages": [
+			"kubectl@latest",
+			"git+http://git@example.com/group/utils.git#kubeupdate",
+			"git+http://git@example.com/group/utils.git#getcrds"
+		]
+	}`))
+	if err != nil {
+		t.Fatalf("loadBytes error: %v", err)
+	}
+
+	got := map[string]bool{}
+	for _, pkg := range cfg.Packages(false /*includeRemovedTriggerPackages*/) {
+		got[pkg.VersionedName()] = true
+	}
+
+	want := []string{
+		"kubectl@latest",
+		"git+http://git@example.com/group/utils.git#kubeupdate",
+		"git+http://git@example.com/group/utils.git#getcrds",
+	}
+	for _, name := range want {
+		if !got[name] {
+			t.Errorf("Packages() dropped %q; got %v", name, got)
+		}
+	}
+	if len(got) != len(want) {
+		t.Errorf("Packages() returned %d packages, want %d: %v", len(got), len(want), got)
+	}
+}
+
+// TestPackagesDedupesByNameForPlainPackages verifies that the flake-aware
+// dedup key preserves the original "last version wins" behavior for plain
+// (non-flake) packages.
+func TestPackagesDedupesByNameForPlainPackages(t *testing.T) {
+	cfg, err := loadBytes([]byte(`{
+		"packages": ["python@3.10", "python@3.11"]
+	}`))
+	if err != nil {
+		t.Fatalf("loadBytes error: %v", err)
+	}
+
+	pkgs := cfg.Packages(false /*includeRemovedTriggerPackages*/)
+	if len(pkgs) != 1 {
+		t.Fatalf("Packages() returned %d packages, want 1: %v", len(pkgs), pkgs)
+	}
+	if got := pkgs[0].VersionedName(); got != "python@3.11" {
+		t.Errorf("Packages() kept %q, want the last occurrence \"python@3.11\"", got)
+	}
+}
+
 // testLockProject satisfies the unexported lock.devboxProject interface for tests.
 type testLockProject struct {
 	dir string

--- a/internal/devconfig/config_test.go
+++ b/internal/devconfig/config_test.go
@@ -577,9 +577,10 @@ func TestPackagesPreservesMultipleFlakeOutputs(t *testing.T) {
 		t.Fatalf("loadBytes error: %v", err)
 	}
 
-	got := map[string]bool{}
-	for _, pkg := range cfg.Packages(false /*includeRemovedTriggerPackages*/) {
-		got[pkg.VersionedName()] = true
+	pkgs := cfg.Packages(false /*includeRemovedTriggerPackages*/)
+	counts := map[string]int{}
+	for _, pkg := range pkgs {
+		counts[pkg.VersionedName()]++
 	}
 
 	want := []string{
@@ -588,12 +589,18 @@ func TestPackagesPreservesMultipleFlakeOutputs(t *testing.T) {
 		"git+http://git@example.com/group/utils.git#getcrds",
 	}
 	for _, name := range want {
-		if !got[name] {
-			t.Errorf("Packages() dropped %q; got %v", name, got)
+		switch counts[name] {
+		case 0:
+			t.Errorf("Packages() dropped %q; got %v", name, pkgs)
+		case 1: // expected
+		default:
+			t.Errorf("Packages() returned %q %d times, want exactly once", name, counts[name])
 		}
 	}
-	if len(got) != len(want) {
-		t.Errorf("Packages() returned %d packages, want %d: %v", len(got), len(want), got)
+	// Assert on the slice length (not the deduped map) so an accidental
+	// regression that returns duplicates is also caught.
+	if len(pkgs) != len(want) {
+		t.Errorf("Packages() returned %d packages, want %d: %v", len(pkgs), len(want), pkgs)
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes #2662.

Adding two outputs from the **same** remote flake dropped the first one:

```jsonc
"packages": [
  "git+http://git@company.gitlab.com/group/utils.git#kubeupdate",
  "git+http://git@company.gitlab.com/group/utils.git#getcrds"
]
```

After adding `#getcrds`, `kubeupdate` disappeared from the environment (only the
last-added output survived).

### Root cause

`Config.Packages` (`internal/devconfig/config.go`) dedupes the package list with
`lo.UniqBy` keyed on `Package.Name`, keeping only the last occurrence per name so
that a later `pkg@v2` replaces an earlier `pkg@v1`.

For flake references that key is **not unique per output**. Package strings are
split on their *last* `@` (`searcher.ParseVersionedPackage`), so:

- the `#fragment` that distinguishes the outputs is parsed into the *version*, and
- for a URL containing `user@host` (here `git@company.gitlab.com`), the `Name` is
  truncated to the part before the `@` — `git+http://git`.

So both outputs parse to the **same** `Name` (`git+http://git`) and collapse into a
single package, dropping the first.

### Fix

Key the dedup on the **full reference** (which includes the `#fragment`) when the
package looks like a flake installable — detected by a `://` scheme separator or a
`#` output fragment — and keep deduping plain packages by name so the existing
"last version wins" behavior for `pkg@v1` / `pkg@v2` is unchanged.

## How was it tested?

- `go build ./...` — clean.
- `go vet ./internal/devconfig/` — clean; `gofmt` reports no changes.
- New unit tests in `internal/devconfig/config_test.go`:
  - `TestPackagesPreservesMultipleFlakeOutputs` — two `#`-fragment outputs from the
    same `git+http://git@host/...` flake are both retained (fails before this change,
    passes after).
  - `TestPackagesDedupesByNameForPlainPackages` — `python@3.10` + `python@3.11` still
    dedupe to the last occurrence (`python@3.11`), confirming the plain-package
    behavior is preserved.
- `go test ./internal/devconfig/...` passes for the changed code. Two pre-existing
  `TestFindError/*Permissions` cases fail in this environment because it runs as
  root (a `chmod 0o000` file is still readable), independent of this change — they
  fail identically on `main`.

> Note: the end-to-end `devbox add`/`devbox shell` flow needs `nix`, which wasn't
> available in the authoring environment; the unit tests exercise the exact dedup
> logic that was dropping the flake output.

cc @jDmacD (issue reporter) — thanks for the clear, step-by-step reproduction.

## Community Contribution License

All community contributions in this pull request are licensed to the project
maintainers under the terms of the
[Apache 2 License](https://www.apache.org/licenses/LICENSE-2.0).

By creating this pull request, I represent that I have the right to license the
contributions to the project maintainers under the Apache 2 License as stated in
the
[Community Contribution License](https://github.com/jetify-com/opensource/blob/main/CONTRIBUTING.md#community-contribution-license).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qk7hyZKVoiy6CrUdA6XknT

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qk7hyZKVoiy6CrUdA6XknT)_