### PR TITLE
fix: redirect process-compose internal log to .devbox/process-compose.log (#2961)

### DIFF
--- a/internal/services/manager.go
+++ b/internal/services/manager.go
@@ -23,8 +23,9 @@ import (
 )
 
 const (
-	processComposeLogfile = ".devbox/compose.log"
-	fileLockTimeout       = 5 * time.Second
+	processComposeLogfile         = ".devbox/compose.log"
+	processComposeInternalLogfile = ".devbox/process-compose.log"
+	fileLockTimeout               = 5 * time.Second
 )
 
 type instance struct {
@@ -135,7 +136,7 @@ func StartProcessManager(
 	}
 
 	// Start building the process-compose command
-	flags := []string{"-p", strconv.Itoa(port)}
+	flags := []string{"-p", strconv.Itoa(port), "--log-file", filepath.Join(projectDir, processComposeInternalLogfile)}
 	upCommand := []string{"up"}
 
 	if len(requestedServices) > 0 {


### PR DESCRIPTION
## Summary

Devbox invokes `process-compose` under the covers, and by default process-compose writes a log file to `/tmp/process-compose-$USER.log` file.

This log file is full of useful info for people debugging services! It deserves a better place than `/tmp`.

This PR passes a `--log-file` arg process-compose, so the log file is written to `.devbox/process-compose.log`.

## How was it tested?

```bash
cat > /tmp/pclog.sh <<'EOF'
#!/bin/bash -eu

if [[ -d /tmp/pclog ]]; then
        ( cd /tmp/pclog && devbox services down >/dev/null 2>&1 || : )
  rm -r /tmp/pclog
fi
mkdir /tmp/pclog
cd /tmp/pclog
devbox init
cat > process-compose.yml <<'EOF2'
version: "0.5"

processes:

  myapp:
    command: bash -c 'Hello world'; sleep infinity
EOF2
devbox services up -b
sleep 1
cat .devbox/process-compose.log  # Newly relocated log file
EOF
bash /tmp/pclog.sh
```
Previously you'd get a `/tmp/process-compose-$USER.log`. Now you get `.devbox/process-compose.log`, which I'll screenshot because the colours are pretty:

<img width="1098" height="289" alt="image" src="https://github.com/user-attachments/assets/ae593d00-0477-4027-bea6-69dedf95679d" />

Fixes #2961

## Community Contribution License

All community contributions in this pull request are licensed to the project
maintainers under the terms of the
[Apache 2 License](https://www.apache.org/licenses/LICENSE-2.0).

By creating this pull request, I represent that I have the right to license the
contributions to the project maintainers under the Apache 2 License as stated in
the
[Community Contribution License](https://github.com/jetify-com/opensource/blob/main/CONTRIBUTING.md#community-contribution-license).
