### PR TITLE
Add readiness_probe to all service plugins, enabling service dependencies (#2915)

### DIFF
--- a/plugins/apache/process-compose.yaml
+++ b/plugins/apache/process-compose.yaml
@@ -11,6 +11,12 @@ processes:
         condition: process_started
       apache-access:
         condition: process_started
+    readiness_probe:
+      http_get:
+        host: localhost
+        port: ${HTTPD_PORT}
+        path: /
+      initial_delay_seconds: 1
   apache-error:
     command: "tail -f $HTTPD_ERROR_LOG_FILE"
     availability:

--- a/plugins/mariadb/process-compose.yaml
+++ b/plugins/mariadb/process-compose.yaml
@@ -8,6 +8,10 @@ processes:
       command: "mariadb-admin -u root shutdown"
     availability:
       restart: "always"
+    readiness_probe:
+      exec:
+        command: "mariadb-admin ping"
+      initial_delay_seconds: 2
   mariadb_logs:
     command: "tail -f $MYSQL_HOME/mysql.log"
     availability:

--- a/plugins/mysql/process-compose.yaml
+++ b/plugins/mysql/process-compose.yaml
@@ -11,6 +11,10 @@ processes:
     depends_on:
       mysql_logs:
         condition: "process_started"
+    readiness_probe:
+      exec:
+        command: "mysqladmin ping"
+      initial_delay_seconds: 2
   mysql_logs:
     command: "tail -f $MYSQL_HOME/mysql.log"
     availability:

--- a/plugins/nginx/process-compose.yaml
+++ b/plugins/nginx/process-compose.yaml
@@ -8,6 +8,12 @@ processes:
     availability:
       restart: on_failure
       max_restarts: 5
+    readiness_probe:
+      http_get:
+        host: localhost
+        port: ${NGINX_WEB_PORT}
+        path: /
+      initial_delay_seconds: 1
   nginx-error:
     command: "tail -f $NGINX_PATH_PREFIX/error.log"
     availability:

--- a/plugins/postgresql/process-compose.yaml
+++ b/plugins/postgresql/process-compose.yaml
@@ -11,3 +11,4 @@ processes:
     readiness_probe:
       exec:
         command: "pg_isready -p \"${PGPORT:-5432}\""
+      initial_delay_seconds: 2

--- a/plugins/redis/process-compose.yaml
+++ b/plugins/redis/process-compose.yaml
@@ -6,3 +6,6 @@ processes:
     availability:
       restart: on_failure
       max_restarts: 5
+    readiness_probe:
+      exec:
+        command: "redis-cli -p $REDIS_PORT ping"

--- a/plugins/valkey/process-compose.yaml
+++ b/plugins/valkey/process-compose.yaml
@@ -6,3 +6,6 @@ processes:
     availability:
       restart: on_failure
       max_restarts: 5
+    readiness_probe:
+      exec:
+        command: "valkey-cli -p $VALKEY_PORT ping"


### PR DESCRIPTION
## Summary

Adds readiness_probe to mariadb, mysql, redis, valkey (using native CLI
ping commands), and apache, nginx (using http_get probes).  PostgreSQL
already had one (pg_isready).

This enables consumers to use `condition: process_healthy` in their
depends_on configuration, ensuring downstream services do not start
until their dependencies are actually accepting connections.

Fixes (along with https://github.com/jetify-com/devbox/pull/2916) #2915

## How was it tested?

First build a devbox with a working https://github.com/jetify-com/devbox/pull/2909 isolated https://github.com/jetify-com/devbox/pull/2906 mariadb plugin (unless those have been merged), plus this PR:

```sh
cd /tmp
git clone git@github.com:jetify-com/devbox.git devbox-2915
direnv allow /tmp/devbox-2915
cd devbox-2915
git remote add jefft git@github.com:jefft/devbox.git
git fetch jefft
git checkout -b merge-plugin-fixes main
git merge --no-edit jefft/jefft/nginx-plugin-fix-2908
git merge --no-edit jefft/jefft/mysql-plugin-ignore-etc-mysql
git merge --no-edit jefft/jefft/plugin_readiness_probes-fix-2915
devbox run build
```

Then to illustrate scripts waiting for their services to come up:

```bash
cat > /tmp/testhealth.sh <<'EOF'
#!/bin/bash -eu

if [[ -d /tmp/testhealth ]]; then
        ( cd /tmp/testhealth && devbox services down >/dev/null 2>&1 || : )
  rm -r /tmp/testhealth
fi
mkdir /tmp/testhealth
cd /tmp/testhealth

cat > devbox.json <<'EOF2'
{
  "$schema": "https://raw.githubusercontent.com/jetify-com/devbox/main/.schema/devbox.schema.json",
  "packages": [
    "mariadb@latest",
    "apache@latest",
    "nginx@latest",
    "redis@latest",
    "valkey@latest"
  ],
  "env": { 
    "HTTPD_PORT": "11101",
    "NGINX_WEB_PORT": "11102",
    "VALKEY_PORT": "11103"
  },
  "shell": {
    "init_hook": [
      "echo 'Welcome to devbox!' > /dev/null"
    ],
    "scripts": {
      "test": [
        "echo \"Error: no test specified\" && exit 1"
      ]
    }
  }
}
EOF2
devbox services ls   # create devbox.d/* dirs

echo "port = $(( 10000 + RANDOM % 50000))" >> devbox.d/mariadb/my.cnf
cat > my_database_using_app <<'EOF2'
#!/bin/bash
# Connect to MariaDBD via unix socket as root.
sudo mariadb --show-warnings -u root --socket "$MYSQL_UNIX_PORT" -e "select 1;"
EOF2
chmod +x ./my_database_using_app

cat > process-compose.yml <<'EOF2'
version: "0.5"

processes:

  mariadb_tester:
    depends_on:
      mariadb:
        condition: process_healthy
    command: ./my_database_using_app

  apache_tester:
    depends_on:
      apache:
        condition: process_healthy
    command: curl http://localhost:11101

  nginx_tester:
    depends_on:
      nginx:
        condition: process_healthy
    command: curl http://localhost:11102

  valkey_tester:
    depends_on:
      valkey:
        condition: process_healthy
    command: valkey-cli -p $VALKEY_PORT ping

EOF2
which devbox
devbox services up
EOF

# Put our compiled version of devbox ahead of others in PATH
PATH=/tmp/devbox-2915/dist:$PATH bash /tmp/testhealth.sh
```

The `*_tester` dependent services now work, coming up (after a delay) as Completed::

```bash
jturner@jturner-desktop:/tmp/testhealth$ devbox services ls
Services running in process-compose:
PID            NAME                  NAMESPACE        STATUS           AGE        HEALTH        RESTARTS        EXIT CODE
1982981        mariadb_logs          default          Running          5s         -             0               0
1982980        redis                 default          Running          5s         Ready         0               0
1982983        apache                default          Running          5s         Ready         0               0
1982984        apache-access         default          Running          5s         -             0               0
1983151        mariadb_tester        default          Completed        0s         -             0               0
1983126        apache_tester         default          Completed        0s         -             0               0
1983127        valkey_tester         default          Completed        0s         -             0               0
1982982        nginx                 default          Running          5s         Ready         0               0
1982978        nginx-error           default          Running          5s         -             0               0
1982974        nginx-access          default          Running          5s         -             0               0
1982977        valkey                default          Running          5s         Ready         0               0
1982976        apache-error          default          Running          5s         -             0               0
1983125        nginx_tester          default          Completed        0s         -             0               0
1982973        mariadb               default          Running          5s         Ready         0               0
```

[devbox_dependent_services.webm](https://github.com/user-attachments/assets/51e78b8f-a848-4a36-9ac0-2745852f8e4a)


## Community Contribution License

All community contributions in this pull request are licensed to the project
maintainers under the terms of the
[Apache 2 License](https://www.apache.org/licenses/LICENSE-2.0).

By creating this pull request, I represent that I have the right to license the
contributions to the project maintainers under the Apache 2 License as stated in
the
[Community Contribution License](https://github.com/jetify-com/opensource/blob/main/CONTRIBUTING.md#community-contribution-license).
