### PR TITLE
fix(nginx plugin): place mime.types next to nginx.conf so include resolves

### DIFF
--- a/examples/servers/nginx/devbox.d/nginx/mime.types
+++ b/examples/servers/nginx/devbox.d/nginx/mime.types
@@ -1,0 +1,98 @@
+types {
+    text/html                                        html htm shtml;
+    text/css                                         css;
+    text/xml                                         xml;
+    image/gif                                        gif;
+    image/jpeg                                       jpeg jpg;
+    application/javascript                           js;
+    application/atom+xml                             atom;
+    application/rss+xml                              rss;
+
+    text/mathml                                      mml;
+    text/plain                                       txt;
+    text/vnd.sun.j2me.app-descriptor                 jad;
+    text/vnd.wap.wml                                 wml;
+    text/x-component                                 htc;
+
+    image/avif                                       avif;
+    image/png                                        png;
+    image/svg+xml                                    svg svgz;
+    image/tiff                                       tif tiff;
+    image/vnd.wap.wbmp                               wbmp;
+    image/webp                                       webp;
+    image/x-icon                                     ico;
+    image/x-jng                                      jng;
+    image/x-ms-bmp                                   bmp;
+
+    font/woff                                        woff;
+    font/woff2                                       woff2;
+
+    application/java-archive                         jar war ear;
+    application/json                                 json;
+    application/mac-binhex40                         hqx;
+    application/msword                               doc;
+    application/pdf                                  pdf;
+    application/postscript                           ps eps ai;
+    application/rtf                                  rtf;
+    application/vnd.apple.mpegurl                    m3u8;
+    application/vnd.google-earth.kml+xml             kml;
+    application/vnd.google-earth.kmz                 kmz;
+    application/vnd.ms-excel                         xls;
+    application/vnd.ms-fontobject                    eot;
+    application/vnd.ms-powerpoint                    ppt;
+    application/vnd.oasis.opendocument.graphics      odg;
+    application/vnd.oasis.opendocument.presentation  odp;
+    application/vnd.oasis.opendocument.spreadsheet   ods;
+    application/vnd.oasis.opendocument.text          odt;
+    application/vnd.openxmlformats-officedocument.presentationml.presentation
+                                                     pptx;
+    application/vnd.openxmlformats-officedocument.spreadsheetml.sheet
+                                                     xlsx;
+    application/vnd.openxmlformats-officedocument.wordprocessingml.document
+                                                     docx;
+    application/vnd.wap.wmlc                          wmlc;
+    application/wasm                                  wasm;
+    application/x-7z-compressed                       7z;
+    application/x-cocoa                               cco;
+    application/x-java-archive-diff                   jardiff;
+    application/x-java-jnlp-file                       jnlp;
+    application/x-makeself                            run;
+    application/x-perl                                pl pm;
+    application/x-pilot                               prc pdb;
+    application/x-rar-compressed                       rar;
+    application/x-redhat-package-manager              rpm;
+    application/x-sea                                 sea;
+    application/x-shockwave-flash                      swf;
+    application/x-stuffit                             sit;
+    application/x-tcl                                 tcl tk;
+    application/x-x509-ca-cert                        der pem crt;
+    application/x-xpinstall                           xpi;
+    application/xhtml+xml                             xhtml;
+    application/xspf+xml                              xspf;
+    application/zip                                   zip;
+
+    application/octet-stream                          bin exe dll;
+    application/octet-stream                          deb;
+    application/octet-stream                          dmg;
+    application/octet-stream                          iso img;
+    application/octet-stream                          msi msp msm;
+
+    audio/midi                                        mid midi kar;
+    audio/mpeg                                        mp3;
+    audio/ogg                                         ogg;
+    audio/x-m4a                                       m4a;
+    audio/x-realaudio                                 ra;
+
+    video/3gpp                                        3gpp 3gp;
+    video/mp2t                                        ts;
+    video/mp4                                         mp4;
+    video/mpeg                                        mpeg mpg;
+    video/quicktime                                   mov;
+    video/webm                                        webm;
+    video/x-flv                                       flv;
+    video/x-m4v                                       m4v;
+    video/x-mng                                       mng;
+    video/x-ms-asf                                    asx asf;
+    video/x-ms-wmv                                    wmv;
+    video/x-msvideo                                   avi;
+}

--- a/plugins/nginx.json
+++ b/plugins/nginx.json
@@ -1,6 +1,6 @@
 {
   "name": "nginx",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "nginx can be configured with env variables\n\nTo customize:\n* Use $NGINX_CONFDIR to change the configuration directory\n* Use $NGINX_TMPDIR to change the tmp directory. Use $NGINX_USER to change the user\n* Use $NGINX_WEB_PORT to change the port NGINX runs on. \n Note: This plugin uses envsubst when running `devbox services` to generate the nginx.conf file from the nginx.template file. To customize the nginx.conf file, edit the nginx.template file.\n",
   "packages": ["gettext@latest", "gawk@latest"],
   "env": {
@@ -14,7 +14,7 @@
   },
   "create_files": {
     "{{ .Virtenv }}/temp": "",
-    "{{ .Virtenv }}/mime.types": "nginx/mime.types",
+    "{{ .DevboxDir }}/mime.types": "nginx/mime.types",
     "{{ .Virtenv }}/process-compose.yaml": "nginx/process-compose.yaml",
     "{{ .DevboxDir }}/nginx.template": "nginx/nginx.template",
     "{{ .DevboxDir }}/nginx.conf": "nginx/nginx.conf",

--- a/plugins/nginx.json
+++ b/plugins/nginx.json
@@ -14,7 +14,7 @@
   },
   "create_files": {
     "{{ .Virtenv }}/temp": "",
-    "{{ .DevboxDir }}/mime.types": "nginx/mime.types",
+    "{{ .Virtenv }}/mime.types": "nginx/mime.types",
     "{{ .Virtenv }}/process-compose.yaml": "nginx/process-compose.yaml",
     "{{ .DevboxDir }}/nginx.template": "nginx/nginx.template",
     "{{ .DevboxDir }}/nginx.conf": "nginx/nginx.conf",

--- a/plugins/nginx/process-compose.yaml
+++ b/plugins/nginx/process-compose.yaml
@@ -4,6 +4,7 @@ processes:
   nginx:
     command: |
       if [ -f $NGINX_CONFDIR/nginx.template ]; then envsubst $(awk 'BEGIN {for (k in ENVIRON) {printf "$"k","}}') < $NGINX_CONFDIR/nginx.template > $NGINX_CONFDIR/nginx.conf; fi
+      if [ ! -f $NGINX_CONFDIR/mime.types ] && [ -f $NGINX_PATH_PREFIX/mime.types ]; then cp $NGINX_PATH_PREFIX/mime.types $NGINX_CONFDIR/mime.types; fi
       nginx -p $NGINX_PATH_PREFIX -c $NGINX_CONFDIR/nginx.conf -e error.log -g "pid nginx.pid;daemon off;"
     availability:
       restart: on_failure


### PR DESCRIPTION
## Summary

Fixes #2908.

The nginx plugin's service fails to start because it can't find `mime.types`:

```
[emerg] open() "/tmp/testnginx/devbox.d/nginx/mime.types" failed (2: No such file or directory) in .../devbox.d/nginx/nginx.conf:6
```

PR #2844 added `include mime.types;` to nginx.conf and created the `mime.types` file under `{{ .Virtenv }}` (`.devbox/virtenv/nginx/`), on the assumption that `nginx -p $NGINX_PATH_PREFIX` would make the `include` resolve relative to the prefix. As the reporter (@jefft) correctly diagnosed, nginx only uses the `-p` prefix for **runtime** paths (`error_log`, `access_log`, `root`, …). At **configuration** time, relative paths in `include` are resolved relative to the directory of `nginx.conf` itself — which is `{{ .DevboxDir }}` (`devbox.d/nginx/`), not the virtenv. So the include pointed at a file that wasn't there.

### Fix

`mime.types` needs to sit next to `nginx.conf` in `$NGINX_CONFDIR`. Simply moving the `create_files` destination to `{{ .DevboxDir }}` would fix **fresh** installs but **not existing** ones: `Manager.shouldCreateFile()` (`internal/plugin/plugin.go:241-243`) skips creating any `devbox.d/` file once a plugin is installed (`PluginVersion` set in `devbox.lock`), even when the file is missing, and the version bump doesn't reset that.

Instead, this PR does the copy at service-startup time from files that always live under `.devbox` (which is regenerated on every env compute):

- `mime.types` continues to be created in the virtenv (`{{ .Virtenv }}/mime.types`), which is always regenerated.
- `plugins/nginx/process-compose.yaml` — also regenerated under `.devbox` — copies `mime.types` into `$NGINX_CONFDIR` next to `nginx.conf` when it's missing, before starting nginx:
  ```sh
  if [ ! -f $NGINX_CONFDIR/mime.types ] && [ -f $NGINX_PATH_PREFIX/mime.types ]; then cp $NGINX_PATH_PREFIX/mime.types $NGINX_CONFDIR/mime.types; fi
  ```
- Add the `mime.types` file to the checked-in nginx server example so it works out of the box.
- Bump the plugin version `0.0.5` → `0.0.6`.

This remediates both fresh installs and projects that already have nginx installed.

## How was it tested?

Reproduced the failure and verified the fix by following the issue's repro steps:

```sh
mkdir /tmp/testnginx && cd /tmp/testnginx
devbox init
devbox add nginx
devbox services up -b
tail -1 .devbox/virtenv/nginx/error.log   # no more mime.types emerg error
devbox services down
```

With the change, `mime.types` is copied to `devbox.d/nginx/mime.types` next to `nginx.conf` at service start, the `include` resolves, and the service starts cleanly. The change is limited to plugin data files (JSON config, process-compose YAML, and a static `mime.types`); no Go code paths are affected.

/cc @jefft (issue reporter) — thanks for the precise diagnosis.

## Community Contribution License

All community contributions in this pull request are licensed to the project
maintainers under the terms of the
[Apache 2 License](https://www.apache.org/licenses/LICENSE-2.0).

By creating this pull request, I represent that I have the right to license the
contributions to the project maintainers under the Apache 2 License as stated in
the
[Community Contribution License](https://github.com/jetify-com/opensource/blob/main/CONTRIBUTING.md#community-contribution-license).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017uK5pHhERaRaoDAvNdw9ww