### PR TITLE
fix(shellenv): preserve newlines in exported env values (#2814)

### DIFF
--- a/internal/devbox/envvars.go
+++ b/internal/devbox/envvars.go
@@ -93,7 +93,15 @@ func exportify(w io.Writer, vars map[string]string) string {
 				switch r {
 				// Special characters inside double quotes:
 				// https://pubs.opengroup.org/onlinepubs/009604499/utilities/xcu_chap02.html#tag_02_02_03
-				case '$', '`', '"', '\\', '\n':
+				//
+				// A newline is intentionally NOT escaped. Inside double
+				// quotes a literal newline is preserved as-is, but a
+				// backslash-newline is a line continuation that the shell
+				// removes entirely. Escaping it would silently join adjacent
+				// lines of a multiline value and corrupt it (see #2814, where
+				// a multiline PROMPT_COMMAND turned `2>&1\<newline>foo` into
+				// `2>&1foo` and produced an "ambiguous redirect" error).
+				case '$', '`', '"', '\\':
 					strb.WriteRune('\\')
 				}
 				strb.WriteRune(r)

--- a/internal/devbox/envvars.go
+++ b/internal/devbox/envvars.go
@@ -89,18 +89,18 @@ func exportify(w io.Writer, vars map[string]string) string {
 			strb.WriteString("export ")
 			strb.WriteString(key)
 			strb.WriteString(`="`)
+			// Escape the characters that are special inside double quotes:
+			// https://pubs.opengroup.org/onlinepubs/009604499/utilities/xcu_chap02.html#tag_02_02_03
+			//
+			// A newline is intentionally NOT escaped. Inside double quotes a
+			// literal newline is preserved as-is, but a backslash-newline is a
+			// line continuation that the shell removes entirely. Escaping it
+			// would silently join adjacent lines of a multiline value and
+			// corrupt it (see #2814, where a multiline PROMPT_COMMAND turned
+			// `2>&1\<newline>foo` into `2>&1foo` and produced an "ambiguous
+			// redirect" error).
 			for _, r := range vars[key] {
 				switch r {
-				// Special characters inside double quotes:
-				// https://pubs.opengroup.org/onlinepubs/009604499/utilities/xcu_chap02.html#tag_02_02_03
-				//
-				// A newline is intentionally NOT escaped. Inside double
-				// quotes a literal newline is preserved as-is, but a
-				// backslash-newline is a line continuation that the shell
-				// removes entirely. Escaping it would silently join adjacent
-				// lines of a multiline value and corrupt it (see #2814, where
-				// a multiline PROMPT_COMMAND turned `2>&1\<newline>foo` into
-				// `2>&1foo` and produced an "ambiguous redirect" error).
 				case '$', '`', '"', '\\':
 					strb.WriteRune('\\')
 				}

--- a/internal/devbox/envvars_test.go
+++ b/internal/devbox/envvars_test.go
@@ -47,6 +47,28 @@ func TestExportifySkipsInvalidNames(t *testing.T) {
 	}
 }
 
+// TestExportifyMultilineValue ensures that env vars whose values contain
+// newlines are emitted with literal newlines inside the double quotes, not a
+// backslash-newline. A backslash-newline is a shell line continuation that gets
+// removed on eval, which would join adjacent lines and corrupt the value (see
+// issue #2814: a multiline PROMPT_COMMAND produced an "ambiguous redirect").
+func TestExportifyMultilineValue(t *testing.T) {
+	got := exportify(io.Discard, map[string]string{
+		"MULTI": "line1\nline2",
+	})
+
+	want := "export MULTI=\"line1\nline2\";"
+	if got != want {
+		t.Errorf("exportify multiline value = %q, want %q", got, want)
+	}
+
+	// A backslash-newline (line continuation) must not appear; that is the
+	// exact corruption we are guarding against.
+	if strings.Contains(got, "\\\n") {
+		t.Errorf("exportify escaped a newline as a line continuation, got:\n%s", got)
+	}
+}
+
 func TestExportifyNushellSkipsInvalidNames(t *testing.T) {
 	got := exportifyNushell(io.Discard, map[string]string{
 		"GOOD": "value",


### PR DESCRIPTION
## Summary

Fixes #2814.

`eval "$(devbox global shellenv)"` printed `bash: 1__bp_interactive_mode: ambiguous redirect` at every prompt when the environment contained a **multiline** value (in the reporter's case a `PROMPT_COMMAND` built by bash-preexec / an elementary-terminal dbus hook).

### Root cause

`exportify` (`internal/devbox/envvars.go`) emits each value as `export KEY="…";` and escapes special characters by prefixing them with `\`. It also escaped `\n`, so a newline in a value was written as a **backslash + literal newline**:

```sh
export PROMPT_COMMAND="… >/dev/null 2>&1\
__bp_interactive_mode";
```

Inside double quotes, a backslash-newline is a **line continuation** — the shell removes it entirely on `eval`. So the newline was silently deleted and the two lines were joined:

```
… >/dev/null 2>&1__bp_interactive_mode
```

`2>&1__bp_interactive_mode` makes the redirect target `1__bp_interactive_mode`, which bash rejects as an **ambiguous redirect** — exactly the reported error.

### Fix

A literal newline inside double quotes is preserved as-is and needs no escaping (per the [POSIX quoting rules](https://pubs.opengroup.org/onlinepubs/009604499/utilities/xcu_chap02.html#tag_02_02_03), only `$`, `` ` ``, `"`, and `\` are special there). So `exportify` now stops escaping `\n` and emits the newline literally, keeping multiline values intact. A regression test pins the behavior.

The change is limited to the POSIX-shell export path; `exportifyNushell` already did not escape newlines and is untouched.

## How was it tested?

- `go test ./internal/devbox/ -run TestExportify` — passes, including the new `TestExportifyMultilineValue`.
- `go vet ./internal/devbox/` and `gofmt -l` — clean.
- End-to-end in real bash, reproducing the reporter's value. Before the fix the sourced value collapses to `… 2>&1__bp_interactive_mode` (deleted newlines → ambiguous redirect); after the fix the newlines are preserved:

  ```
  === OLD (backslash-newline, line continuation) ===
  VALUE=[echo start>/dev/null 2>&1__bp_interactive_mode]

  === NEW (literal newline) ===
  VALUE=[echo start
  >/dev/null 2>&1
  __bp_interactive_mode]
  ```

## Community Contribution License

All community contributions in this pull request are licensed to the project
maintainers under the terms of the
[Apache 2 License](https://www.apache.org/licenses/LICENSE-2.0).

By creating this pull request, I represent that I have the right to license the
contributions to the project maintainers under the Apache 2 License as stated in
the
[Community Contribution License](https://github.com/jetify-com/opensource/blob/main/CONTRIBUTING.md#community-contribution-license).

---

cc @proedie (issue reporter) — thanks for the precise diagnosis, including the exact line that needed moving.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016JemcBvhaZqahAzACV4aQF

---
_Generated by [Claude Code](https://claude.ai/code/session_016JemcBvhaZqahAzACV4aQF)_