### PR TITLE
fix(nix): check per-output binary-cache status in InputAddressedPathForOutput (#2921)

### DIFF
--- a/internal/devpkg/package.go
+++ b/internal/devpkg/package.go
@@ -602,11 +602,23 @@ func (p *Package) InputAddressedPaths() ([]string, error) {
 }
 
 func (p *Package) InputAddressedPathForOutput(output string) (string, error) {
-	if inCache, err := p.IsInBinaryCache(); err != nil {
+	// Check that this specific output is in the binary cache, rather than
+	// requiring every one of the package's default outputs to be cached.
+	//
+	// The flake template calls this per-output, and only for outputs it has
+	// already determined are cached (via GetOutputsWithCache, which checks each
+	// output individually). A multi-output package can have the requested
+	// output cached while some other default output is not. Guarding with the
+	// stricter IsInBinaryCache (which requires all default outputs) would
+	// spuriously fail in that case with "cannot be fetched from binary cache
+	// store", even though the output being fetched here is present. This also
+	// matches InstallableForOutput, which already gates on IsOutputInBinaryCache.
+	// See issue #2921.
+	if inCache, err := p.IsOutputInBinaryCache(output); err != nil {
 		return "", err
 	} else if !inCache {
 		return "",
-			errors.Errorf("Package %q cannot be fetched from binary cache store", p.Raw)
+			errors.Errorf("Package %q output %q cannot be fetched from binary cache store", p.Raw, output)
 	}
 
 	entry, err := p.lockfile.Resolve(p.LockfileKey())


### PR DESCRIPTION
## Summary

Fixes #2921.

Devbox 0.17.3 regressed so that `devbox shellenv` (and any command that regenerates the environment) fails during flake generation with:

```
Error: Package "dnsutils@latest" cannot be fetched from binary cache store
```

for multi-output packages (e.g. `dnsutils`, `curl`) when the requested output is available in the binary cache but not *every* one of the package's default outputs is.

### Root cause

The error is raised by `InputAddressedPathForOutput` (`internal/devpkg/package.go`), called from the flake template at `internal/shellgen/tmpl/flake.nix.tmpl:52` — exactly where the reported stack trace points.

That template line only runs **inside** `{{ if $output.CacheURI }}`, and `CacheURI` is set **per output** by `GetOutputsWithCache` → `fetchNarInfoStatusOnce(name)`, which checks *that single output*.

But `InputAddressedPathForOutput` internally guarded on `IsInBinaryCache()`, which is the **all-default-outputs** check (`areExpectedOutputsInCacheOnce(useDefaultOutputs)` requires `len(found) == len(defaultOutputs)`).

So for a package whose requested output is cached while some other default output is not, the template committed to emitting a `builtins.fetchClosure` for the cached output, yet the stricter internal guard reported the whole package as not-cached and returned the error. The per-output check (template) and the all-outputs check (guard) disagreed. This is the only code path that produces that error message at that template line.

### Fix

`InputAddressedPathForOutput` returns the input-addressed path for a **single** output, so its precondition should concern only that output. Switch its guard from `IsInBinaryCache()` to `IsOutputInBinaryCache(output)`. This mirrors `InstallableForOutput`, which already gates the very same call on the per-output check:

```go
func (p *Package) InstallableForOutput(output string) (string, error) {
    inCache, err := p.IsOutputInBinaryCache(output)   // per-output
    ...
    if inCache {
        installable, err := p.InputAddressedPathForOutput(output)
```

The plural `InputAddressedPaths()` is unchanged: it still guards on `IsInBinaryCache()` (it legitimately wants all default outputs) before iterating, so relaxing the singular guard cannot weaken it — each per-output check there is a subset of the all-outputs check the caller already passed.

The error message now names the specific output for clearer diagnostics.

## How was it tested?

- `go build ./...` and `go vet ./internal/devpkg/` — clean.
- `go test ./internal/devpkg/` — passes.
- Verified by code analysis that this is the sole path producing `"... cannot be fetched from binary cache store"` at `flake.nix.tmpl:52`, and that the fix restores agreement between the template's per-output caching decision and the guard.

Note: the binary-cache resolution path gates on a Nix ≥ 2.17 install (`sysInfoIfExists` → `nix.AtLeast`), so an end-to-end reproduction requires a Nix environment with a partially-populated cache (as in the issue). I was unable to run that scenario in the sandbox used here; reviewers with a Nix toolchain can confirm against the issue's repro steps.

cc @sstarcher (issue reporter) — thanks for the detailed diagnosis and stack trace.

## Community Contribution License

All community contributions in this pull request are licensed to the project
maintainers under the terms of the
[Apache 2 License](https://www.apache.org/licenses/LICENSE-2.0).

By creating this pull request, I represent that I have the right to license the
contributions to the project maintainers under the Apache 2 License as stated in
the
[Community Contribution License](https://github.com/jetify-com/opensource/blob/main/CONTRIBUTING.md#community-contribution-license).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017rMbKrge1aJW6mNbGuPGDS

---
_Generated by [Claude Code](https://claude.ai/code/session_017rMbKrge1aJW6mNbGuPGDS)_