### PR TITLE
docs(go example): document GOPATH/GOROOT and warn against GOPATH=$PWD

### DIFF
--- a/examples/development/go/hello-world/README.md
+++ b/examples/development/go/hello-world/README.md
@@ -26,3 +26,38 @@ If you need additional C libraries, you can add them along with `gcc` to your pa
     "libcap"
 ]
 ```
+
+## Setting up the Go environment
+
+This example configures a few environment variables in `devbox.json`:
+
+```json
+"env": {
+    "GOPATH": "$HOME/go/",
+    "PATH":   "$PATH:$HOME/go/bin"
+}
+```
+
+- `GOPATH` is set to `$HOME/go`, which is Go's default location. Keeping the
+  `GOPATH` outside of your project directory lets the module cache
+  (`$GOPATH/pkg/mod`) be shared across projects and keeps build artifacts out of
+  your source tree.
+- Adding `$GOPATH/bin` to `PATH` makes tools installed with `go install`
+  available inside the Devbox shell.
+
+The `init_hook` exports `GOROOT` so that the Go toolchain provided by Nix is
+used:
+
+```json
+"shell": {
+    "init_hook": [
+        "export \"GOROOT=$(go env GOROOT)\""
+    ]
+}
+```
+
+> **Note on `GOPATH`:** avoid setting `GOPATH` to your project directory (e.g.
+> `"GOPATH": "$PWD"`). When a module (a directory containing `go.mod`) lives
+> inside `GOPATH`, the Go toolchain prints `go: warning: ignoring go.mod in
+> $GOPATH` and falls back to legacy `GOPATH` mode. Using `$HOME/go` (as above)
+> keeps module-aware builds working as expected.

--- a/examples/development/go/hello-world/README.md
+++ b/examples/development/go/hello-world/README.md
@@ -45,8 +45,9 @@ This example configures a few environment variables in `devbox.json`:
 - Adding `$GOPATH/bin` to `PATH` makes tools installed with `go install`
   available inside the Devbox shell.
 
-The `init_hook` exports `GOROOT` so that the Go toolchain provided by Nix is
-used:
+Which Go toolchain is active is determined by the `go` binary on `PATH` (here,
+the one provided by Nix). The `init_hook` sets `GOROOT` to match that
+installation, which some tooling relies on:
 
 ```json
 "shell": {
@@ -58,6 +59,11 @@ used:
 
 > **Note on `GOPATH`:** avoid setting `GOPATH` to your project directory (e.g.
 > `"GOPATH": "$PWD"`). When a module (a directory containing `go.mod`) lives
-> inside `GOPATH`, the Go toolchain prints `go: warning: ignoring go.mod in
-> $GOPATH` and falls back to legacy `GOPATH` mode. Using `$HOME/go` (as above)
-> keeps module-aware builds working as expected.
+> inside `GOPATH`, the Go toolchain falls back to legacy `GOPATH` mode and
+> prints a warning:
+>
+> ```
+> go: warning: ignoring go.mod in $GOPATH /path/to/your/project
+> ```
+>
+> Using `$HOME/go` (as above) keeps module-aware builds working as expected.


### PR DESCRIPTION
## Summary

Fixes #2640.

The reporter noticed that the in-repo Go example and the [Go example in the docs](https://www.jetify.com/docs/devbox/devbox_examples/languages/go/) configure `GOPATH` differently:

- **In-repo** (`examples/development/go/hello-world`, also the `devbox create --template go` scaffold): `GOPATH=$HOME/go`
- **Website docs**: `GOPATH=$PWD`

They asked to either align the examples or clarify the intended use case.

## What I found

`GOPATH=$PWD` is **not** just a stylistic difference — it is incorrect for module-based projects. When a directory containing `go.mod` lives inside `GOPATH`, the Go toolchain ignores the module and falls back to legacy GOPATH mode:

```console
$ cd examples/development/go/hello-world
$ env GOPATH="$PWD" go run main.go
go: warning: ignoring go.mod in $GOPATH /.../examples/development/go/hello-world
```

The in-repo example's `GOPATH=$HOME/go` (Go's default) produces no such warning and is the correct configuration:

```console
$ env GOPATH="$HOME/go" go run main.go
(no warning)
```

The docs website source lives in a separate repository, so this PR addresses the in-repo side: the example's README previously said nothing about its `env` block. It now documents the environment configuration and explains why `$HOME/go` is used and why `GOPATH=$PWD` should be avoided. This resolves the "clarify the intended use cases" path from the issue and gives maintainers the evidence to update the website example to match.

## Changes

- `examples/development/go/hello-world/README.md`: add a "Setting up the Go environment" section documenting `GOPATH`, `PATH`, and the `GOROOT` `init_hook`, with a note warning against `GOPATH=$PWD` for module projects.

No behavior change to the example itself — the existing `devbox.json` already uses the correct `$HOME/go` configuration and continues to pass the `run_test` CI check.

## How was it tested?

- Reproduced the `go: warning: ignoring go.mod in $GOPATH` warning with `GOPATH=$PWD` and confirmed it is absent with `GOPATH=$HOME/go`, using this example's `main.go`/`go.mod`.
- The example's `run_test` (`go run main.go`) is unaffected — only documentation changed.

---

cc @vn7n24fzkq (issue reporter) — thanks for flagging the inconsistency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015HVAMekrsEQLDoiD6dp8Pi

---
_Generated by [Claude Code](https://claude.ai/code/session_015HVAMekrsEQLDoiD6dp8Pi)_