### PR TITLE
fix(nix): parse Nix versions that omit the patch component

### DIFF
--- a/nix/nix.go
+++ b/nix/nix.go
@@ -179,8 +179,12 @@ const (
 //
 // The semantic component is sourced from <https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string>.
 // It's been modified to tolerate Nix prerelease versions, which don't have a
-// hyphen before the prerelease component and contain underscores.
-var versionRegexp = regexp.MustCompile(`^(.+) \(.+\) ((?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)(?:(?:-|pre)(?P<prerelease>(?:0|[1-9]\d*|\d*[_a-zA-Z-][_0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[_a-zA-Z-][_0-9a-zA-Z-]*))*))?(?:\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)$`)
+// hyphen before the prerelease component and contain underscores. The patch
+// component is also optional: some Nix builds report a two-component version
+// followed directly by a prerelease, e.g. "2.33pre20251107_479b6b73" (see
+// https://github.com/jetify-com/devbox/issues/2766). normalizeVersion inserts
+// the missing ".0" patch so the result is comparable as a semver.
+var versionRegexp = regexp.MustCompile(`^(.+) \(.+\) ((?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)(?:\.(?P<patch>0|[1-9]\d*))?(?:(?:-|pre)(?P<prerelease>(?:0|[1-9]\d*|\d*[_a-zA-Z-][_0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[_a-zA-Z-][_0-9a-zA-Z-]*))*))?(?:\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)$`)
 
 // preReleaseRegexp matches Nix prerelease version strings, which are not valid
 // semvers.
@@ -255,7 +259,7 @@ func parseInfo(data []byte) (Info, error) {
 		return info, redact.Errorf("parse nix version: %s", redact.Safe(lines[0]))
 	}
 	info.Name = matches[1]
-	info.Version = matches[2]
+	info.Version = normalizeVersion(matches)
 	for _, line := range lines {
 		name, value, found := strings.Cut(line, ": ")
 		if !found {
@@ -282,6 +286,21 @@ func parseInfo(data []byte) (Info, error) {
 		}
 	}
 	return info, nil
+}
+
+// normalizeVersion returns the semantic version string from a versionRegexp
+// match, inserting a ".0" patch component when Nix omits it (e.g. it turns
+// "2.33pre20251107_479b6b73" into "2.33.0pre20251107_479b6b73"). A patch
+// component is required for the version to be comparable as a semver, both
+// directly and via AtLeast's prerelease coercion.
+func normalizeVersion(matches []string) string {
+	version := matches[2]
+	if matches[versionRegexp.SubexpIndex("patch")] != "" {
+		return version
+	}
+	majorMinor := matches[versionRegexp.SubexpIndex("major")] +
+		"." + matches[versionRegexp.SubexpIndex("minor")]
+	return majorMinor + ".0" + strings.TrimPrefix(version, majorMinor)
 }
 
 // AtLeast returns true if i.Version is >= version per semantic versioning. It

--- a/nix/nix_test.go
+++ b/nix/nix_test.go
@@ -112,6 +112,11 @@ func TestParseVersionInfoShort(t *testing.T) {
 		{"nix (Nix) 2.23.0pre20240526_7de033d6", "nix", "2.23.0pre20240526_7de033d6"},
 		{"command (Nix) name (Nix) 2.21.2", "command (Nix) name", "2.21.2"},
 		{"nix (Lix, like Nix) 2.90.0-beta.1", "nix", "2.90.0-beta.1"},
+		// Nix builds that omit the patch component get it inserted so the
+		// version stays comparable as a semver. See
+		// https://github.com/jetify-com/devbox/issues/2766.
+		{"nix (Nix) 2.33pre20251107_479b6b73", "nix", "2.33.0pre20251107_479b6b73"},
+		{"nix (Nix) 2.33", "nix", "2.33.0"},
 	}
 
 	for _, tt := range cases {
@@ -184,6 +189,20 @@ func TestVersionInfoAtLeast(t *testing.T) {
 	}
 	if !info.AtLeast("2.23.0-pre.1") {
 		t.Errorf("got %s < %s", info.Version, "2.23.0-pre.1")
+	}
+
+	// https://github.com/jetify-com/devbox/issues/2766: a prerelease that
+	// omits the patch component is normalized to "2.33.0pre..." by parseInfo,
+	// which AtLeast must then treat as newer than the minimum version.
+	info.Version = "2.33.0pre20251107_479b6b73"
+	if !info.AtLeast(Version2_12) {
+		t.Errorf("got %s < %s", info.Version, Version2_12)
+	}
+	if !info.AtLeast(MinVersion) {
+		t.Errorf("got %s < %s", info.Version, MinVersion)
+	}
+	if info.AtLeast("2.34.0") {
+		t.Errorf("got %s >= %s", info.Version, "2.34.0")
 	}
 
 	t.Run("ArgEmptyPanic", func(t *testing.T) {


### PR DESCRIPTION
## Summary

Fixes #2766.

Some Nix builds report a two-component version followed directly by a prerelease, e.g. `nix (Nix) 2.33pre20251107_479b6b73` (note: `2.33pre…`, not `2.33.0pre…`). `versionRegexp` required a full `major.minor.patch` triple, so it failed to match these strings. `Info.Version` was then left empty and Devbox aborted every command with a confusing error where the version renders as empty:

```
Error: Devbox requires nix of version >= 2.12.0. Your version is . Please upgrade nix and try again.
```

### Fix

- Make the `patch` component **optional** in `versionRegexp`.
- Normalize the parsed version by inserting a `.0` patch when Nix omits it, so `2.33pre20251107_479b6b73` becomes `2.33.0pre20251107_479b6b73` (and a bare `2.33` becomes `2.33.0`).

The normalization is necessary because a patch component is required for the version to be comparable as a semver — **both** directly and via `AtLeast`'s prerelease coercion. Without it, `AtLeast` would coerce the version to `2.33-pre.20251107+479b6b73`, which is not a valid semver (a prerelease requires a patch), so `AtLeast(2.12.0)` would still return `false` and the version would keep being rejected. Inserting the `.0` makes the coerced form `2.33.0-pre.20251107+479b6b73`, a valid semver that compares correctly.

All previously-supported version formats (`2.21.2`, `2.23.0pre20240526_7de033d6`, `2.90.0-beta.1`, …) are unchanged.

## How was it tested?

- Added cases to `TestParseVersionInfoShort` asserting `2.33pre20251107_479b6b73` → `2.33.0pre20251107_479b6b73` and `2.33` → `2.33.0`.
- Extended `TestVersionInfoAtLeast` so a patch-less prerelease (`2.33.0pre20251107_479b6b73`) is treated as `>= 2.12.0` and `>= MinVersion`, and `< 2.34.0`.
- `go test ./nix/` passes; `go vet ./nix/`, `go build ./...`, and `gofmt -l` are clean.

cc @Electrenator (issue reporter) — thanks for the detailed debug logs that pinpointed this.

## Community Contribution License

All community contributions in this pull request are licensed to the project
maintainers under the terms of the
[Apache 2 License](https://www.apache.org/licenses/LICENSE-2.0).

By creating this pull request, I represent that I have the right to license the
contributions to the project maintainers under the Apache 2 License as stated in
the
[Community Contribution License](https://github.com/jetify-com/opensource/blob/main/CONTRIBUTING.md#community-contribution-license).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VeatwKxvuw66rgQUnekx7J

---
_Generated by [Claude Code](https://claude.ai/code/session_01VeatwKxvuw66rgQUnekx7J)_