### PR TITLE
fix(shellenv): don't escape newlines in exported env var values (#2814)

### DIFF
--- a/internal/devbox/envvars.go
+++ b/internal/devbox/envvars.go
@@ -93,7 +93,15 @@ func exportify(w io.Writer, vars map[string]string) string {
 				switch r {
 				// Special characters inside double quotes:
 				// https://pubs.opengroup.org/onlinepubs/009604499/utilities/xcu_chap02.html#tag_02_02_03
-				case '$', '`', '"', '\\', '\n':
+				//
+				// Note: a newline is NOT escaped. Inside double quotes a bare
+				// newline is already a literal newline, whereas a backslash
+				// followed by a newline is a line continuation that the shell
+				// removes entirely. Escaping newlines would collapse a
+				// multi-line value onto a single line and silently corrupt it
+				// (e.g. a PROMPT_COMMAND containing `... 2>&1\n__bp_...` would
+				// become `... 2>&1__bp_...`, causing an "ambiguous redirect").
+				case '$', '`', '"', '\\':
 					strb.WriteRune('\\')
 				}
 				strb.WriteRune(r)

--- a/internal/devbox/envvars.go
+++ b/internal/devbox/envvars.go
@@ -89,22 +89,21 @@ func exportify(w io.Writer, vars map[string]string) string {
 			strb.WriteString("export ")
 			strb.WriteString(key)
 			strb.WriteString(`="`)
-			for _, r := range vars[key] {
-				switch r {
+			// Note: a newline is NOT escaped. Inside double quotes a bare
+			// newline is already a literal newline, whereas a backslash
+			// followed by a newline is a line continuation that the shell
+			// removes entirely. Escaping newlines would collapse a multi-line
+			// value onto a single line and silently corrupt it (e.g. a
+			// PROMPT_COMMAND containing `... 2>&1\n__bp_...` would become
+			// `... 2>&1__bp_...`, causing an "ambiguous redirect").
+			for _, char := range vars[key] {
+				switch char {
 				// Special characters inside double quotes:
 				// https://pubs.opengroup.org/onlinepubs/009604499/utilities/xcu_chap02.html#tag_02_02_03
-				//
-				// Note: a newline is NOT escaped. Inside double quotes a bare
-				// newline is already a literal newline, whereas a backslash
-				// followed by a newline is a line continuation that the shell
-				// removes entirely. Escaping newlines would collapse a
-				// multi-line value onto a single line and silently corrupt it
-				// (e.g. a PROMPT_COMMAND containing `... 2>&1\n__bp_...` would
-				// become `... 2>&1__bp_...`, causing an "ambiguous redirect").
 				case '$', '`', '"', '\\':
 					strb.WriteRune('\\')
 				}
-				strb.WriteRune(r)
+				strb.WriteRune(char)
 			}
 			strb.WriteString("\";\n")
 		}

--- a/internal/devbox/envvars_test.go
+++ b/internal/devbox/envvars_test.go
@@ -47,6 +47,29 @@ func TestExportifySkipsInvalidNames(t *testing.T) {
 	}
 }
 
+// TestExportifyPreservesNewlines ensures that a value containing newlines is
+// emitted with literal (unescaped) newlines. Escaping a newline as `\<newline>`
+// makes the shell treat it as a line continuation and strip it, collapsing a
+// multi-line value onto a single line. That corrupted, for example, a
+// PROMPT_COMMAND whose `... 2>&1` and `__bp_interactive_mode` lines got joined
+// into `... 2>&1__bp_interactive_mode`, yielding a "1__bp_...: ambiguous
+// redirect" error at every prompt. See issue #2814.
+func TestExportifyPreservesNewlines(t *testing.T) {
+	value := "cmd_a >/dev/null 2>&1\n__bp_interactive_mode"
+	got := exportify(io.Discard, map[string]string{"PROMPT_COMMAND": value})
+
+	want := "export PROMPT_COMMAND=\"cmd_a >/dev/null 2>&1\n__bp_interactive_mode\";"
+	if got != want {
+		t.Errorf("exportify newline handling:\n got: %q\nwant: %q", got, want)
+	}
+
+	// A backslash-newline (line continuation) must not appear: that is the
+	// exact corruption this test guards against.
+	if strings.Contains(got, "\\\n") {
+		t.Errorf("exportify escaped a newline as a line continuation, corrupting the value:\n%s", got)
+	}
+}
+
 func TestExportifyNushellSkipsInvalidNames(t *testing.T) {
 	got := exportifyNushell(io.Discard, map[string]string{
 		"GOOD": "value",


### PR DESCRIPTION
## Summary

Fixes #2814.

`eval "$(devbox global shellenv)"` could print `bash: 1__bp_interactive_mode: ambiguous redirect` at every prompt when an environment variable (e.g. a `PROMPT_COMMAND` set by [bash-preexec](https://github.com/rcaloras/bash-preexec)) contained newlines.

### Root cause

`exportify` (`internal/devbox/envvars.go`) emits each variable as `export KEY="value";`, escaping special characters inside the double quotes. It escaped `\n` by writing a backslash **before** the newline, producing `\<newline>`:

```go
case '$', '`', '"', '\\', '\n':
    strb.WriteRune('\\')
```

Inside double quotes the shell treats a backslash-newline as a **line continuation** and removes it entirely, collapsing a multi-line value onto one line. A bare newline inside double quotes is already literal, so the escaping was both unnecessary and corrupting.

For the reporter's `PROMPT_COMMAND`, the lines `... >/dev/null 2>&1` and `__bp_interactive_mode` were joined into `... 2>&1__bp_interactive_mode`, so the `2>&1` redirect target became `1__bp_interactive_mode` — hence the "ambiguous redirect" error.

Minimal demonstration of the shell behavior:

```console
$ eval 'export A="line1\
2>&1\
tail"'; printf '[%s]\n' "$A"
[line12>&1tail]          # backslash-newline (old behavior) — corrupted

$ eval 'export B="line1
2>&1
tail"'; printf '[%s]\n' "$B"
[line1
2>&1
tail]                   # bare newline (new behavior) — correct
```

### Fix

Drop `\n` from the set of characters escaped inside double quotes, so newlines are emitted literally. The `exportifyNushell` path already emits newlines literally, so this makes the two consistent.

## How was it tested?

- Added `TestExportifyPreservesNewlines`, which pins the multi-line output and asserts no `\<newline>` line-continuation is produced.
- `go test ./internal/devbox/ -run 'TestExportify|TestIsValidEnvName'` — passes.
- `gofmt -l` and `go vet ./internal/devbox/` — clean.

/cc @proedie (issue reporter) — thanks for the precise diagnosis and workaround in the report.

## Community Contribution License

All community contributions in this pull request are licensed to the project
maintainers under the terms of the
[Apache 2 License](https://www.apache.org/licenses/LICENSE-2.0).

By creating this pull request, I represent that I have the right to license the
contributions to the project maintainers under the Apache 2 License as stated in
the
[Community Contribution License](https://github.com/jetify-com/opensource/blob/main/CONTRIBUTING.md#community-contribution-license).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WzomNNnDLmX4LMZ4aPtYvm

---
_Generated by [Claude Code](https://claude.ai/code/session_01WzomNNnDLmX4LMZ4aPtYvm)_