### PR TITLE
fix(env): expose Devbox profile share dir via XDG_DATA_DIRS so package completions work

### DIFF
--- a/internal/devbox/devbox.go
+++ b/internal/devbox/devbox.go
@@ -820,6 +820,18 @@ func (d *Devbox) computeEnv(
 
 	slog.Debug("computed environment PATH", "path", env["PATH"])
 
+	// Expose the Devbox profile's share directory through XDG_DATA_DIRS so that
+	// data files installed by packages are discoverable inside the Devbox
+	// environment. Most notably this includes shell completions (which Nix
+	// packages install under share/bash-completion/completions), but also man
+	// pages, icons, and other XDG data. Tools such as bash-completion look these
+	// up via XDG_DATA_DIRS, so without the profile's share directory the
+	// completions shipped by packages like kubectl are never loaded. This is
+	// done even in --pure mode so completions keep working there too.
+	// See https://github.com/jetify-com/devbox/issues/2776
+	profileShareDir := filepath.Join(d.projectDir, nix.ProfilePath, "share")
+	env["XDG_DATA_DIRS"] = envpath.JoinPathLists(profileShareDir, env["XDG_DATA_DIRS"])
+
 	if !envOpts.Pure {
 		// preserve the original XDG_DATA_DIRS by prepending to it
 		env["XDG_DATA_DIRS"] = envpath.JoinPathLists(env["XDG_DATA_DIRS"], os.Getenv("XDG_DATA_DIRS"))

--- a/testscripts/run/xdg_data_dirs.test.txt
+++ b/testscripts/run/xdg_data_dirs.test.txt
@@ -7,6 +7,11 @@
 exec devbox run echo '$XDG_DATA_DIRS'
 stdout '\.devbox/nix/profile/default/share'
 
+# The profile's share directory must also be exposed in --pure mode, where the
+# host's XDG_DATA_DIRS is not inherited, so completions keep working there too.
+exec devbox run --pure echo '$XDG_DATA_DIRS'
+stdout '\.devbox/nix/profile/default/share'
+
 -- devbox.json --
 {
   "packages": []

--- a/testscripts/run/xdg_data_dirs.test.txt
+++ b/testscripts/run/xdg_data_dirs.test.txt
@@ -1,0 +1,13 @@
+# The Devbox profile's share directory must be exposed through XDG_DATA_DIRS so
+# that data files installed by packages are discoverable inside the Devbox
+# environment. Most importantly this lets tools like bash-completion find the
+# shell completions that packages install under share/bash-completion/completions.
+# https://github.com/jetify-com/devbox/issues/2776
+
+exec devbox run echo '$XDG_DATA_DIRS'
+stdout '\.devbox/nix/profile/default/share'
+
+-- devbox.json --
+{
+  "packages": []
+}


### PR DESCRIPTION
## Summary

Fixes #2776.

Package-provided shell completions were never active inside a Devbox shell. For
example, on a fresh Ubuntu + bash setup, `kubectl <TAB>` does nothing even though
the `kubectl` Nix package ships a completion script.

### Root cause

Nix packages install their bash completions under
`share/bash-completion/completions/<cmd>`, and `bash-completion`'s dynamic loader
discovers them by scanning the `bash-completion/completions` subdirectory of
**every** entry in `XDG_DATA_DIRS` at completion time.

When computing the environment (`internal/devbox/devbox.go`), Devbox only
preserved the host's original `XDG_DATA_DIRS`:

```go
if !envOpts.Pure {
    // preserve the original XDG_DATA_DIRS by prepending to it
    env["XDG_DATA_DIRS"] = envpath.JoinPathLists(env["XDG_DATA_DIRS"], os.Getenv("XDG_DATA_DIRS"))
}
```

It never added the Devbox profile's own `share` directory
(`.devbox/nix/profile/default/share`), which is where all of a project's
installed packages aggregate their data files. As a result the completions — and
other XDG data such as man pages and icons — shipped by those packages were
invisible to the shell.

### Fix

Prepend the profile's `share` directory to `XDG_DATA_DIRS` while computing the
environment:

```go
profileShareDir := filepath.Join(d.projectDir, nix.ProfilePath, "share")
env["XDG_DATA_DIRS"] = envpath.JoinPathLists(profileShareDir, env["XDG_DATA_DIRS"])
```

- Done for both regular and `--pure` environments, so completions keep working
  in pure shells too.
- `envpath.JoinPathLists` cleans, dedupes, and drops empty/relative segments, so
  this is a no-op if the entry is already present and it never introduces a
  duplicate or an unsafe relative path.
- This mirrors how `nix-env` / home-manager expose the same data via
  `XDG_DATA_DIRS`.

## How was it tested?

- `go build ./...` and `go vet ./internal/devbox/` — clean.
- Added `testscripts/run/xdg_data_dirs.test.txt`, which asserts that
  `devbox run echo '$XDG_DATA_DIRS'` includes
  `.devbox/nix/profile/default/share`.

Manual verification of the underlying mechanism: with the profile's `share`
directory on `XDG_DATA_DIRS`, `bash-completion`'s `__load_completion` finds
`share/bash-completion/completions/kubectl` in the Devbox profile and activates
`kubectl <TAB>` completion; the change is additive and does not alter any other
environment variable.

/cc @gberche-orange (issue reporter) — thanks for the clear report and the
upstream package links.

## Community Contribution License

All community contributions in this pull request are licensed to the project
maintainers under the terms of the
[Apache 2 License](https://www.apache.org/licenses/LICENSE-2.0).

By creating this pull request, I represent that I have the right to license the
contributions to the project maintainers under the Apache 2 License as stated in
the
[Community Contribution License](https://github.com/jetify-com/opensource/blob/main/CONTRIBUTING.md#community-contribution-license).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EuAos6xjPuVdUWNEVvCYh1

---
_Generated by [Claude Code](https://claude.ai/code/session_01EuAos6xjPuVdUWNEVvCYh1)_