### PR TITLE
fix(shellenv): preserve newlines in exported env var values (#2814)

### DIFF
--- a/internal/devbox/envvars.go
+++ b/internal/devbox/envvars.go
@@ -89,8 +89,8 @@ func exportify(w io.Writer, vars map[string]string) string {
 			strb.WriteString("export ")
 			strb.WriteString(key)
 			strb.WriteString(`="`)
-			for _, r := range vars[key] {
-				switch r {
+			for _, char := range vars[key] {
+				switch char {
 				// Special characters inside double quotes:
 				// https://pubs.opengroup.org/onlinepubs/009604499/utilities/xcu_chap02.html#tag_02_02_03
 				// Note: a newline is NOT escaped. Inside double quotes a bare
@@ -101,7 +101,7 @@ func exportify(w io.Writer, vars map[string]string) string {
 				case '$', '`', '"', '\\':
 					strb.WriteRune('\\')
 				}
-				strb.WriteRune(r)
+				strb.WriteRune(char)
 			}
 			strb.WriteString("\";\n")
 		}

--- a/internal/devbox/envvars.go
+++ b/internal/devbox/envvars.go
@@ -93,7 +93,12 @@ func exportify(w io.Writer, vars map[string]string) string {
 				switch r {
 				// Special characters inside double quotes:
 				// https://pubs.opengroup.org/onlinepubs/009604499/utilities/xcu_chap02.html#tag_02_02_03
-				case '$', '`', '"', '\\', '\n':
+				// Note: a newline is NOT escaped. Inside double quotes a bare
+				// newline is preserved literally, but a backslash-newline is a
+				// line continuation that the shell deletes, which would silently
+				// join multi-line values (e.g. a PROMPT_COMMAND whose commands are
+				// newline-separated) into one line and corrupt them.
+				case '$', '`', '"', '\\':
 					strb.WriteRune('\\')
 				}
 				strb.WriteRune(r)

--- a/internal/devbox/envvars_test.go
+++ b/internal/devbox/envvars_test.go
@@ -47,6 +47,29 @@ func TestExportifySkipsInvalidNames(t *testing.T) {
 	}
 }
 
+// TestExportifyPreservesNewlines ensures that env var values containing newlines
+// (e.g. a PROMPT_COMMAND whose commands are newline-separated, as set up by
+// bash-preexec) are emitted with literal newlines rather than backslash-newline
+// line continuations. A backslash-newline is deleted by the shell, which would
+// glue adjacent lines together and corrupt the value (see issue #2814, where
+// `... 2>&1\n__bp_interactive_mode` became `... 2>&1__bp_interactive_mode` and
+// produced a "1__bp_interactive_mode: ambiguous redirect" error).
+func TestExportifyPreservesNewlines(t *testing.T) {
+	got := exportify(io.Discard, map[string]string{
+		"PROMPT_COMMAND": "__bp_precmd_invoke_cmd\ncmd >/dev/null 2>&1\n__bp_interactive_mode",
+	})
+
+	want := "export PROMPT_COMMAND=\"__bp_precmd_invoke_cmd\ncmd >/dev/null 2>&1\n__bp_interactive_mode\";"
+	if got != want {
+		t.Errorf("exportify did not preserve newlines\ngot:\n%q\nwant:\n%q", got, want)
+	}
+	// A backslash immediately before a newline is a shell line continuation and
+	// must not appear, since it would delete the newline and join the lines.
+	if strings.Contains(got, "\\\n") {
+		t.Errorf("exportify emitted a backslash-newline line continuation, which corrupts multi-line values:\n%q", got)
+	}
+}
+
 func TestExportifyNushellSkipsInvalidNames(t *testing.T) {
 	got := exportifyNushell(io.Discard, map[string]string{
 		"GOOD": "value",


### PR DESCRIPTION
## Summary

Fixes #2814.

`eval "$(devbox global shellenv)"` produced `bash: 1__bp_interactive_mode: ambiguous redirect` on every prompt for users whose `PROMPT_COMMAND` is set up by bash-preexec (newline-separated commands).

Root cause is in `exportify` (`internal/devbox/envvars.go`). It escaped every newline inside a double-quoted value as a backslash-newline:

```go
case '$', '`', '"', '\\', '\n':
    strb.WriteRune('\\')
```

In the shell, a **backslash-newline inside double quotes is a line continuation** — the shell *deletes* it. So any env var whose value spans multiple lines had its newlines silently stripped and its lines glued together when re-imported. For the reporter's `PROMPT_COMMAND`, `... 2>&1` was joined onto the following `__bp_interactive_mode`, yielding `... 2>&1__bp_interactive_mode`, which bash parses as a redirect to fd `1__bp_interactive_mode` → "ambiguous redirect".

A **bare** newline inside double quotes is already preserved literally, so the fix is simply to stop escaping it (drop `'\n'` from the escape set). The nushell exporter already writes newlines literally, so this makes the two consistent.

## How was it tested?

- Added `TestExportifyPreservesNewlines`, a regression test that asserts a multi-line value round-trips with literal newlines and contains no backslash-newline continuation. It fails on the old code and passes with the fix.
- `go test ./internal/devbox/ -run 'TestExportify|TestIsValidEnvName'` — all pass.
- Confirmed the exact symptom in a shell. Before (escaped):
  ```
  $ eval 'export PC="cmd >/dev/null 2>&1\
  __bp_interactive_mode";'
  # PC == "cmd >/dev/null 2>&1__bp_interactive_mode"  -> ambiguous redirect
  ```
  After (literal newline): the value keeps its newline and the two commands stay separate.

cc @proedie (issue reporter) — thanks for the precise diagnosis and workaround in the report, which pinpointed the exact line.

## Community Contribution License

All community contributions in this pull request are licensed to the project
maintainers under the terms of the
[Apache 2 License](https://www.apache.org/licenses/LICENSE-2.0).

By creating this pull request, I represent that I have the right to license the
contributions to the project maintainers under the Apache 2 License as stated in
the
[Community Contribution License](https://github.com/jetify-com/opensource/blob/main/CONTRIBUTING.md#community-contribution-license).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QGpiSzrugFvBQtAXxkVT75

---
_Generated by [Claude Code](https://claude.ai/code/session_01QGpiSzrugFvBQtAXxkVT75)_