### PR TITLE
fix(run): run scripts and init hooks with bash, not sh (#2607)

### DIFF
--- a/internal/nix/run.go
+++ b/internal/nix/run.go
@@ -45,8 +45,18 @@ func RunScript(projectDir, cmdWithArgs string, env map[string]string) error {
 // path) when bash isn't available.
 // See https://github.com/jetify-com/devbox/issues/2607
 func scriptRunnerPath() string {
+	// Prefer bash on PATH.
 	if bashPath := cmdutil.GetPathOrDefault("bash", ""); bashPath != "" {
 		return bashPath
 	}
+	// bash may be installed at a well-known location even when it isn't on
+	// PATH (e.g. a restricted environment where PATH doesn't include /bin or
+	// /usr/bin). Check those before giving up on bash.
+	for _, p := range []string{"/bin/bash", "/usr/bin/bash", "/usr/local/bin/bash"} {
+		if fi, err := os.Stat(p); err == nil && !fi.IsDir() {
+			return p
+		}
+	}
+	// Fall back to POSIX sh.
 	return cmdutil.GetPathOrDefault("sh", "/bin/sh")
 }

--- a/internal/nix/run.go
+++ b/internal/nix/run.go
@@ -24,9 +24,7 @@ func RunScript(projectDir, cmdWithArgs string, env map[string]string) error {
 		envPairs = append(envPairs, fmt.Sprintf("%s=%s", k, v))
 	}
 
-	// Try to find sh in the PATH, if not, default to a well known absolute path.
-	shPath := cmdutil.GetPathOrDefault("sh", "/bin/sh")
-	cmd := exec.Command(shPath, "-c", cmdWithArgs)
+	cmd := exec.Command(scriptRunnerPath(), "-c", cmdWithArgs)
 	cmd.Env = envPairs
 	cmd.Dir = projectDir
 	cmd.Stdin = os.Stdin
@@ -36,4 +34,19 @@ func RunScript(projectDir, cmdWithArgs string, env map[string]string) error {
 	slog.Debug("executing script", "cmd", cmd.Args)
 	// Report error as exec error when executing scripts.
 	return usererr.NewExecError(cmd.Run())
+}
+
+// scriptRunnerPath returns the shell used to execute Devbox scripts and init
+// hooks. It prefers bash so that scripts run with `devbox run` behave the same
+// as they do inside `devbox shell`, which sources the init hooks from the
+// user's interactive shell (usually bash). Init hooks commonly rely on bash
+// features such as the `source` builtin, which POSIX sh implementations like
+// dash don't provide. We fall back to `sh` (and finally a well-known absolute
+// path) when bash isn't available.
+// See https://github.com/jetify-com/devbox/issues/2607
+func scriptRunnerPath() string {
+	if bashPath := cmdutil.GetPathOrDefault("bash", ""); bashPath != "" {
+		return bashPath
+	}
+	return cmdutil.GetPathOrDefault("sh", "/bin/sh")
 }

--- a/internal/nix/run_test.go
+++ b/internal/nix/run_test.go
@@ -4,6 +4,8 @@
 package nix
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -23,7 +25,12 @@ func TestRunScriptUsesBashForBashisms(t *testing.T) {
 	}
 
 	// `source` fails under dash (`source: not found`) but succeeds under bash.
-	err := RunScript(t.TempDir(), "source /dev/null", map[string]string{})
+	dir := t.TempDir()
+	sourced := filepath.Join(dir, "sourced.sh")
+	if err := os.WriteFile(sourced, []byte("SOURCED=1\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	err := RunScript(dir, "source "+sourced, map[string]string{})
 	if err != nil {
 		t.Fatalf("RunScript should run bashisms under bash, got error: %v", err)
 	}

--- a/internal/nix/run_test.go
+++ b/internal/nix/run_test.go
@@ -1,0 +1,39 @@
+// Copyright 2024 Jetify Inc. and contributors. All rights reserved.
+// Use of this source code is governed by the license in the LICENSE file.
+
+package nix
+
+import (
+	"strings"
+	"testing"
+
+	"go.jetify.com/devbox/internal/cmdutil"
+)
+
+// TestRunScriptUsesBashForBashisms verifies that RunScript executes scripts
+// with bash so that init hooks and scripts relying on bash features work with
+// `devbox run`, matching the behavior of `devbox shell`. `source` is a bash
+// builtin that POSIX sh implementations like dash don't provide, so it makes a
+// good proxy for "are we running under bash?".
+//
+// Regression test for https://github.com/jetify-com/devbox/issues/2607
+func TestRunScriptUsesBashForBashisms(t *testing.T) {
+	if !cmdutil.Exists("bash") {
+		t.Skip("bash is not installed; RunScript falls back to sh")
+	}
+
+	// `source` fails under dash (`source: not found`) but succeeds under bash.
+	err := RunScript(t.TempDir(), "source /dev/null", map[string]string{})
+	if err != nil {
+		t.Fatalf("RunScript should run bashisms under bash, got error: %v", err)
+	}
+}
+
+func TestScriptRunnerPathPrefersBash(t *testing.T) {
+	if !cmdutil.Exists("bash") {
+		t.Skip("bash is not installed")
+	}
+	if got := scriptRunnerPath(); !strings.HasSuffix(got, "bash") {
+		t.Errorf("scriptRunnerPath() = %q, want a path ending in \"bash\"", got)
+	}
+}

--- a/internal/shellgen/scripts.go
+++ b/internal/shellgen/scripts.go
@@ -106,7 +106,8 @@ func WriteScriptFile(devbox devboxer, name, body string) (err error) {
 	defer script.Close() // best effort: close file
 
 	if featureflag.ScriptExitOnError.Enabled() {
-		// NOTE: Devbox scripts run using `sh` for consistency.
+		// NOTE: Devbox scripts run using bash when available (see
+		// nix.scriptRunnerPath), falling back to POSIX sh; `set -e` works in both.
 		body = fmt.Sprintf("set -e\n\n%s", body)
 	}
 	_, err = script.WriteString(body)

--- a/internal/shellgen/tmpl/script-wrapper.tmpl
+++ b/internal/shellgen/tmpl/script-wrapper.tmpl
@@ -3,8 +3,10 @@
     hooks once, even if the init hook calls devbox run again. This will also
     protect against using devbox service in the init hook.
 
-    Scripts always use sh to run, so POSIX is OK. We don't (yet) support fish
-    scripts. (though users can run a fish script within their script)
+    Scripts run with bash when it's available (falling back to POSIX sh), so
+    that they behave the same as init hooks do inside `devbox shell`. We don't
+    (yet) support fish scripts. (though users can run a fish script within their
+    script)
 */ -}}
 
 if [ -z "${{ .SkipInitHookHash }}" ]; then

--- a/testscripts/run/init_hook_source.test.txt
+++ b/testscripts/run/init_hook_source.test.txt
@@ -1,0 +1,28 @@
+# An init hook that uses the bash `source` builtin should work with
+# `devbox run`, just like it does inside `devbox shell`. Previously this
+# failed with "source: not found" on systems where /bin/sh is a POSIX shell
+# such as dash, because scripts were run with sh instead of bash.
+# Regression test for https://github.com/jetify-com/devbox/issues/2607
+
+# A script that relies on state set up by a sourced init hook should run.
+exec devbox run print_sourced
+stdout 'sourced-value'
+
+# Running the `source` builtin directly should also work.
+exec devbox run source_directly
+stdout 'ran source ok'
+
+-- devbox.json --
+{
+  "packages": [],
+  "shell": {
+    "init_hook": "source ./configure.sh",
+    "scripts": {
+      "print_sourced": "echo $SOURCED_VAR",
+      "source_directly": "source ./configure.sh && echo \"ran source ok\""
+    }
+  }
+}
+
+-- configure.sh --
+export SOURCED_VAR=sourced-value


### PR DESCRIPTION
## Summary

Fixes #2607.

`devbox run` executed generated scripts — and the init hook they `source` — with `sh`. On many systems (Debian/Ubuntu, and the CI containers used here) `/bin/sh` is a POSIX shell such as **dash**. Init hooks that use bash features, most commonly the `source` builtin, work inside `devbox shell` (which runs them under the user's interactive shell, usually bash) but fail under `devbox run` with:

```
.hooks.sh: source: not found
Error: error running script "..." in Devbox: exit status 127
```

So the same `devbox.json` behaves differently between `devbox shell` and `devbox run`, which is surprising and hard to debug.

### Change

- `nix.RunScript` now prefers **bash**, falling back to POSIX `sh` (and finally a well-known absolute path) when bash isn't installed. Running scripts under bash matches the interactive shell and is a strict superset of the previous behavior for POSIX scripts.
- Updated the now-stale `Scripts always use sh to run` comments in `internal/shellgen` to reflect the new behavior.

The fallback keeps things working on the rare system without bash, so no POSIX script regresses.

## How was it tested?

- `go build ./...`, `go vet`, and `gofmt` are clean.
- Added a unit test in the `nix` package (`internal/nix/run_test.go`) that runs the `source` builtin through `RunScript` and asserts it succeeds — this fails when scripts run under dash and passes under bash.
- Added an integration testscript (`testscripts/run/init_hook_source.test.txt`) reproducing the exact issue: an `init_hook` that `source`s a file, with a script that reads the sourced variable.
- Manually confirmed the root cause: `dash -c 'source /dev/null'` → `source: not found` (exit 127); `bash -c 'source /dev/null'` → ok.

cc @ashishkurian (issue reporter)

## Community Contribution License

All community contributions in this pull request are licensed to the project
maintainers under the terms of the
[Apache 2 License](https://www.apache.org/licenses/LICENSE-2.0).

By creating this pull request, I represent that I have the right to license the
contributions to the project maintainers under the Apache 2 License as stated in
the
[Community Contribution License](https://github.com/jetify-com/opensource/blob/main/CONTRIBUTING.md#community-contribution-license).

---
_Generated by [Claude Code](https://claude.ai/code/session_01WEsmatXnTzGGBLG9H5ySrw)_