### PR TITLE
fix(nginx plugin): place mime.types next to nginx.conf so include resolves

### DIFF
--- a/plugins/nginx.json
+++ b/plugins/nginx.json
@@ -1,6 +1,6 @@
 {
   "name": "nginx",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "nginx can be configured with env variables\n\nTo customize:\n* Use $NGINX_CONFDIR to change the configuration directory\n* Use $NGINX_TMPDIR to change the tmp directory. Use $NGINX_USER to change the user\n* Use $NGINX_WEB_PORT to change the port NGINX runs on. \n Note: This plugin uses envsubst when running `devbox services` to generate the nginx.conf file from the nginx.template file. To customize the nginx.conf file, edit the nginx.template file.\n",
   "packages": ["gettext@latest", "gawk@latest"],
   "env": {
@@ -14,7 +14,7 @@
   },
   "create_files": {
     "{{ .Virtenv }}/temp": "",
-    "{{ .Virtenv }}/mime.types": "nginx/mime.types",
+    "{{ .DevboxDir }}/mime.types": "nginx/mime.types",
     "{{ .Virtenv }}/process-compose.yaml": "nginx/process-compose.yaml",
     "{{ .DevboxDir }}/nginx.template": "nginx/nginx.template",
     "{{ .DevboxDir }}/nginx.conf": "nginx/nginx.conf",


### PR DESCRIPTION
## Summary

Fixes #2908.

The nginx plugin currently fails to start because it cannot find its `mime.types` file:

```
[emerg] open() ".../devbox.d/nginx/mime.types" failed (2: No such file or directory) in .../devbox.d/nginx/nginx.conf:6
```

**Root cause:** PR #2844 added `include mime.types;` to `nginx.conf` and created the `mime.types` file at `{{ .Virtenv }}/mime.types` (`.devbox/virtenv/nginx/mime.types`), under the assumption that `nginx -p $NGINX_PATH_PREFIX` would make the relative `include` resolve against the prefix path. In fact nginx only uses the `-p` prefix for *runtime* paths (`error_log`, `access_log`, `root`, …); at **configuration** time, relative `include` paths are resolved relative to the `nginx.conf` file itself, which devbox places in the `DevboxDir` (`devbox.d/nginx/`).

**Fix:** Create `mime.types` in the `DevboxDir` alongside `nginx.conf`, so the relative `include mime.types;` resolves correctly. This mirrors how the plugin already handles `fastcgi.conf` (also created in `DevboxDir`). The plugin version is bumped `0.0.5` → `0.0.6` to follow the existing convention (PR #2844 bumped `0.0.4` → `0.0.5`).

```diff
-    "{{ .Virtenv }}/mime.types": "nginx/mime.types",
+    "{{ .DevboxDir }}/mime.types": "nginx/mime.types",
```

## Scope: fresh installs vs. existing environments

This fix applies automatically to **fresh installs** of the nginx plugin (new projects, or projects with no prior nginx lockfile entry) — the relocated `mime.types` is created next to `nginx.conf` and the `include` resolves.

It does **not** auto-remediate **environments that already installed the plugin** (i.e. anyone already affected by #2908). Devbox intentionally treats files under `devbox.d/` as user-owned and never overwrites them once the plugin is recorded in `devbox.lock`: `shouldCreateFile` (`internal/plugin/plugin.go:233`) returns `false` for any `devbox.d/` path when `PluginVersion != ""`, and this check is not gated on a version change — so the version bump alone does not force regeneration. (The same limitation applied to PR #2844's original change.)

**Manual remediation for existing broken environments:** remove the plugin's materialized config dir and reinstall, e.g.

```sh
rm -rf devbox.d/nginx
devbox install
```

The stale `.devbox/virtenv/nginx/mime.types` from `0.0.5` is harmless — nothing references it after this change.

## How was it tested?

- Verified `plugins/nginx.json` remains valid JSON.
- Traced the file-placement logic: `nginx.conf` is created at `{{ .DevboxDir }}/nginx.conf` and uses a relative `include mime.types;`; placing `mime.types` in the same `DevboxDir` makes the include resolvable. The `fastcgi.conf` file already follows this exact placement pattern.
- Traced `CreateFilesForConfig` / `shouldCreateFile` in `internal/plugin/plugin.go` to confirm fresh installs create the file (all `devbox.d/nginx/` files are only created because a fresh install has no locked `PluginVersion`) and to characterize the existing-environment behavior documented above.
- No other references to the `{{ .Virtenv }}/mime.types` path exist in the codebase, and the nginx `env.test.txt` testscript does not assert on the `mime.types` location, so behavior is unchanged apart from the fix.

cc @jefft (issue reporter)

## Community Contribution License

All community contributions in this pull request are licensed to the project
maintainers under the terms of the
[Apache 2 License](https://www.apache.org/licenses/LICENSE-2.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013yJQ9FtijMB9SfnTeRVC1P