### PR TITLE
fix(mariadb plugin): wrap mysql/mariadb clients with project socket (#2522)

### DIFF
--- a/plugins/mariadb/flake.nix
+++ b/plugins/mariadb/flake.nix
@@ -28,6 +28,21 @@
               --add-flags '--basedir=$out --datadir=''$MYSQL_DATADIR --pid-file=''$MYSQL_PID_FILE --socket=''$MYSQL_UNIX_PORT';
           fi
 
+          # Point the client binaries at the project's socket. Unlike the MySQL
+          # client, the MariaDB client does not honor the MYSQL_UNIX_PORT
+          # environment variable, so without this it falls back to its
+          # compile-time default (e.g. /run/mysqld/mysqld.sock).
+          # https://github.com/jetify-com/devbox/issues/2522
+          if [ -e "$out/bin/mysql" ]; then
+            wrapProgram "$out/bin/mysql" \
+              --add-flags '--socket=''$MYSQL_UNIX_PORT';
+          fi
+
+          if [ -e "$out/bin/mariadb" ]; then
+            wrapProgram "$out/bin/mariadb" \
+              --add-flags '--socket=''$MYSQL_UNIX_PORT';
+          fi
+
           wrapProgram "$out/bin/mysql_install_db" \
             --add-flags '--basedir=$out --datadir=''$MYSQL_DATADIR --pid-file=''$MYSQL_PID_FILE --basedir=''$MYSQL_BASEDIR';
 


### PR DESCRIPTION
## Summary

Fixes #2522.

The MariaDB client does not honor the `MYSQL_UNIX_PORT` environment variable, so running the client inside a Devbox environment (`devbox run mariadb` / `devbox run mysql`) falls back to its compile-time default socket (e.g. `/run/mysqld/mysqld.sock`) instead of the project's socket at `$MYSQL_UNIX_PORT`:

```
ERROR 2002 (HY000): Can't connect to local server through socket '/run/mysqld/mysqld.sock' (2)
```

This differs from the `mysql` plugin, whose (Oracle MySQL) client *does* honor `MYSQL_UNIX_PORT`, which is why the same steps work there.

This change wraps the `mysql` and `mariadb` client binaries in the mariadb plugin's `flake.nix` so they default to `--socket=$MYSQL_UNIX_PORT`, mirroring how the daemon binaries (`mysqld`, `mariadbd`, `mysqld_safe`, ...) are already wrapped. It's the fix suggested by the reporter in the issue.

Details:
- Each wrap is guarded by an existence check (`[ -e ... ]`) because the available client names vary across MariaDB versions (`mysql` is typically a symlink to `mariadb`).
- `--add-flags` prepends the socket flag, so users can still override it explicitly (e.g. connecting to a remote host over TCP is unaffected).
- The generated flake lives under `.devbox/`, which Devbox always regenerates, so existing projects pick up the fix on the next shell entry (the changed derivation rebuilds the wrapped package).

cc @jefft (issue reporter)

## How was it tested?

- `go build ./internal/plugin/... ./plugins/...` passes; the plugin's `flake.nix` is embedded via `//go:embed` in `plugins/builtins.go`.
- Reviewed the generated Nix `postBuild` output for shell correctness (proper `[ -e ... ]` guards, `''$MYSQL_UNIX_PORT` escaping consistent with the surrounding wrappers).

Note: I don't have a Nix-enabled environment here to run the full `devbox create --template mariadb` reproduction end to end, so a maintainer verification of `devbox run mariadb` connecting to `$MYSQL_UNIX_PORT` would be appreciated.

## Community Contribution License

All community contributions in this pull request are licensed to the project
maintainers under the terms of the
[Apache 2 License](https://www.apache.org/licenses/LICENSE-2.0).

By creating this pull request, I represent that I have the right to license the
contributions to the project maintainers under the Apache 2 License as stated in
the
[Community Contribution License](https://github.com/jetify-com/opensource/blob/main/CONTRIBUTING.md#community-contribution-license).

---
_Generated by [Claude Code](https://claude.ai/code/session_01D8QQU1dVaNycyxQWcRyBhs)_