### PR TITLE
fix(shellenv): preserve newlines in exported env values (ambiguous redirect)

### DIFF
--- a/internal/devbox/envvars.go
+++ b/internal/devbox/envvars.go
@@ -93,7 +93,16 @@ func exportify(w io.Writer, vars map[string]string) string {
 				switch r {
 				// Special characters inside double quotes:
 				// https://pubs.opengroup.org/onlinepubs/009604499/utilities/xcu_chap02.html#tag_02_02_03
-				case '$', '`', '"', '\\', '\n':
+				//
+				// Note: newline is intentionally NOT escaped. A literal newline
+				// inside double quotes is preserved as-is, but a backslash
+				// followed by a newline is a line continuation that the shell
+				// *removes*, silently joining the two lines. Escaping it would
+				// corrupt any multi-line value (e.g. a PROMPT_COMMAND that spans
+				// several lines), producing broken shell such as
+				// `... 2>&1__bp_interactive_mode` and errors like
+				// "ambiguous redirect". See issue #2814.
+				case '$', '`', '"', '\\':
 					strb.WriteRune('\\')
 				}
 				strb.WriteRune(r)

--- a/internal/devbox/envvars.go
+++ b/internal/devbox/envvars.go
@@ -89,8 +89,8 @@ func exportify(w io.Writer, vars map[string]string) string {
 			strb.WriteString("export ")
 			strb.WriteString(key)
 			strb.WriteString(`="`)
-			for _, r := range vars[key] {
-				switch r {
+			for _, char := range vars[key] {
+				switch char {
 				// Special characters inside double quotes:
 				// https://pubs.opengroup.org/onlinepubs/009604499/utilities/xcu_chap02.html#tag_02_02_03
 				//
@@ -105,7 +105,7 @@ func exportify(w io.Writer, vars map[string]string) string {
 				case '$', '`', '"', '\\':
 					strb.WriteRune('\\')
 				}
-				strb.WriteRune(r)
+				strb.WriteRune(char)
 			}
 			strb.WriteString("\";\n")
 		}

--- a/internal/devbox/envvars_test.go
+++ b/internal/devbox/envvars_test.go
@@ -47,6 +47,28 @@ func TestExportifySkipsInvalidNames(t *testing.T) {
 	}
 }
 
+// TestExportifyPreservesNewlines ensures multi-line env values (e.g. a
+// PROMPT_COMMAND that spans several lines) survive round-tripping through the
+// shell. A newline must be emitted literally, not as a backslash-newline: inside
+// double quotes the latter is a line continuation that the shell removes, which
+// silently joins adjacent lines and corrupts the value. See issue #2814, where a
+// multi-line PROMPT_COMMAND collapsed into `... 2>&1__bp_interactive_mode` and
+// produced a "bash: ...: ambiguous redirect" error at every prompt.
+func TestExportifyPreservesNewlines(t *testing.T) {
+	value := "line1 >/dev/null 2>&1\n__bp_interactive_mode"
+	got := exportify(io.Discard, map[string]string{"PROMPT_COMMAND": value})
+
+	// The value must be emitted with a literal newline, never a
+	// backslash-newline (which bash would strip as a line continuation).
+	if strings.Contains(got, "2>&1\\\n") {
+		t.Errorf("newline was escaped as a line continuation, which corrupts the value:\n%s", got)
+	}
+	want := "export PROMPT_COMMAND=\"line1 >/dev/null 2>&1\n__bp_interactive_mode\";"
+	if got != want {
+		t.Errorf("exportify(...) = %q, want %q", got, want)
+	}
+}
+
 func TestExportifyNushellSkipsInvalidNames(t *testing.T) {
 	got := exportifyNushell(io.Discard, map[string]string{
 		"GOOD": "value",


### PR DESCRIPTION
## Summary

Fixes #2814.

`eval "$(devbox global shellenv)"` printed `bash: ...__bp_interactive_mode: ambiguous redirect` at every prompt when the user's `PROMPT_COMMAND` was multi-line (as set up by bash-preexec / the elementary terminal integration).

**Root cause:** `exportify` (`internal/devbox/envvars.go`) emits each variable as `export KEY="value";`, escaping special characters so the value is treated literally. It escaped newlines as a backslash followed by the newline. Inside a bash double-quoted string, a backslash-newline is a **line continuation** that the shell *removes*, silently joining the two lines. So a `PROMPT_COMMAND` like:

```
__bp_precmd_invoke_cmd
dbus-send ... >/dev/null 2>&1
__bp_interactive_mode
```

collapsed into `... 2>&1__bp_interactive_mode`, and bash parsed `2>&1__bp_interactive_mode` as a redirect to the ambiguous target `1__bp_interactive_mode` → *"ambiguous redirect"*.

**Fix:** stop escaping the newline. A literal newline inside double quotes is already preserved verbatim, so the value round-trips correctly. `$`, `` ` ``, `"`, and `\` are still escaped as before.

```diff
-				case '$', '`', '"', '\\', '\n':
+				case '$', '`', '"', '\\':
```

Demonstration of the two behaviors:

```console
$ X="a 2>&1\<newline>b"   # backslash-newline (old): lines fused
$ echo "[$X]"
[a 2>&1b]

$ X="a 2>&1<newline>b"    # literal newline (new): preserved
$ echo "[$X]"
[a 2>&1
b]
```

## How was it tested?

- Added `TestExportifyPreservesNewlines` reproducing the issue's multi-line `PROMPT_COMMAND` and asserting the newline is emitted literally (never as a backslash-newline line continuation).
- `go test ./internal/devbox/ -run 'TestExportify|TestIsValidEnvName'` — all pass.
- `go build ./internal/devbox/`, `go vet ./internal/devbox/`, and `gofmt -l` — clean.

## Community Contribution License

All community contributions in this pull request are licensed to the project
maintainers under the terms of the
[Apache 2 License](https://www.apache.org/licenses/LICENSE-2.0).

By creating this pull request, I represent that I have the right to license the
contributions to the project maintainers under the Apache 2 License as stated in
the
[Community Contribution License](https://github.com/jetify-com/opensource/blob/main/CONTRIBUTING.md#community-contribution-license).

---

cc @proedie (issue reporter)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014nhuYqHdGxzteXxH78b4sE

---
_Generated by [Claude Code](https://claude.ai/code/session_014nhuYqHdGxzteXxH78b4sE)_