### PR TITLE
fix(generate): drop `nix-store --optimise` from generated dev Dockerfile

### DIFF
--- a/internal/devbox/generate/devcontainer_util_test.go
+++ b/internal/devbox/generate/devcontainer_util_test.go
@@ -4,7 +4,6 @@
 package generate
 
 import (
-	"context"
 	"os"
 	"path/filepath"
 	"strings"
@@ -43,7 +42,7 @@ func generateDevDockerfile(t *testing.T, rootUser bool) string {
 		Path:     dir,
 		RootUser: rootUser,
 	}
-	if err := g.CreateDockerfile(context.Background(), CreateDockerfileOptions{
+	if err := g.CreateDockerfile(t.Context(), CreateDockerfileOptions{
 		ForType: "dev",
 	}); err != nil {
 		t.Fatalf("CreateDockerfile failed: %v", err)

--- a/internal/devbox/generate/devcontainer_util_test.go
+++ b/internal/devbox/generate/devcontainer_util_test.go
@@ -1,0 +1,57 @@
+// Copyright 2024 Jetify Inc. and contributors. All rights reserved.
+// Use of this source code is governed by the license in the LICENSE file.
+
+package generate
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestCreateDockerfileDevOmitsNixStoreOptimise ensures the generated dev
+// Dockerfile does not run `nix-store --optimise`. That command fails on Docker's
+// default overlay2 storage driver ("cannot rename: Stale file handle") and
+// breaks the image build, while providing negligible size savings in a freshly
+// built image. Regression test for
+// https://github.com/jetify-com/devbox/issues/2616.
+func TestCreateDockerfileDevOmitsNixStoreOptimise(t *testing.T) {
+	for _, rootUser := range []bool{false, true} {
+		dockerfile := generateDevDockerfile(t, rootUser)
+
+		if strings.Contains(dockerfile, "nix-store --optimise") {
+			t.Errorf("generated dev Dockerfile (rootUser=%t) should not run "+
+				"`nix-store --optimise`; it breaks Docker builds on overlay2.\n%s",
+				rootUser, dockerfile)
+		}
+		// The garbage-collection pass is still wanted: it removes build-time
+		// dependencies and is what actually shrinks the image.
+		if !strings.Contains(dockerfile, "nix-store --gc") {
+			t.Errorf("generated dev Dockerfile (rootUser=%t) should still run "+
+				"`nix-store --gc`.\n%s", rootUser, dockerfile)
+		}
+	}
+}
+
+func generateDevDockerfile(t *testing.T, rootUser bool) string {
+	t.Helper()
+
+	dir := t.TempDir()
+	g := &Options{
+		Path:     dir,
+		RootUser: rootUser,
+	}
+	if err := g.CreateDockerfile(context.Background(), CreateDockerfileOptions{
+		ForType: "dev",
+	}); err != nil {
+		t.Fatalf("CreateDockerfile failed: %v", err)
+	}
+
+	contents, err := os.ReadFile(filepath.Join(dir, "Dockerfile"))
+	if err != nil {
+		t.Fatalf("reading generated Dockerfile: %v", err)
+	}
+	return string(contents)
+}

--- a/internal/devbox/generate/tmpl/dev.Dockerfile.tmpl
+++ b/internal/devbox/generate/tmpl/dev.Dockerfile.tmpl
@@ -21,7 +21,16 @@ COPY devbox.lock devbox.lock
 {{range $i, $element := .LocalFlakeDirs -}}
 COPY {{$element}} {{$element}}
 {{end}}
-RUN devbox run -- echo "Installed Packages." && nix-store --gc && nix-store --optimise
+{{- /*
+We run `nix-store --gc` to drop build-time dependencies and shrink the image,
+but intentionally do NOT run `nix-store --optimise`. Optimise hard-links
+duplicate files in the Nix store, and on Docker's default overlay2 storage
+driver the rename it performs fails with "cannot rename: Stale file handle",
+which breaks the image build. In a freshly built, single-purpose image there is
+little to no duplication to reclaim anyway, so the optimise pass provides
+negligible benefit. See https://github.com/jetify-com/devbox/issues/2616.
+*/ -}}
+RUN devbox run -- echo "Installed Packages." && nix-store --gc
 {{if .IsDevcontainer}}
 RUN devbox shellenv --init-hook >> ~/.profile
 {{- else}}


### PR DESCRIPTION
## Summary

Fixes #2616.

The dev Dockerfile produced by `devbox generate dockerfile` / `devbox generate devcontainer` runs:

```dockerfile
RUN devbox run -- echo "Installed Packages." && nix-store --gc && nix-store --optimise
```

`nix-store --optimise` deduplicates the Nix store by hard-linking identical files. On Docker's default **overlay2** storage driver the rename it performs on the temporary link fails with a stale file handle, which aborts the image build:

```
error: filesystem error: cannot rename: Stale file handle
  [/nix/store/.tmp-link-...] [/nix/store/...-aws-c-common-0.9.27/nix-support/setup-hook]
------
 13 | >>> RUN devbox run -- echo "Installed Packages." && nix-store --gc && nix-store --optimise
ERROR: failed to solve: ... did not complete successfully: exit code: 1
```

So the Dockerfile that `devbox generate` emits does not build out of the box, and the reporter confirmed that removing `nix-store --optimise` fixes it.

### Fix

Drop the `nix-store --optimise` step from `dev.Dockerfile.tmpl`, keeping `nix-store --gc`:

- `nix-store --gc` is the pass that actually shrinks the image — it drops the build-time closure (`.drv` files, bootstrap tools, source tarballs). That part already completes successfully in the failing build log.
- `nix-store --optimise` provides negligible benefit here: in a freshly built, single-purpose image there is little to no duplication to reclaim, and Nix itself reports `note: currently hard linking saves -0.00 MiB` right before it errors out.

A template comment documents why the optimise pass is intentionally omitted (with a link back to the issue) so it isn't reintroduced later.

## How was it tested?

- Added `internal/devbox/generate/devcontainer_util_test.go`, which renders the dev Dockerfile (for both root and non-root users) and asserts it no longer contains `nix-store --optimise` while still running `nix-store --gc`. Verified the test **fails** when the optimise step is present and **passes** with the fix.
- `go test ./internal/devbox/generate/...`, `go build ./internal/...`, `go vet`, and `gofmt` are clean.
- Rendered the generated Dockerfile to confirm the output is well-formed and the `RUN` line is now `RUN devbox run -- echo "Installed Packages." && nix-store --gc`.

cc @jDmacD (issue reporter) — thanks for the detailed build log and root-cause.

## Community Contribution License

All community contributions in this pull request are licensed to the project
maintainers under the terms of the
[Apache 2 License](https://www.apache.org/licenses/LICENSE-2.0).

By creating this pull request, I represent that I have the right to license the
contributions to the project maintainers under the Apache 2 License as stated in
the
[Community Contribution License](https://github.com/jetify-com/opensource/blob/main/CONTRIBUTING.md#community-contribution-license).

---
_Generated by [Claude Code](https://claude.ai/code/session_01W6BX9jAviSLnWk93YUeD6W)_