### PR TITLE
feat(generate): add Services section to generated project README

### DIFF
--- a/internal/devbox/docgen/docgen.go
+++ b/internal/devbox/docgen/docgen.go
@@ -45,6 +45,11 @@ func GenerateReadme(
 		outputPath = defaultName
 	}
 
+	services, err := devbox.Services()
+	if err != nil {
+		return err
+	}
+
 	f, err := os.Create(outputPath)
 	if err != nil {
 		return err
@@ -58,6 +63,7 @@ func GenerateReadme(
 		"EnvVars":  devbox.Config().Env(),
 		"InitHook": devbox.Config().InitHook(),
 		"Packages": devbox.TopLevelPackages(),
+		"Services": services,
 		// TODO add includes
 	})
 }

--- a/internal/devbox/docgen/readme.tmpl
+++ b/internal/devbox/docgen/readme.tmpl
@@ -33,6 +33,16 @@ Scripts are custom commands that can be run using this project's environment. Th
 {{- end }}
 {{ end }}
 
+{{- if .Services }}
+## Services
+Services are long-running processes (such as databases or web servers) provided by this project's packages and plugins. This project has the following services:
+{{ range $name, $_ := .Services }}
+* {{ $name }}
+{{- end }}
+
+Start all services with `devbox services up`, and stop them with `devbox services stop`. You can also target an individual service by name, for example `devbox services up <service>`. Run `devbox services ls` to list the services and their status.
+{{ end }}
+
 {{- if .EnvVars }}
 ## Environment
 

--- a/testscripts/generate/readme.test.txt
+++ b/testscripts/generate/readme.test.txt
@@ -1,0 +1,26 @@
+# Verify `devbox generate readme` includes a Services section listing the
+# services defined for the project. See issue #2626.
+
+exec devbox init
+exists devbox.json
+
+# `devbox generate readme` should discover the services defined in the
+# project's process-compose.yaml (see the embedded file below).
+exec devbox generate readme
+exists README.md
+
+# The generated README should contain a Services section that lists each
+# service and documents how to start/stop them.
+grep '## Services' README.md
+grep '\* web' README.md
+grep '\* worker' README.md
+grep 'devbox services up' README.md
+grep 'devbox services stop' README.md
+
+-- process-compose.yaml --
+version: "0.5"
+processes:
+  web:
+    command: "echo web"
+  worker:
+    command: "echo worker"


### PR DESCRIPTION
## Summary

Fixes #2626.

`devbox generate readme` produces a project README that documents the
project's **scripts**, **packages**, **environment variables**, and **shell init
hook** — but it never mentioned **services**. As the issue reporter points out,
services are as central to a Devbox environment as scripts and packages, so
their absence from the generated README both hid a useful feature and left
readers unaware that services exist at all.

This PR adds a **Services** section to the generated README, mirroring how
Scripts are documented:

- Lists each service available to the project. Services are gathered the same
  way the rest of the CLI gathers them — via `Devbox.Services()`, which combines
  plugin-provided services with any defined in the project's
  `process-compose.yaml`.
- Documents how to start (`devbox services up`), stop (`devbox services stop`),
  and list (`devbox services ls`) services, including targeting an individual
  service by name.
- The section is omitted entirely when the project defines no services (the
  template guards it with `{{- if .Services }}`), so existing service-less
  projects generate an unchanged README.

### Changes

- `internal/devbox/docgen/docgen.go` — pass the project's services into the
  template data (propagating any error from `Devbox.Services()`).
- `internal/devbox/docgen/readme.tmpl` — render the new Services section.
- `testscripts/generate/readme.test.txt` — new testscript that defines two
  services via a project `process-compose.yaml`, runs `devbox generate readme`,
  and asserts the generated README lists both services and documents how to
  start/stop them.

## How was it tested?

- Added `testscripts/generate/readme.test.txt` covering the new behavior end to
  end (`devbox init` → `devbox generate readme` → assert the Services section and
  service names are present).
- Rendered `readme.tmpl` directly against a sample data map (with and without
  services) to confirm the Services section appears when services are present,
  is omitted when they are absent, and that all other sections are unchanged.
- `go build ./...`, `go vet ./internal/devbox/docgen/`, and `gofmt` are clean on
  the changed files.

cc @ametad (issue reporter) — thanks for the suggestion!

## Community Contribution License

All community contributions in this pull request are licensed to the project
maintainers under the terms of the
[Apache 2 License](https://www.apache.org/licenses/LICENSE-2.0).

By creating this pull request, I represent that I have the right to license the
contributions to the project maintainers under the Apache 2 License as stated in
the
[Community Contribution License](https://github.com/jetify-com/opensource/blob/main/CONTRIBUTING.md#community-contribution-license).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qgu2wVkmAdXLRKcpgevoBW

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qgu2wVkmAdXLRKcpgevoBW)_