### PR TITLE
fix(env): don't leak nixpkgs SOURCE_DATE_EPOCH into the shell (#2597)

### DIFF
--- a/internal/devbox/devbox.go
+++ b/internal/devbox/devbox.go
@@ -1079,8 +1079,9 @@ var ignoreCurrentEnvVar = map[string]bool{
 // ignoreDevEnvVar contains environment variables that Devbox should remove from
 // the slice of [Devbox.PrintDevEnv] variables before sourcing them.
 //
-// This list comes directly from the "nix develop" source:
+// Most of this list comes directly from the "nix develop" source:
 // https://github.com/NixOS/nix/blob/f08ad5bdbac02167f7d9f5e7f9bab57cf1c5f8c4/src/nix/develop.cc#L257-L275
+// Entries not in that list are called out below.
 var ignoreDevEnvVar = map[string]bool{
 	"BASHOPTS":           true,
 	"HOME":               true,
@@ -1091,13 +1092,28 @@ var ignoreDevEnvVar = map[string]bool{
 	"PPID":               true,
 	"SHELL":              true,
 	"SHELLOPTS":          true,
-	"TEMP":               true,
-	"TEMPDIR":            true,
-	"TERM":               true,
-	"TMP":                true,
-	"TMPDIR":             true,
-	"TZ":                 true,
-	"UID":                true,
+
+	// SOURCE_DATE_EPOCH is set by the nixpkgs stdenv to a fixed timestamp
+	// (315532800 = 1980-01-01) so that *builds* are reproducible. Leaking it
+	// into the interactive Devbox shell makes any timestamp-respecting tool run
+	// there stamp its output with 1980 instead of the current time. The most
+	// visible symptom is Docker images showing up as created "45 years ago"
+	// (which can trip age-based registry cleanup), but it also affects tar,
+	// gzip, and other build tools. Ignore the Nix-provided value so the shell
+	// falls back to the current environment (normally unset, so tools use the
+	// real time). Users who genuinely want reproducible builds can still set
+	// SOURCE_DATE_EPOCH explicitly via devbox.json's env block, which is layered
+	// on top of these variables. See
+	// https://github.com/jetify-com/devbox/issues/2597.
+	"SOURCE_DATE_EPOCH": true,
+
+	"TEMP":    true,
+	"TEMPDIR": true,
+	"TERM":    true,
+	"TMP":     true,
+	"TMPDIR":  true,
+	"TZ":      true,
+	"UID":     true,
 }
 
 func (d *Devbox) ProjectDirHash() string {

--- a/testscripts/run/source_date_epoch.test.txt
+++ b/testscripts/run/source_date_epoch.test.txt
@@ -1,0 +1,15 @@
+# The nixpkgs stdenv sets SOURCE_DATE_EPOCH to a fixed timestamp
+# (315532800 = 1980-01-01) so that builds are reproducible. Devbox must not
+# leak that value into the interactive shell, otherwise timestamp-respecting
+# tools (docker build, tar, gzip, ...) stamp their output with 1980 -- e.g.
+# Docker images show up as created "45 years ago". See
+# https://github.com/jetify-com/devbox/issues/2597.
+
+exec devbox run echo 'epoch=<$SOURCE_DATE_EPOCH>'
+stdout 'epoch=<'
+! stdout '315532800'
+
+-- devbox.json --
+{
+  "packages": []
+}


### PR DESCRIPTION
## Summary

Fixes #2597.

The nixpkgs stdenv sets `SOURCE_DATE_EPOCH` to a fixed timestamp
(`315532800` = 1980-01-01) so that *builds* are reproducible. Devbox sources the
variables from `nix print-dev-env` into the interactive shell, so this value
leaked into every Devbox environment.

As a result, any timestamp-respecting tool run inside the shell stamps its output
with 1980 instead of the current time. The most visible symptom is Docker images
showing up as created **"45 years ago"** — which, as the reporter notes, can trip
age-based registry cleanup and delete freshly built images. It also affects
`tar`, `gzip`, and other build tools.

**Root cause:** `computeNixEnv` (`internal/devbox/devbox.go`) copies every
`exported` variable from `nix print-dev-env` except those in `ignoreDevEnvVar`.
That denylist mirrors Nix's own `nix develop` ignore list, which does **not**
include `SOURCE_DATE_EPOCH`, so the stdenv value passed straight through.

**Fix:** add `SOURCE_DATE_EPOCH` to `ignoreDevEnvVar`, mirroring how `HOME` and
`TMPDIR` (other stdenv-provided values that are wrong for an interactive shell)
are already ignored. Devbox now drops the Nix-provided value and falls back to
the current environment — normally unset, so tools use the real time. Users who
genuinely want reproducible builds can still set `SOURCE_DATE_EPOCH` explicitly
via `devbox.json`'s `env` block, which is layered on top of these variables.

Worth noting: the `python/pip` and `temporal` examples already carry a
`SOURCE_DATE_EPOCH=$(date +%s)` workaround in their generated `venvShellHook.sh`,
which corroborates that the 1980 leak has been a real-world nuisance.

```diff
 	"SHELLOPTS":          true,
+	"SOURCE_DATE_EPOCH":  true,
 	"TEMP":               true,
```

## How was it tested?

- `go build ./internal/devbox/`, `go vet ./internal/devbox/`, and `gofmt -l` — all clean.
- Added `testscripts/run/source_date_epoch.test.txt`, which asserts that
  `devbox run echo '$SOURCE_DATE_EPOCH'` does not emit the `315532800` (1980)
  value. This fails on the old code and passes with the fix.

cc @truearken (issue reporter)

## Community Contribution License

All community contributions in this pull request are licensed to the project
maintainers under the terms of the
[Apache 2 License](https://www.apache.org/licenses/LICENSE-2.0).

By creating this pull request, I represent that I have the right to license the
contributions to the project maintainers under the Apache 2 License as stated in
the
[Community Contribution License](https://github.com/jetify-com/opensource/blob/main/CONTRIBUTING.md#community-contribution-license).

---
_Generated by [Claude Code](https://claude.ai/code/session_017YBWVPRVeEoftDjUW6WUR4)_