### PR TITLE
fix(services): re-invoke devbox by executable path, not hardcoded name (#1321)

### DIFF
--- a/internal/devbox/services.go
+++ b/internal/devbox/services.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"os"
 	"strconv"
 	"text/tabwriter"
 
@@ -271,7 +272,24 @@ func (d *Devbox) StartProcessManager(
 // defaults for the `devbox services` scenario.
 func (d *Devbox) runDevboxServicesScript(ctx context.Context, cmdArgs []string) error {
 	cmdArgs = append([]string{"services"}, cmdArgs...)
-	return d.RunScript(ctx, devopt.EnvOptions{}, "devbox", cmdArgs)
+	return d.RunScript(ctx, devopt.EnvOptions{}, devboxBinaryForSelfInvocation(), cmdArgs)
+}
+
+// devboxBinaryForSelfInvocation returns a shell-quoted reference to the
+// currently running devbox binary. `devbox services ...` re-invokes devbox
+// inside the computed environment, and using the actual executable path (rather
+// than a hardcoded "devbox") ensures this works even when the binary has been
+// installed or renamed to something other than "devbox". If the executable path
+// can't be determined, it falls back to "devbox", relying on a PATH lookup as
+// before. See https://github.com/jetify-com/devbox/issues/1321.
+func devboxBinaryForSelfInvocation() string {
+	exe, err := os.Executable()
+	if err != nil {
+		return "devbox"
+	}
+	// Quote the path so it survives being eval'd by the generated run script
+	// (e.g. when the path contains spaces).
+	return strconv.Quote(exe)
 }
 
 func (d *Devbox) ShowProcessComposePort(ctx context.Context, writer io.Writer) error {

--- a/internal/devbox/services_test.go
+++ b/internal/devbox/services_test.go
@@ -1,0 +1,32 @@
+// Copyright 2024 Jetify Inc. and contributors. All rights reserved.
+// Use of this source code is governed by the license in the LICENSE file.
+
+package devbox
+
+import (
+	"os"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDevboxBinaryForSelfInvocation verifies that `devbox services ...`
+// re-invokes devbox using the path to the currently running binary rather than
+// a hardcoded "devbox" that must be resolvable on PATH. This is a regression
+// guard for https://github.com/jetify-com/devbox/issues/1321, where services
+// commands broke whenever the binary was installed or renamed to something
+// other than "devbox".
+func TestDevboxBinaryForSelfInvocation(t *testing.T) {
+	exe, err := os.Executable()
+	require.NoError(t, err)
+
+	got := devboxBinaryForSelfInvocation()
+
+	// It should reference the actual running binary (shell-quoted), not the
+	// literal command name "devbox".
+	assert.Equal(t, strconv.Quote(exe), got)
+	assert.NotEqual(t, "devbox", got)
+	assert.NotEqual(t, strconv.Quote("devbox"), got)
+}


### PR DESCRIPTION
## Summary

Fixes #1321.

`devbox services start|stop|ls|restart` (and the non-current-shell path of `devbox services up`) work by **re-invoking devbox inside the computed environment**. `runDevboxServicesScript` builds a command and hands it to `RunScript`, which writes a small script that `eval`s the command. The command began with the hard-coded string `"devbox"`:

```go
// internal/devbox/services.go
func (d *Devbox) runDevboxServicesScript(ctx context.Context, cmdArgs []string) error {
	cmdArgs = append([]string{"services"}, cmdArgs...)
	return d.RunScript(ctx, devopt.EnvOptions{}, "devbox", cmdArgs)
}
```

So the generated script effectively runs `eval "devbox services ..."`, which requires the binary to be named exactly `devbox` **and** be resolvable on `PATH`. If the binary is installed or renamed to anything else (a versioned install, a wrapper, `devbox-cli`, etc.), services commands fail with `devbox: command not found`.

This was the only real self-invocation of the binary — the process-compose manager already shells out via `processComposeConfig.BinPath`, and every other `devbox ...` occurrence in the services code is user-facing help text.

### Fix

Reference the currently running binary via `os.Executable()` instead of the literal `"devbox"`. The path is shell-quoted (via `strconv.Quote`, matching how the surrounding code already quotes arguments before they are `eval`'d) so it survives the eval even if it contains spaces. If the executable path can't be determined, it falls back to `"devbox"` — the previous PATH-lookup behavior.

```go
func devboxBinaryForSelfInvocation() string {
	exe, err := os.Executable()
	if err != nil {
		return "devbox"
	}
	return strconv.Quote(exe)
}
```

This mirrors the existing use of `os.Executable()` in `internal/devbox/pure_shell.go`.

## How was it tested?

- `go build ./...` — clean.
- `go vet ./internal/devbox/` — clean.
- `gofmt` — no diffs.
- Added `TestDevboxBinaryForSelfInvocation` in `internal/devbox/services_test.go`, which asserts the helper returns the shell-quoted path to the running binary rather than the literal `"devbox"`. It passes:
  ```
  --- PASS: TestDevboxBinaryForSelfInvocation (0.00s)
  ```

cc @mikeland73 (issue reporter)

## Community Contribution License

All community contributions in this pull request are licensed to the project
maintainers under the terms of the
[Apache 2 License](https://www.apache.org/licenses/LICENSE-2.0).

By creating this pull request, I represent that I have the right to license the
contributions to the project maintainers under the Apache 2 License as stated in
the
[Community Contribution License](https://github.com/jetify-com/opensource/blob/main/CONTRIBUTING.md#community-contribution-license).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BQ4KvbTQb7oJ2M3tc79DuG

---
_Generated by [Claude Code](https://claude.ai/code/session_01BQ4KvbTQb7oJ2M3tc79DuG)_