### PR TITLE
fix(nix): don't report a broken install for a freshly mounted /nix volume (#2601)

### DIFF
--- a/internal/nix/install.go
+++ b/internal/nix/install.go
@@ -17,7 +17,6 @@ import (
 
 	"go.jetify.com/devbox/internal/boxcli/usererr"
 	"go.jetify.com/devbox/internal/cmdutil"
-	"go.jetify.com/devbox/internal/fileutil"
 	"go.jetify.com/devbox/nix"
 )
 
@@ -25,9 +24,33 @@ func BinaryInstalled() bool {
 	return cmdutil.Exists("nix")
 }
 
-func dirExistsAndIsNotEmpty(dir string) bool {
-	empty, err := fileutil.IsDirEmpty(dir)
-	return err == nil && !empty
+// nonNixDirEntries are directory entries that can appear inside /nix without
+// indicating an existing Nix installation. Container and VM users commonly
+// mount an otherwise-empty volume at /nix, and many filesystems (for example
+// ext4) create a lost+found directory at the root of such a mount. A /nix that
+// contains only these entries should still be treated as a fresh install
+// target rather than a broken installation.
+var nonNixDirEntries = map[string]bool{
+	"lost+found": true,
+	".DS_Store":  true,
+}
+
+// nixDirIsInstalled reports whether dir looks like it already contains a Nix
+// installation. It returns false when dir is missing, empty, or contains only
+// filesystem cruft (see nonNixDirEntries) so that Devbox installs Nix into a
+// freshly mounted /nix volume instead of reporting a broken installation.
+// See https://github.com/jetify-com/devbox/issues/2601.
+func nixDirIsInstalled(dir string) bool {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return false
+	}
+	for _, entry := range entries {
+		if !nonNixDirEntries[entry.Name()] {
+			return true
+		}
+	}
+	return false
 }
 
 var ensured = false
@@ -58,7 +81,7 @@ func EnsureNixInstalled(ctx context.Context, writer io.Writer, withDaemonFunc fu
 	if BinaryInstalled() {
 		return nil
 	}
-	if dirExistsAndIsNotEmpty("/nix") {
+	if nixDirIsInstalled("/nix") {
 		if _, err = SourceProfile(); err != nil {
 			return err
 		} else if BinaryInstalled() {

--- a/internal/nix/install_test.go
+++ b/internal/nix/install_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestDirExistsAndIsNotEmpty(t *testing.T) {
+func TestNixDirIsInstalled(t *testing.T) {
 	tests := []struct {
 		name     string
 		setup    func(string) error
@@ -34,10 +34,9 @@ func TestDirExistsAndIsNotEmpty(t *testing.T) {
 			expected: true,
 		},
 		{
-			name: "directory with subdirectories",
+			name: "directory with nix store",
 			setup: func(dir string) error {
-				subdir := filepath.Join(dir, "subdir")
-				return os.MkdirAll(subdir, 0o755)
+				return os.MkdirAll(filepath.Join(dir, "store"), 0o755)
 			},
 			expected: true,
 		},
@@ -46,6 +45,26 @@ func TestDirExistsAndIsNotEmpty(t *testing.T) {
 			setup: func(dir string) error {
 				file := filepath.Join(dir, ".hidden")
 				return os.WriteFile(file, []byte("hidden content"), 0o644)
+			},
+			expected: true,
+		},
+		{
+			// Regression test for jetify-com/devbox#2601: mounting an empty
+			// /nix volume in Docker/Kubernetes often leaves a lost+found
+			// directory, which must not be mistaken for an existing install.
+			name: "directory with only lost+found",
+			setup: func(dir string) error {
+				return os.MkdirAll(filepath.Join(dir, "lost+found"), 0o755)
+			},
+			expected: false,
+		},
+		{
+			name: "directory with lost+found and nix store",
+			setup: func(dir string) error {
+				if err := os.MkdirAll(filepath.Join(dir, "lost+found"), 0o755); err != nil {
+					return err
+				}
+				return os.MkdirAll(filepath.Join(dir, "store"), 0o755)
 			},
 			expected: true,
 		},
@@ -70,7 +89,7 @@ func TestDirExistsAndIsNotEmpty(t *testing.T) {
 			}
 
 			// Run the function
-			result := dirExistsAndIsNotEmpty(tempDir)
+			result := nixDirIsInstalled(tempDir)
 
 			// Check results
 			assert.Equal(t, curTest.expected, result)


### PR DESCRIPTION
## Summary

Fixes #2601.

When running Devbox in a container (e.g. Docker or Kubernetes) with `/nix` mounted as a persistent volume, the volume starts out effectively empty. Devbox is supposed to install Nix into it, but instead it fails with:

> Error: We found a /nix directory but nix binary is not in your PATH and we were not able to find it in the usual locations. Your nix installation might be broken. [...]

### Root cause

`EnsureNixInstalled` decided whether `/nix` already contained an installation by checking whether the directory was non-empty:

```go
if dirExistsAndIsNotEmpty("/nix") { ... return "broken installation" error ... }
```

A truly empty `/nix` already falls through to the installer, but a freshly **mounted** volume is usually not truly empty: `ext4` (and other filesystems) create a `lost+found` directory at the root of the mount. So `/nix` looks non-empty, Devbox assumes a pre-existing (broken) install, and refuses to install Nix.

### Fix

Detect an existing installation by ignoring known filesystem cruft (`lost+found`, `.DS_Store`) rather than treating any non-empty `/nix` as installed. A `/nix` that contains only those entries is now treated as a fresh install target, so Devbox proceeds to install Nix as expected. A `/nix` that contains real content (e.g. a `store` directory) is still treated as an existing installation, preserving the original "broken install" diagnostics.

The generic `dirExistsAndIsNotEmpty` helper was only used here, so it's replaced by a `/nix`-specific `nixDirIsInstalled` helper.

## How was it tested?

- `go test ./internal/nix/ -run TestNixDirIsInstalled -v` — new table-driven test covering: empty dir, dir with files, dir with a nix `store`, dir with hidden files, **dir with only `lost+found`** (the regression case → treated as not installed), dir with `lost+found` + `store` (→ installed), and non-existent dir. All pass.
- `go build ./...` / `go vet ./internal/nix/` / `gofmt` clean.

(Pre-existing `TestConfigIsUserTrusted` failures in the package are unrelated — they require a `nix` binary that isn't present in the CI sandbox and are not touched by this change.)

cc @ascknx (issue reporter)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Upz2KchxkA6erYatxPzVjg)_