### PR TITLE
feat(config): discover devbox.json in a .config subdirectory

### DIFF
--- a/internal/devconfig/config.go
+++ b/internal/devconfig/config.go
@@ -141,8 +141,15 @@ func Find(path string) (*Config, error) {
 
 // searchDir looks for a config file in dir. It does not search parent
 // directories.
+//
+// It first looks for devbox.json directly in dir, and then falls back to
+// dir/.config/devbox.json. The latter lets projects keep their root directory
+// tidy by storing the config under .config. See jetify-com/devbox#2792.
 func searchDir(dir string) (*Config, error) {
-	try := []string{configfile.DefaultName}
+	try := []string{
+		configfile.DefaultName,
+		filepath.Join(configfile.ConfigSubdir, configfile.DefaultName),
+	}
 	for _, name := range try {
 		path := filepath.Join(dir, name)
 		slog.Debug("trying config file", "path", path)

--- a/internal/devconfig/config_test.go
+++ b/internal/devconfig/config_test.go
@@ -95,6 +95,63 @@ func TestOpenError(t *testing.T) {
 	})
 }
 
+// TestConfigSubdir verifies that Devbox discovers a config file stored in a
+// .config subdirectory, so that projects can keep devbox.json out of their
+// root directory. See jetify-com/devbox#2792.
+func TestConfigSubdir(t *testing.T) {
+	t.Run("Open", func(t *testing.T) {
+		root, _, _ := mkNestedDirs(t)
+		configDir := mkConfigSubdir(t, root)
+		if _, err := Init(configDir); err != nil {
+			t.Fatalf("Init(%q) error: %v", configDir, err)
+		}
+
+		cfg, err := Open(root)
+		if err != nil {
+			t.Fatalf("Open(%q) error: %v", root, err)
+		}
+		gotDir := filepath.Dir(cfg.Root.AbsRootPath)
+		if gotDir != configDir {
+			t.Errorf("filepath.Dir(cfg.Root.AbsRootPath) = %q, want %q", gotDir, configDir)
+		}
+	})
+	t.Run("RootConfigTakesPrecedence", func(t *testing.T) {
+		root, _, _ := mkNestedDirs(t)
+		if _, err := Init(root); err != nil {
+			t.Fatalf("Init(%q) error: %v", root, err)
+		}
+		configDir := mkConfigSubdir(t, root)
+		if _, err := Init(configDir); err != nil {
+			t.Fatalf("Init(%q) error: %v", configDir, err)
+		}
+
+		cfg, err := Open(root)
+		if err != nil {
+			t.Fatalf("Open(%q) error: %v", root, err)
+		}
+		gotDir := filepath.Dir(cfg.Root.AbsRootPath)
+		if gotDir != root {
+			t.Errorf("filepath.Dir(cfg.Root.AbsRootPath) = %q, want %q", gotDir, root)
+		}
+	})
+	t.Run("FindFromChildDir", func(t *testing.T) {
+		root, child, _ := mkNestedDirs(t)
+		configDir := mkConfigSubdir(t, root)
+		if _, err := Init(configDir); err != nil {
+			t.Fatalf("Init(%q) error: %v", configDir, err)
+		}
+
+		cfg, err := Find(child)
+		if err != nil {
+			t.Fatalf("Find(%q) error: %v", child, err)
+		}
+		gotDir := filepath.Dir(cfg.Root.AbsRootPath)
+		if gotDir != configDir {
+			t.Errorf("filepath.Dir(cfg.Root.AbsRootPath) = %q, want %q", gotDir, configDir)
+		}
+	})
+}
+
 func TestFind(t *testing.T) {
 	t.Run("StartInSameDir", func(t *testing.T) {
 		root, child, _ := mkNestedDirs(t)
@@ -295,6 +352,19 @@ func mkNestedDirs(t *testing.T) (root, child, nested string) {
 		t.Fatalf("os.MkdirAll(%q, %O) error: %v", nested, perm, err)
 	}
 	return root, child, nested
+}
+
+// mkConfigSubdir creates a .config subdirectory inside dir and returns its
+// path, for tests that store devbox.json under .config.
+func mkConfigSubdir(t *testing.T, dir string) string {
+	t.Helper()
+
+	configDir := filepath.Join(dir, configfile.ConfigSubdir)
+	perm := fs.FileMode(0o777)
+	if err := os.MkdirAll(configDir, perm); err != nil {
+		t.Fatalf("os.MkdirAll(%q, %O) error: %v", configDir, perm, err)
+	}
+	return configDir
 }
 
 func TestAliases(t *testing.T) {

--- a/internal/devconfig/configfile/file.go
+++ b/internal/devconfig/configfile/file.go
@@ -21,6 +21,12 @@ import (
 
 const (
 	DefaultName = "devbox.json"
+
+	// ConfigSubdir is a subdirectory that Devbox also searches for a config
+	// file. It lets projects keep their root directory tidy by placing
+	// devbox.json inside a .config directory (e.g. .config/devbox.json)
+	// instead of at the top level. See jetify-com/devbox#2792.
+	ConfigSubdir = ".config"
 )
 
 // ConfigFile defines a devbox environment as JSON.


### PR DESCRIPTION
## Summary

Fixes #2792.

Devbox now discovers a config file at `.config/devbox.json` in addition to a top-level `devbox.json`. This lets projects keep their root directory tidy by moving the Devbox config (and the `.devbox` state that lives alongside it) under a `.config` directory, instead of adding yet another dotfile/config file to the project root.

Behavior:
- When resolving a directory, Devbox first looks for `devbox.json` directly in it, then falls back to `<dir>/.config/devbox.json`.
- A top-level `devbox.json` always takes precedence, so existing projects are completely unaffected — the new location is only used when no root-level config exists.
- Both `Open` (single directory) and `Find` (walking up parent directories) honor the new location, so running `devbox` from a subdirectory of a project that stores its config under `.config` works as expected.

The change is small and localized to `searchDir`, which already used a `[]string` of candidate names — the project-directory anchoring semantics (project dir = the directory containing the resolved config file) are unchanged, so `.config/devbox.json` keeps its state self-contained under `.config`.

Note: this implements the `devbox.json` half of the request. `process-compose.yml` discovery was left out of scope for this change to keep it focused and low-risk.

cc @eknowles (issue reporter)

## How was it tested?

Added unit tests in `internal/devconfig/config_test.go` (`TestConfigSubdir`) covering:
- `Open` finding `.config/devbox.json`.
- A root-level `devbox.json` taking precedence over `.config/devbox.json`.
- `Find` locating `.config/devbox.json` in a parent directory when invoked from a child directory.

`go build ./...`, `go vet ./internal/devconfig/...`, and `gofmt` are clean. The new tests pass. (Two unrelated pre-existing failures in `TestFindError/Permissions` and `TestFindError/ExactFilePermissions` occur only because the test environment runs as root, which bypasses `chmod 0o000`; they fail identically on the base commit and are untouched by this change.)

## Community Contribution License

All community contributions in this pull request are licensed to the project
maintainers under the terms of the
[Apache 2 License](https://www.apache.org/licenses/LICENSE-2.0).

By creating this pull request, I represent that I have the right to license the
contributions to the project maintainers under the Apache 2 License as stated in
the
[Community Contribution License](https://github.com/jetify-com/opensource/blob/main/CONTRIBUTING.md#community-contribution-license).

---
_Generated by [Claude Code](https://claude.ai/code/session_01VgaUq2F9Drmri6oRUp5duV)_