### PR TITLE
docs(run): document that scripts and commands run from the project root

### DIFF
--- a/internal/boxcli/run.go
+++ b/internal/boxcli/run.go
@@ -48,7 +48,11 @@ func runCmd(defaults runFlagDefaults) *cobra.Command {
 		Long: "Start a new shell and runs your script or command in it, exiting when done.\n\n" +
 			"The script must be defined in `devbox.json`, or else it will be interpreted as an " +
 			"arbitrary command. You can pass arguments to your script or command. Everything " +
-			"after `--` will be passed verbatim into your command (see examples).\n\n",
+			"after `--` will be passed verbatim into your command (see examples).\n\n" +
+			"Scripts and commands always run from the project's root directory (the directory " +
+			"containing your `devbox.json`), not the current working directory. If you invoke " +
+			"`devbox run` from a subdirectory and need to run there, change into it as part of " +
+			"your command, e.g. `devbox run -- sh -c 'cd subdir && <command>'`.\n\n",
 		Example: "\nRun a command directly:\n\n  devbox add cowsay\n  devbox run cowsay hello\n  " +
 			"devbox run -- cowsay -d hello\n\nRun a script (defined as `\"moo\": \"cowsay moo\"`) " +
 			"in your devbox.json:\n\n  devbox run moo",


### PR DESCRIPTION
## Summary

`devbox run` always executes from the project's root directory — the directory
containing `devbox.json` — regardless of the subdirectory it was invoked from.
This is enforced in `nix.RunScript`, which sets `cmd.Dir = projectDir`
(`internal/nix/run.go`). Users invoking `devbox run` from a subdirectory are
surprised that `pwd` and relative paths resolve against the project root rather
than the current working directory, as reported in #2559.

A maintainer confirmed on the issue that this is intentional: it keeps a command
run via `devbox run -- <cmd>` consistent with a script defined in `devbox.json`,
which should always run from the same place. The reporter's remaining ask was
simply that this behavior be surfaced in the command's help.

This PR adds a short paragraph to the `devbox run` long help explaining that
scripts and commands run from the project root and showing how to run from a
subdirectory when needed:

```
Scripts and commands always run from the project's root directory (the directory
containing your devbox.json), not the current working directory. If you invoke
devbox run from a subdirectory and need to run there, change into it as part of
your command, e.g. devbox run -- sh -c 'cd subdir && <command>'.
```

No behavior changes — documentation only.

Closes #2559

cc @alezkv (issue reporter) — thanks for raising this.

## How was it tested?

- `go build ./internal/boxcli/` and `gofmt -l internal/boxcli/run.go` are clean.
- Ran `devbox run --help` and confirmed the new paragraph renders correctly in
  the long description, above the usage/examples output.

## Community Contribution License

All community contributions in this pull request are licensed to the project
maintainers under the terms of the
[Apache 2 License](https://www.apache.org/licenses/LICENSE-2.0).

By creating this pull request, I represent that I have the right to license the
contributions to the project maintainers under the Apache 2 License as stated in
the
[Community Contribution License](https://github.com/jetify-com/opensource/blob/main/CONTRIBUTING.md#community-contribution-license).

---
_Generated by [Claude Code](https://claude.ai/code/session_01RFT549LGzNm3R2dy1edVL3)_