### PR TITLE
fix(examples/zig): upgrade to zig 0.16 to unbreak the macOS test

### DIFF
--- a/examples/development/zig/zig-hello-world/.gitignore
+++ b/examples/development/zig/zig-hello-world/.gitignore
@@ -1,2 +1,2 @@
-zig-cache/
+.zig-cache/
 zig-out/

--- a/examples/development/zig/zig-hello-world/build.zig
+++ b/examples/development/zig/zig-hello-world/build.zig
@@ -15,9 +15,11 @@ pub fn build(b: *std.Build) void {
 
     const exe = b.addExecutable(.{
         .name = "zig-hello-world",
-        .root_source_file = .{ .path = "src/main.zig" },
-        .target = target,
-        .optimize = optimize,
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/main.zig"),
+            .target = target,
+            .optimize = optimize,
+        }),
     });
     b.installArtifact(exe);
 
@@ -25,8 +27,14 @@ pub fn build(b: *std.Build) void {
     const run_step = b.step("run", "Run the application");
     run_step.dependOn(&run_exe.step);
 
-    const test_step = b.step("test", "Run unit tests");
-    const unit_tests = b.addTest(.{ .root_source_file = .{ .path = "src/main.zig" }, .target = target, .optimize = optimize });
+    const unit_tests = b.addTest(.{
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/main.zig"),
+            .target = target,
+            .optimize = optimize,
+        }),
+    });
     const run_unit_tests = b.addRunArtifact(unit_tests);
+    const test_step = b.step("test", "Run unit tests");
     test_step.dependOn(&run_unit_tests.step);
 }

--- a/examples/development/zig/zig-hello-world/devbox.json
+++ b/examples/development/zig/zig-hello-world/devbox.json
@@ -1,6 +1,6 @@
 {
   "packages": {
-    "zig": "latest"
+    "zig": "0.16.0"
   },
   "shell": {
     "scripts": {

--- a/examples/development/zig/zig-hello-world/devbox.lock
+++ b/examples/development/zig/zig-hello-world/devbox.lock
@@ -1,67 +1,71 @@
 {
   "lockfile_version": "1",
   "packages": {
-    "zig@latest": {
-      "last_modified": "2024-02-10T18:15:24Z",
-      "resolved": "github:NixOS/nixpkgs/10b813040df67c4039086db0f6eaf65c536886c6#zig",
+    "github:NixOS/nixpkgs/nixpkgs-unstable": {
+      "last_modified": "2026-08-03T09:05:39Z",
+      "resolved": "github:NixOS/nixpkgs/104240a772428cc2e20d8fd86c9ddbb886bbaff2?lastModified=1785747939&narHash=sha256-D740uKsMbgsfK2oaDenJLLPIZfq7W0%2Fg4KN%2FFls8eKs%3D"
+    },
+    "zig@0.16.0": {
+      "last_modified": "2026-08-01T16:34:20Z",
+      "resolved": "github:NixOS/nixpkgs/a5cbcfe954791221bfffe2307f7d1a1bf61a871e#zig",
       "source": "devbox-search",
-      "version": "0.11.0",
+      "version": "0.16.0",
       "systems": {
         "aarch64-darwin": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/jdcras9fpriayy669zl3c4wbqr5gvspz-zig-0.11.0",
+              "path": "/nix/store/z8xy4x10v889vlqhysikr9wyinn03zhn-zig-0.16.0",
               "default": true
             },
             {
               "name": "doc",
-              "path": "/nix/store/c6c7clbl1fbwax4bj9lqrw0yx4fmdbqr-zig-0.11.0-doc"
+              "path": "/nix/store/v584k9yqzhd7r0az7xvwvn6vmb5yj7nn-zig-0.16.0-doc"
             }
           ],
-          "store_path": "/nix/store/jdcras9fpriayy669zl3c4wbqr5gvspz-zig-0.11.0"
+          "store_path": "/nix/store/z8xy4x10v889vlqhysikr9wyinn03zhn-zig-0.16.0"
         },
         "aarch64-linux": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/qs3v2dp6izd6b66bhhjcj7c96k0bvznl-zig-0.11.0",
+              "path": "/nix/store/8xs3313y6pg95zxhma393asphfin0kmm-zig-0.16.0",
               "default": true
             },
             {
               "name": "doc",
-              "path": "/nix/store/fik8lifgkdd3pjwzrywggv2rxys6pn0f-zig-0.11.0-doc"
+              "path": "/nix/store/ndq3kq2zgjxb1b4adc7j17kbmsi9bcz6-zig-0.16.0-doc"
             }
           ],
-          "store_path": "/nix/store/qs3v2dp6izd6b66bhhjcj7c96k0bvznl-zig-0.11.0"
+          "store_path": "/nix/store/8xs3313y6pg95zxhma393asphfin0kmm-zig-0.16.0"
         },
         "x86_64-darwin": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/dh721al3vdr3akb6zsjykjr6qv65fqwj-zig-0.11.0",
+              "path": "/nix/store/7wsm80i713618s84j1hw2nk2v58zf081-zig-0.16.0",
               "default": true
             },
             {
               "name": "doc",
-              "path": "/nix/store/qs0vgs443r4f0d6wfp54j3yzsx71gaf6-zig-0.11.0-doc"
+              "path": "/nix/store/6h4nc1xc8kr3wfn7f4f6ma4my48mn9qk-zig-0.16.0-doc"
             }
           ],
-          "store_path": "/nix/store/dh721al3vdr3akb6zsjykjr6qv65fqwj-zig-0.11.0"
+          "store_path": "/nix/store/7wsm80i713618s84j1hw2nk2v58zf081-zig-0.16.0"
         },
         "x86_64-linux": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/s7h19d99gn1arvykjvzhkx57qa4bvaj9-zig-0.11.0",
+              "path": "/nix/store/j0yhl5hnz61i7g8plp0nx0hradbqd80a-zig-0.16.0",
               "default": true
             },
             {
               "name": "doc",
-              "path": "/nix/store/pc7jbvwkn560nqakaqf01b2rm9fgwppj-zig-0.11.0-doc"
+              "path": "/nix/store/hxd1fy04p0hapdp5s08x1v0slqd5jn8z-zig-0.16.0-doc"
             }
           ],
-          "store_path": "/nix/store/s7h19d99gn1arvykjvzhkx57qa4bvaj9-zig-0.11.0"
+          "store_path": "/nix/store/j0yhl5hnz61i7g8plp0nx0hradbqd80a-zig-0.16.0"
         }
       }
     }


### PR DESCRIPTION
## Summary

The `zig-hello-world` example test has been failing on macOS, which blocks every release since `cli-release` gates on the test suite. `devbox.lock` pinned zig **0.11.0** (from a Feb 2024 nixpkgs commit), whose self-hosted Mach-O linker emits `__DATA_CONST` segments without the `SG_READ_ONLY` flag — modern macOS dyld rejects these, and the binary that crashed was zig's own build runner, hence the opaque `the following build command crashed` (Linux was unaffected). This pins zig explicitly at `0.16.0` rather than tracking `latest`, since zig's build API breaks across nearly every release and an unpinned update would silently re-break `build.zig` — matching how `go` and `nim` are already pinned under `examples/`. Upgrading exposed a second latent problem, so `build.zig` is migrated from the pre-0.12 `.root_source_file = .{ .path = ... }` form to the 0.15+ `root_module` API for both the executable and the test. Finally, `.gitignore` is corrected to `.zig-cache/`, since zig 0.12 renamed the cache directory and build output was no longer being ignored.

## How was it tested?

Reproduced the original `dyld: __DATA_CONST segment missing SG_READ_ONLY flag` crash locally on macos-arm64 (same architecture as the `macos-latest` runner), then confirmed the fix through the exact CI harness rather than a bare `zig build`:

```
DEVBOX_RUN_PROJECT_TESTS=1 go test ./testscripts -run 'TestExamples/development_zig_zig-hello-world_run_test' -v
```
```
Build Summary: 6/6 steps succeeded; 1/1 tests passed
--- PASS: TestExamples/development_zig_zig-hello-world_run_test.test (2.56s)
ok  go.jetify.com/devbox/testscripts
```

The Linux shard was not run locally, but both changes are platform-independent (build API) and already green there. All four systems resolve in the updated lock.

## Community Contribution License

All community contributions in this pull request are licensed to the project
maintainers under the terms of the
[Apache 2 License](https://www.apache.org/licenses/LICENSE-2.0).

By creating this pull request, I represent that I have the right to license the
contributions to the project maintainers under the Apache 2 License as stated in
the
[Community Contribution License](https://github.com/jetify-com/opensource/blob/main/CONTRIBUTING.md#community-contribution-license).

🤖 Generated with [Claude Code](https://claude.com/claude-code)