### PR TITLE
Update devbox global activation instructions

### DIFF
--- a/internal/boxcli/global.go
+++ b/internal/boxcli/global.go
@@ -115,7 +115,7 @@ func ensureGlobalEnvEnabled(cmd *cobra.Command, args []string) error {
 Add the following line to your shell's rcfile and restart your shell:
 
 For bash/zsh (~/.bashrc or ~/.zshrc):
-	eval "$(devbox global shellenv)"
+	eval "$(devbox global shellenv --init-hook)"
 
 For nushell: See NUSHELL.md for setup instructions
 `,

--- a/internal/boxcli/global.go
+++ b/internal/boxcli/global.go
@@ -117,6 +117,9 @@ Add the following line to your shell's rcfile and restart your shell:
 For bash/zsh (~/.bashrc or ~/.zshrc):
 	eval "$(devbox global shellenv --init-hook)"
 
+For fish (~/.config/fish/config.fish):
+	devbox global shellenv --init-hook | source
+
 For nushell: See NUSHELL.md for setup instructions
 `,
 		)

--- a/internal/boxcli/global.go
+++ b/internal/boxcli/global.go
@@ -120,7 +120,14 @@ For bash/zsh (~/.bashrc or ~/.zshrc):
 For fish (~/.config/fish/config.fish):
 	devbox global shellenv --init-hook | source
 
-For nushell: See NUSHELL.md for setup instructions
+For nushell (~/.config/nushell/env.nu):
+	devbox global shellenv --format nushell --preserve-path-stack -r
+	| lines
+	| parse "$env.{name} = \"{value}\""
+	| where name != null
+	| transpose -r
+	| into record
+	| load-env
 `,
 		)
 	}


### PR DESCRIPTION
## Summary

This PR updates the `devbox global` activation instructions to match the [current documentation]:

- Uses the `--init-hook` option in the activation command for Bash and Zsh.
- Adds activation commands for Fish and Nushell.
- Removes the reference to `NUSHELL.md`, so that all supported shell instructions are available directly in the message.

## How was it tested?

Ran `devbox global add cowsay` in a shell without `devbox global` activated and verified the message displayed.

## Community Contribution License

All community contributions in this pull request are licensed to the project maintainers under the terms of the [Apache 2 License].

By creating this pull request, I represent that I have the right to license the contributions to the project maintainers under the Apache 2 License as stated in the [Community Contribution License].

[current documentation]: https://www.jetify.com/docs/devbox/devbox-global
[apache 2 license]: https://www.apache.org/licenses/LICENSE-2.0
[community contribution license]: https://github.com/jetify-com/opensource/blob/main/CONTRIBUTING.md#community-contribution-license
