### PR TITLE
ci: test against Nix 2.35.2

### DIFF
--- a/.github/workflows/cli-tests.yaml
+++ b/.github/workflows/cli-tests.yaml
@@ -320,7 +320,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        nix-version: [2.18.0, 2.19.2, 2.24.7, 2.30.2]
+        nix-version: [2.18.0, 2.19.2, 2.24.7, 2.30.2, 2.35.2]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v7


### PR DESCRIPTION
## Summary

Adds `2.35.2` to the `nix-version` matrix in the `test-nix-versions` job, so the install/run/remove sanity check covers the latest Nix release alongside 2.18.0 – 2.30.2. This is the only place CI pins a Nix version — the main `testscripts` job installs Nix via `devbox-install-action`, which doesn't accept a version.

## How was it tested?

Verified that the release tarballs the job's `nix-package-url` resolves to exist for both matrix platforms (`nix-2.35.2-x86_64-linux.tar.xz` and `nix-2.35.2-aarch64-darwin.tar.xz` return HTTP 200 from releases.nixos.org); the new legs themselves run in CI on this PR.

## Community Contribution License

All community contributions in this pull request are licensed to the project
maintainers under the terms of the
[Apache 2 License](https://www.apache.org/licenses/LICENSE-2.0).

By creating this pull request, I represent that I have the right to license the
contributions to the project maintainers under the Apache 2 License as stated in
the
[Community Contribution License](https://github.com/jetify-com/opensource/blob/main/CONTRIBUTING.md#community-contribution-license).

🤖 Generated with [Claude Code](https://claude.com/claude-code)