### PR TITLE
fix(poetry plugin): activate the in-project virtualenv so scripts land on PATH

### DIFF
--- a/plugins/poetry.json
+++ b/plugins/poetry.json
@@ -1,6 +1,6 @@
 {
     "name": "poetry",
-    "version": "0.0.5",
+    "version": "0.0.6",
     "description": "This plugin automatically configures poetry to use the version of python installed in your Devbox shell, instead of the Python version that it is bundled with. The pyproject.toml location can be configured by setting DEVBOX_PYPROJECT_DIR (defaults to the devbox.json's directory).",
     "env": {
         "DEVBOX_DEFAULT_PYPROJECT_DIR": "{{ .DevboxProjectDir }}",
@@ -13,7 +13,8 @@
     },
     "shell": {
         "init_hook": [
-            "\"{{ .Virtenv }}/bin/initHook.sh\""
+            "\"{{ .Virtenv }}/bin/initHook.sh\"",
+            "if [ -d \"${DEVBOX_PYPROJECT_DIR:-$DEVBOX_DEFAULT_PYPROJECT_DIR}/.venv\" ]; then export VIRTUAL_ENV=\"${DEVBOX_PYPROJECT_DIR:-$DEVBOX_DEFAULT_PYPROJECT_DIR}/.venv\"; export PATH=\"$VIRTUAL_ENV/bin:$PATH\"; fi"
         ]
     }
 }


### PR DESCRIPTION
## Summary

Fixes #2676.

Since **Poetry 2.0.0** removed the bundled `poetry shell` command, the poetry plugin relies on `poetry env use` (in `initHook.sh`) to point Poetry at the Devbox-provided Python. That *selects* the virtualenv but never *activates* it, so console scripts and entry points installed by `poetry install` live in `<project>/.venv/bin` and are **not on the Devbox shell's PATH**. Users are forced to prefix everything with `poetry run`, which is the regression reported in the issue:

> Scripts from the python package are not available on the path of the devbox shell since updating from 1.7.1.

### Fix

The plugin already sets `POETRY_VIRTUALENVS_IN_PROJECT=true`, so the virtualenv is always created at `<pyproject-dir>/.venv`. I activate it from the plugin's `init_hook` — which runs in the *sourced* shellrc context, unlike the *executed* `initHook.sh`, so it can actually modify the shell's `PATH`:

```jsonc
"init_hook": [
    "\"{{ .Virtenv }}/bin/initHook.sh\"",
    "if [ -d \"${DEVBOX_PYPROJECT_DIR:-$DEVBOX_DEFAULT_PYPROJECT_DIR}/.venv\" ]; then export VIRTUAL_ENV=\"${DEVBOX_PYPROJECT_DIR:-$DEVBOX_DEFAULT_PYPROJECT_DIR}/.venv\"; export PATH=\"$VIRTUAL_ENV/bin:$PATH\"; fi"
]
```

Ordering makes this robust:
- Plugin init hooks run **before** the user's own hooks (`Config.InitHook()` appends included-plugin hooks ahead of the root config's hooks).
- `poetry env use` inside `initHook.sh` creates `.venv`, so the `[ -d … ]` guard already passes when the activation line runs.
- By the time the user's `poetry install` executes, `.venv/bin` is already on `PATH`, so the freshly installed scripts resolve by name.

The path is derived from env vars and every expansion is double-quoted, so project directories containing spaces are handled correctly. The plugin `version` is bumped `0.0.5` → `0.0.6` so existing environments regenerate with the new hook, matching the convention used by prior plugin behavior changes.

## How was it tested?

- `go test ./plugins/ ./internal/plugin/` passes, including `plugins/init_hook_quoting_test.go` (the new line uses no `{{ }}` templates, and all path expansions are quoted).
- Validated the JSON parses and `bash -n` syntax-checked the rendered activation line.
- Simulated a spaced project dir end-to-end: exported `DEVBOX_DEFAULT_PYPROJECT_DIR="/tmp/pdir with space"`, placed an executable at `.venv/bin/myscript`, ran the activation line, and confirmed `VIRTUAL_ENV` was set correctly and `myscript` resolved and ran by name from `PATH`.

cc @tlelson — thanks for the clear root-cause analysis and reproduction in the issue.

## Community Contribution License

All community contributions in this pull request are licensed to the project
maintainers under the terms of the
[Apache 2 License](https://www.apache.org/licenses/LICENSE-2.0).

By creating this pull request, I represent that I have the right to license the
contributions to the project maintainers under the Apache 2 License as stated in
the
[Community Contribution License](https://github.com/jetify-com/opensource/blob/main/CONTRIBUTING.md#community-contribution-license).

---
_Generated by [Claude Code](https://claude.ai/code/session_012aiRPVpidRdyKDJiUQJhxN)_