### PR TITLE
Add devbox global info command

### DIFF
--- a/internal/boxcli/global.go
+++ b/internal/boxcli/global.go
@@ -29,6 +29,7 @@ func globalCmd() *cobra.Command {
 	}
 
 	addCommandAndHideConfigFlag(globalCmd, addCmd())
+	addCommandAndHideConfigFlag(globalCmd, infoCmd())
 	addCommandAndHideConfigFlag(globalCmd, installCmd())
 	addCommandAndHideConfigFlag(globalCmd, pathCmd())
 	addCommandAndHideConfigFlag(globalCmd, pullCmd())

--- a/internal/boxcli/global.go
+++ b/internal/boxcli/global.go
@@ -31,6 +31,7 @@ func globalCmd() *cobra.Command {
 	addCommandAndHideConfigFlag(globalCmd, addCmd())
 	addCommandAndHideConfigFlag(globalCmd, infoCmd())
 	addCommandAndHideConfigFlag(globalCmd, installCmd())
+	addCommandAndHideConfigFlag(globalCmd, listCmd())
 	addCommandAndHideConfigFlag(globalCmd, pathCmd())
 	addCommandAndHideConfigFlag(globalCmd, pullCmd())
 	addCommandAndHideConfigFlag(globalCmd, pushCmd())
@@ -43,7 +44,6 @@ func globalCmd() *cobra.Command {
 		omitNixEnv: true,
 	}))
 	addCommandAndHideConfigFlag(globalCmd, updateCmd())
-	addCommandAndHideConfigFlag(globalCmd, listCmd())
 
 	return globalCmd
 }


### PR DESCRIPTION
## Summary

This PR adds `devbox global info`, reusing the existing `info` command with the global configuration. This keeps it consistent with other project-scoped commands such as `add` and `rm`, which provide global variants.

Closes #2275 (cc @andbleo).
Closes #2500 (cc @yonil7).

## How was it tested?

Ran it from a directory with no `devbox.json` in the current directory or any parent directory.

Verified that `devbox info cowsay` failed because no project configuration was found, while `devbox global info cowsay` succeeded and displayed the package information.

## Community Contribution License

All community contributions in this pull request are licensed to the project maintainers under the terms of the [Apache 2 License].

By creating this pull request, I represent that I have the right to license the contributions to the project maintainers under the Apache 2 License as stated in the [Community Contribution License].

[apache 2 license]: https://www.apache.org/licenses/LICENSE-2.0
[community contribution license]: https://github.com/jetify-com/opensource/blob/main/CONTRIBUTING.md#community-contribution-license
