### PR TITLE
php(plugin): set default session.save_path to devbox sessions dir

### DIFF
--- a/plugins/php.json
+++ b/plugins/php.json
@@ -11,11 +11,13 @@
     "PHPFPM_ERROR_LOG_FILE": "{{ .Virtenv }}/php-fpm.log",
     "PHPFPM_PID_FILE": "{{ .Virtenv }}/php-fpm.pid",
     "PHPFPM_PORT": "8082",
-    "PHPRC": "{{ .DevboxDir }}"
+    "PHPRC": "{{ .DevboxDir }}",
+    "PHPFPM_SESSIONDIR": "{{ .Virtenv }}/sessions"
   },
   "create_files": {
     "{{ .DevboxDir }}/php-fpm.conf": "php/php-fpm.conf",
     "{{ .DevboxDir }}/php.ini": "php/php.ini",
+    "{{ .Virtenv }}/sessions": "",
     "{{ .Virtenv }}/process-compose.yaml": "php/process-compose.yaml",
     "{{ .Virtenv }}/flake/flake.nix": "php/flake.nix"
   }

--- a/plugins/php/php.ini
+++ b/plugins/php/php.ini
@@ -1,5 +1,8 @@
 [php]
 
+; Sessions are persisted to .devbox/virtenv/php/sessions/ by default
+session.save_path = ${PHPFPM_SESSIONDIR}
+
 ; Put your php.ini directives here. For the latest default php.ini file, see https://github.com/php/php-src/blob/master/php.ini-production
 
 ; memory_limit = 128M


### PR DESCRIPTION
## Summary

Add `session.save_path = "{{ .DevboxDir }}/sessions"` to the PHP plugin ini template so PHP session files are stored inside the devbox project directory rather than the system default.

Also add a `create_files` entry for `{{ .DevboxDir }}/sessions` (empty source = directory creation) so the sessions directory is created on plugin activation.

Fixes #2962

## How was it tested?

Create and run this [phpsessionfixed.sh](https://github.com/user-attachments/files/31795484/phpsessionfixed.sh) script:

```bash
#!/bin/bash

fail() { echo >&2 "$*"; exit 1; }

PORT=8081
EXPECTED_SESSIONDIR=/tmp/phpsessionfixed/.devbox/virtenv/php/sessions

main() {
	trap 'teardown' EXIT TERM
	setup
	testing
}

setup() {
	if [[ -d /tmp/phpsessionfixed ]]; then
		cd /tmp/phpsessionfixed
		devbox services down &>/dev/null
		rm -r /tmp/phpsessionfixed
	fi
	mkdir /tmp/phpsessionfixed
	cd /tmp/phpsessionfixed
	devbox init
	devbox add php nginx &>/dev/null
	devbox install
	touch devbox.d/nginx/mime.types  # #2908
	cat > devbox.d/nginx/nginx.template <<-'EOF'
	events {}
	http {
	include mime.types;
	server {
		 listen       $NGINX_WEB_PORT;
		 listen       [::]:$NGINX_WEB_PORT;
		 server_name  $NGINX_WEB_SERVER_NAME;
		 root         $NGINX_WEB_ROOT;

		 location ~ \.php$ {
		     try_files $uri =404;
		     fastcgi_pass 127.0.0.1:$PHPFPM_PORT;
		     include $NGINX_CONFDIR/fastcgi.conf;
		 }

		 error_log error.log error;
		 access_log access.log;
		 client_body_temp_path temp/client_body;
		 proxy_temp_path temp/proxy;
		 fastcgi_temp_path temp/fastcgi;
		 uwsgi_temp_path temp/uwsgi;
		 scgi_temp_path temp/scgi;

		 index index.html;
		 server_tokens off;
	    }
	}
	EOF

	cat > devbox.d/web/index.php <<-'EOF'
	<?php
	session_start();
	echo ini_get('session.save_path').'/sess_'.session_id();
	EOF
	devbox services up -b
	until (echo > /dev/tcp/localhost/$PORT) 2>/dev/null; do echo -n .; sleep 1; done
}

testing() {
	sessdir="$(devbox run echo '$PHPFPM_SESSIONDIR')"
	[[ -n $sessdir ]] || fail "PHPFPM_SESSIONDIR env var not set"
	[[ -d $sessdir ]] || fail "PHPFPM_SESSION_DIR $PHPFPM_SESSION_DIR not created"
	sesspath="$(curl -s http://localhost:$PORT/index.php)"
	[[ -n $sesspath ]] || fail "Something failed, index.php did not print the session path"
	[[ $sesspath =~ ^$EXPECTED_SESSIONDIR ]] || fail "Session path was $sesspath, not in $EXPECTED_SESSIONDIR"
	[[ -f $sesspath ]] || fail "Odd, no session file $sesspath"
	echo "As expected, php created session file $sesspath"
}

teardown() {
	devbox services down
}

main "$@"
```

Expected output:

```sh
jturner@jturner-desktop:/tmp$ bash phpsessionfixed.sh 
Created devbox.json in /tmp/phpsessionfixed
Run `devbox add <package>` to add packages, or `devbox shell` to start a dev shell.
Info: Ensuring packages are installed.
✓ Computed the Devbox environment.
Finished installing packages.
Starting all services: nginx, nginx-access, nginx-error, php-fpm 
Process-compose is now running on port 45747
To stop your services, run `devbox services stop`
.Info: Running script "echo" on /tmp/phpsessionfixed
As expected, php created session file /tmp/phpsessionfixed/.devbox/virtenv/php/sessions/sess_3dd3d4d6044c0d115e8f7c1aed6c19ab
Process-compose stopped successfully.
```



## Community Contribution License

All community contributions in this pull request are licensed to the project
maintainers under the terms of the
[Apache 2 License](https://www.apache.org/licenses/LICENSE-2.0).

By creating this pull request, I represent that I have the right to license the
contributions to the project maintainers under the Apache 2 License as stated in
the
[Community Contribution License](https://github.com/jetify-com/opensource/blob/main/CONTRIBUTING.md#community-contribution-license).
